### PR TITLE
Replace deprecated matchers with actual

### DIFF
--- a/src/test/java/net/datafaker/AbstractFakerTest.java
+++ b/src/test/java/net/datafaker/AbstractFakerTest.java
@@ -21,7 +21,7 @@ public class AbstractFakerTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         Logger rootLogger = LogManager.getLogManager().getLogger("");
         Handler[] handlers = rootLogger.getHandlers();

--- a/src/test/java/net/datafaker/BoolTest.java
+++ b/src/test/java/net/datafaker/BoolTest.java
@@ -3,14 +3,15 @@ package net.datafaker;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class BoolTest extends AbstractFakerTest {
 
     @Test
     public void testBool() {
         for (int i = 0; i < 100; i++) {
-            assertThat(faker.bool().bool(), isOneOf(true, false));
+            assertThat(faker.bool().bool(), is(oneOf(true, false)));
         }
     }
 }

--- a/src/test/java/net/datafaker/OptionsTest.java
+++ b/src/test/java/net/datafaker/OptionsTest.java
@@ -7,8 +7,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isIn;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.oneOf;
 
 public class OptionsTest extends AbstractFakerTest {
 
@@ -21,23 +22,23 @@ public class OptionsTest extends AbstractFakerTest {
 
     @Test
     public void testOptionWithArray() {
-        assertThat(faker.options().option(options), isOneOf(options));
+        assertThat(faker.options().option(options), is(oneOf(options)));
     }
 
     @Test
     public void testOptionWithVarargsString() {
-        assertThat(faker.options().option("A", "B", "C"), isOneOf(options));
+        assertThat(faker.options().option("A", "B", "C"), is(oneOf(options)));
     }
 
     @Test
     public void testOptionWithVarargsInteger() {
         Integer[] integerOptions = new Integer[]{1, 3, 4, 5};
-        assertThat(faker.options().option(1, 3, 4, 5), isOneOf(integerOptions));
+        assertThat(faker.options().option(1, 3, 4, 5), is(oneOf(integerOptions)));
     }
 
     @Test
     public void testOptionWithEnum() {
-        assertThat(faker.options().option(Day.class), isOneOf(Day.values()));
+        assertThat(faker.options().option(Day.class), is(oneOf(Day.values())));
     }
 
     @Test

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -20,12 +20,12 @@ import java.util.Locale;
 import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -47,7 +47,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     @Before
     public void before() {
         super.before();
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         // always return the first element
         when(randomService.nextInt(anyInt())).thenReturn(0);
@@ -83,7 +83,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
 
     @Test
     public void safeFetchShouldReturnEmptyStringWhenPropertyDoesntExist() {
-        assertThat(fakeValuesService.safeFetch("property.dummy2", ""), isEmptyString());
+        assertThat(fakeValuesService.safeFetch("property.dummy2", ""), is(emptyString()));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         final DummyService dummy = mock(DummyService.class);
 
         String value = fakeValuesService.resolve("property.regexify1", dummy, faker);
-        assertThat(value, isOneOf("55", "44", "45", "54"));
+        assertThat(value, is(oneOf("55", "44", "45", "54")));
         verify(faker).regexify("[45]{2}");
     }
 
@@ -110,7 +110,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         final DummyService dummy = mock(DummyService.class);
 
         String value = fakeValuesService.resolve("property.regexify_slash_format", dummy, faker);
-        assertThat(value, isOneOf("55", "44", "45", "54"));
+        assertThat(value, is(oneOf("55", "44", "45", "54")));
         verify(faker).regexify("[45]{2}");
     }
 
@@ -119,7 +119,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         final DummyService dummy = mock(DummyService.class);
 
         String value = fakeValuesService.resolve("property.regexify_cell", dummy, faker);
-        assertThat(value, isOneOf("479", "459"));
+        assertThat(value, is(oneOf("479", "459")));
         verify(faker).regexify("4[57]9");
     }
 


### PR DESCRIPTION
The PR removes some deprecated matchers replacing it with actuals
`initMocks` => `openMocks`
`isOneOf(...)` => `is(oneOf(...))`
`isEmptyString()` => `is(emptyString(...))`