### PR TITLE
Add support of date time pattern for string representation of date an…

### DIFF
--- a/src/main/java/net/datafaker/DateAndTime.java
+++ b/src/main/java/net/datafaker/DateAndTime.java
@@ -1,5 +1,6 @@
 package net.datafaker;
 
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -34,17 +35,44 @@ public class DateAndTime {
     }
 
     /**
+     * Generates and converts to string representation a future date from now.
+     * Note that there is a 1 second slack to avoid generating a past date.
+     *
+     * @param atMost    at most this amount of time ahead from now exclusive.
+     * @param unit      the time unit.
+     * @param pattern   date time pattern to convert to string.
+     * @return a string representation of a future date from now.
+     */
+    public String future(int atMost, TimeUnit unit, String pattern) {
+        return toString(future(atMost, unit), pattern);
+    }
+
+    /**
      * Generates a future date from now, with a minimum time.
      *
      * @param atMost  at most this amount of time ahead from now exclusive.
      * @param minimum the minimum amount of time in the future from now.
      * @param unit    the time unit.
-     * @return a future date from now.
+     * @return a future date from now, with a minimum time.
      */
     public Date future(int atMost, int minimum, TimeUnit unit) {
         Date now = new Date();
         Date minimumDate = new Date(now.getTime() + unit.toMillis(minimum));
         return future(atMost - minimum, unit, minimumDate);
+    }
+
+    /**
+     * Generates and converts to string representation
+     * of a future date from now, with a minimum time.
+     *
+     * @param atMost  at most this amount of time ahead from now exclusive.
+     * @param minimum the minimum amount of time in the future from now.
+     * @param unit    the time unit.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a future date from now, with a minimum time.
+     */
+    public String future(int atMost, int minimum, TimeUnit unit, String pattern) {
+        return toString(future(atMost, minimum, unit), pattern);
     }
 
     /**
@@ -65,6 +93,20 @@ public class DateAndTime {
     }
 
     /**
+     * Generates and converts to string representation
+     * a future date relative to the {@code referenceDate}.
+     *
+     * @param atMost        at most this amount of time ahead to the {@code referenceDate} exclusive.
+     * @param unit          the time unit.
+     * @param referenceDate the future date relative to this date.
+     * @param pattern       date time pattern to convert to string.
+     * @return a string representation of a future date relative to {@code referenceDate}.
+     */
+    public String future(int atMost, TimeUnit unit, Date referenceDate, String pattern) {
+        return toString(future(atMost, unit, referenceDate), pattern);
+    }
+
+    /**
      * Generates a past date from now. Note that there is a 1 second slack added.
      *
      * @param atMost at most this amount of time earlier from now exclusive.
@@ -75,6 +117,19 @@ public class DateAndTime {
         Date now = new Date();
         Date aBitEarlierThanNow = new Date(now.getTime() - 1000);
         return past(atMost, unit, aBitEarlierThanNow);
+    }
+
+    /**
+     * Generates a string representation of a past date from now.
+     * Note that there is a 1 second slack added.
+     *
+     * @param atMost  at most this amount of time earlier from now exclusive.
+     * @param unit    the time unit.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a past date from now.
+     */
+    public String past(int atMost, TimeUnit unit, String pattern) {
+        return toString(past(atMost, unit), pattern);
     }
 
     /**
@@ -92,6 +147,19 @@ public class DateAndTime {
     }
 
     /**
+     * Generates and converts to string representation a past date from now, with a minimum time.
+     *
+     * @param atMost  at most this amount of time earlier from now exclusive.
+     * @param minimum the minimum amount of time in the past from now.
+     * @param unit    the time unit.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a past date from now, with a minimum time.
+     */
+    public String past(int atMost, int minimum, TimeUnit unit, String pattern) {
+        return toString(past(atMost, minimum, unit), pattern);
+    }
+
+    /**
      * Generates a past date relative to the {@code referenceDate}.
      *
      * @param atMost        at most this amount of time past to the {@code referenceDate} exclusive.
@@ -106,6 +174,19 @@ public class DateAndTime {
         futureMillis -= 1 + faker.random().nextLong(upperBound - 1);
 
         return new Date(futureMillis);
+    }
+
+    /**
+     * Generates a string representation of a past date relative to the {@code referenceDate}.
+     *
+     * @param atMost        at most this amount of time past to the {@code referenceDate} exclusive.
+     * @param unit          the time unit.
+     * @param referenceDate the past date relative to this date.
+     * @param pattern       date time pattern to convert to string.
+     * @return a string representation of a past date relative to {@code referenceDate}.
+     */
+    public String past(int atMost, TimeUnit unit, Date referenceDate, String pattern) {
+        return toString(past(atMost, unit, referenceDate), pattern);
     }
 
     /**
@@ -130,12 +211,35 @@ public class DateAndTime {
     }
 
     /**
+     * Generates a string representation of a random date between two dates.
+     *
+     * @param from    the lower bound inclusive
+     * @param to      the upper bound exclusive
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a random date between {@code from} and {@code to}.
+     * @throws IllegalArgumentException if the {@code to} date represents an earlier date than {@code from} date.
+     */
+    public String between(Date from, Date to, String pattern) throws IllegalArgumentException {
+        return toString(between(from, to), pattern);
+    }
+
+    /**
      * Generates a random birthday between 65 and 18 years ago from now.
      *
      * @return a random birthday between 65 and 18 years ago from now.
      */
     public Date birthday() {
         return birthday(DEFAULT_MIN_AGE, DEFAULT_MAX_AGE);
+    }
+
+    /**
+     * Generates a string representation of a random birthday between 65 and 18 years ago from now.
+     *
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a random birthday between 65 and 18 years ago from now.
+     */
+    public String birthday(String pattern) {
+        return toString(birthday(DEFAULT_MIN_AGE, DEFAULT_MAX_AGE), pattern);
     }
 
     /**
@@ -154,5 +258,22 @@ public class DateAndTime {
         Calendar to = new GregorianCalendar(currentYear - minAge, currentMonth, currentDay);
 
         return between(from.getTime(), to.getTime());
+    }
+
+    /**
+     * Generates and converts to string representation a random birthday between two ages from now.
+     *
+     * @param minAge  the minimal age
+     * @param maxAge  the maximal age
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a random birthday between {@code minAge} and {@code maxAge} years ago from now.
+     * @throws IllegalArgumentException if the {@code maxAge} is lower than {@code minAge}.
+     */
+    public String birthday(int minAge, int maxAge, String pattern) {
+        return toString(birthday(minAge, maxAge), pattern);
+    }
+
+    private String toString(Date date, String pattern) {
+        return new SimpleDateFormat(pattern).format(date);
     }
 }

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -163,6 +163,10 @@ public class FakerTest extends AbstractFakerTest {
         assertThat(faker.expression("#{Name.first_name} #{Name.first_name} #{Name.last_name}"), matchesRegularExpression("[a-zA-Z']+ [a-zA-Z']+ [a-zA-Z']+"));
         assertThat(faker.expression("#{number.number_between '1','10'}"), matchesRegularExpression("[1-9]"));
         assertThat(faker.expression("#{color.name}"), matchesRegularExpression("[a-z\\s]+"));
+        assertThat(faker.expression("#{date.past '15','SECONDS','dd/MM/yyyy hh:mm:ss'}"),
+                matchesRegularExpression("[0-9]{2}/[0-9]{2}/[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}"));
+        assertThat(faker.expression("#{date.birthday 'yy DDD hh:mm:ss'}"),
+                matchesRegularExpression("[0-9]{2} [0-9]{3} [0-9]{2}:[0-9]{2}:[0-9]{2}"));
     }
 
     @Test


### PR DESCRIPTION
The problem is that calls like `#{date.past ... }` and others with `date` converts date and time based on default `toString` with no way to customize it.

The PR adds corresponding methods which allow to specify date/time pattern