### PR TITLE
Flaky testNumberBetweenContain could fail if size is 0

### DIFF
--- a/src/test/java/net/datafaker/NumberTest.java
+++ b/src/test/java/net/datafaker/NumberTest.java
@@ -18,7 +18,9 @@ import java.util.function.Function;
 
 import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -431,11 +433,11 @@ public class NumberTest extends AbstractFakerTest {
         int maxInt = minInt + size;
         for (int i = 0; i < 100000; ++i) {
             int value = faker.number().numberBetween(minInt, maxInt);
-            assertThat(value, is(lessThan(maxInt)));
+            assertThat(value, either(lessThan(maxInt)).or(equalTo(minInt)));
             assertThat(value, is(greaterThanOrEqualTo(minInt)));
             ints.add(value);
         }
-        assertEquals(ints.size(), size);
+        assertEquals(ints.size(), Math.max(1, size));
 
         //test whether NumberBetween(long, long) can
         // create all number between min and max(not included)
@@ -444,11 +446,11 @@ public class NumberTest extends AbstractFakerTest {
         long maxLong = minLong + size;
         for (int i = 0; i < 100000; ++i) {
             long value = faker.number().numberBetween(minLong, maxLong);
-            assertThat(value, is(lessThan(maxLong)));
+            assertThat(value, either(lessThan(maxLong)).or(equalTo(minLong)));
             assertThat(value, is(greaterThanOrEqualTo(minLong)));
             longs.add(value);
         }
-        assertEquals(longs.size(), size);
+        assertEquals(longs.size(), Math.max(1, size));
     }
 
     @Test


### PR DESCRIPTION
The problem with `net.datafaker.NumberTest#testNumberBetweenContain` is that it fails if size from  `int size = Math.abs(random.nextInt(100));` at line 427 is `0`. 
This PR makes this test working for that boundary scenario as well

An example of failure
```
Expected: is a value less than <574511116>
     but: <574511116> was equal to <574511116>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
	at net.datafaker.NumberTest.testNumberBetweenContain(NumberTest.java:434)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

```