### PR TITLE
Add support of methods with varargs and #{options.option ...}

### DIFF
--- a/src/main/java/net/datafaker/Options.java
+++ b/src/main/java/net/datafaker/Options.java
@@ -21,6 +21,16 @@ public class Options {
     }
 
     /**
+     * Returns a random String element from an varargs.
+     *
+     * @param options The varargs to take a random element from.
+     * @return A randomly selected element from the varargs.
+     */
+    public String option(String... options) {
+        return options[faker.random().nextInt(options.length)];
+    }
+
+    /**
      * Returns a random element from Enum.
      *
      * @param enumeration The Enum to take a random element from.

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -4,6 +4,7 @@ import com.mifmif.common.regex.Generex;
 import net.datafaker.Faker;
 import net.datafaker.service.files.EnFile;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -514,7 +515,7 @@ public class FakeValuesService {
 
         for (Method m : onObject.getClass().getMethods()) {
             if (m.getName().equalsIgnoreCase(name)
-                    && m.getParameterTypes().length == args.size()) {
+                    && (m.getParameterTypes().length == args.size() || m.getParameterTypes().length < args.size() && m.isVarArgs())) {
                 final List<Object> coercedArguments = coerceArguments(m, args);
                 if (coercedArguments != null) {
                     return new MethodAndCoercedArgs(m, coercedArguments);
@@ -535,21 +536,37 @@ public class FakeValuesService {
      * @return array of coerced values if successful, null otherwise
      */
     private List<Object> coerceArguments(Method accessor, List<String> args) {
-        final List<Object> coerced = new ArrayList<>();
+        final List<Object> coerced = new ArrayList<Object>();
         for (int i = 0; i < accessor.getParameterTypes().length; i++) {
-
+            final boolean isVarArg = i == accessor.getParameterTypes().length - 1 && accessor.isVarArgs();
             Class<?> toType = primitiveToWrapper(accessor.getParameterTypes()[i]);
+            toType = isVarArg ? toType.getComponentType() : toType;
             try {
+                final Object coercedArgument;
                 if (toType.isEnum()) {
                     Method method = toType.getMethod("valueOf", String.class);
-                    String enumArg = args.get(i).substring(args.get(i).indexOf(".") + 1);
-                    Object coercedArg = method.invoke(null, enumArg);
-                    coerced.add(coercedArg);
+                    if (isVarArg) {
+                        coercedArgument = Array.newInstance(toType, args.size() - i);
+                        for (int j = i; j < args.size(); j++) {
+                            String enumArg = args.get(j).substring(args.get(j).indexOf(".") + 1);
+                            Array.set(coercedArgument, j - i, method.invoke(null, enumArg));
+                        }
+                    } else {
+                        String enumArg = args.get(i).substring(args.get(i).indexOf(".") + 1);
+                        coercedArgument = method.invoke(null, enumArg);
+                    }
                 } else {
                     final Constructor<?> ctor = toType.getConstructor(String.class);
-                    final Object coercedArgument = ctor.newInstance(args.get(i));
-                    coerced.add(coercedArgument);
+                    if (isVarArg) {
+                        coercedArgument = Array.newInstance(toType, args.size() - i);
+                        for (int j = i; j < args.size(); j++) {
+                            Array.set(coercedArgument, j - i, ctor.newInstance(args.get(j)));
+                        }
+                    } else {
+                        coercedArgument = ctor.newInstance(args.get(i));
+                    }
                 }
+                coerced.add(coercedArgument);
             } catch (Exception e) {
                 log.fine("Unable to coerce " + args.get(i) + " to " + toType.getSimpleName() + " via " + toType.getSimpleName() + "(String) constructor.");
                 return null;

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -156,6 +156,8 @@ public class FakerTest extends AbstractFakerTest {
 
     @Test
     public void expression() {
+        assertThat(faker.expression("#{options.option 'a','b','c','d'}"), matchesRegularExpression("(a|b|c|d)"));
+        assertThat(faker.expression("#{options.option '12','345','89','54321'}"), matchesRegularExpression("(12|345|89|54321)"));
         assertThat(faker.expression("#{regexify '(a|b){2,3}'}"), matchesRegularExpression("(a|b){2,3}"));
         assertThat(faker.expression("#{regexify '\\.\\*\\?\\+'}"), matchesRegularExpression("\\.\\*\\?\\+"));
         assertThat(faker.expression("#{bothify '????','true'}"), matchesRegularExpression("[A-Z]{4}"));


### PR DESCRIPTION
There 2 issues:
1. Current code can not resolve the code with varargs e.g. `Options.option`
2. Options does not have `option` method with `String` varargs which is implied by `FakeValuesService`

This PR adds check if there is varargs in method args and supports it, also adds `Options.option` with String varargs to make it working like
``` 
#{options.option '12','345','89','54321'}
```

the PR is same as https://github.com/DiUS/java-faker/pull/703