### PR TITLE
Flaky testLongTwitterIdLength case

### DIFF
--- a/src/main/java/net/datafaker/Twitter.java
+++ b/src/main/java/net/datafaker/Twitter.java
@@ -65,7 +65,7 @@ public class Twitter {
         String newDate = sdf.format(new Date());
         String result = "";
         RandomService random = faker.random();
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < expectedLength - id1.length() - newDate.length(); i++) {
             result = result.concat(String.valueOf(random.nextInt(10)));
         }
         String id2 = result + newDate;

--- a/src/test/java/net/datafaker/NumberTest.java
+++ b/src/test/java/net/datafaker/NumberTest.java
@@ -18,7 +18,6 @@ import java.util.function.Function;
 
 import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
@@ -379,12 +378,11 @@ public class NumberTest extends AbstractFakerTest {
         int testCase = 100000;
 
         int min = Math.abs(random.nextInt());
-        int max = min + Math.abs(random.nextInt(100));
+        int max = min + Math.max(1, Math.abs(random.nextInt(100)));
         double mean = testCase / (double) (max - min);
         for (int j = 0; j < testCase; j++) {
             int r = faker.number().numberBetween(min, max);
-            Integer count = map.get(r);
-            map.put(r, count == null ? 1 : count + 1);
+            map.merge(r, 1, Integer::sum);
         }
 
         for (Map.Entry<Integer, Integer> entry : map.entrySet()) {
@@ -403,12 +401,11 @@ public class NumberTest extends AbstractFakerTest {
         int testCase = 100000;
 
         long min = Math.abs(random.nextLong());
-        long max = min + Math.abs(random.nextInt(200));
+        long max = min + Math.max(1, Math.abs(random.nextInt(200)));
         double mean = testCase / (double) (max - min);
         for (int j = 0; j < testCase; j++) {
             Long r = faker.number().numberBetween(min, max);
-            Integer count = map.get(r);
-            map.put(r, count == null ? 1 : count + 1);
+            map.merge(r, 1, Integer::sum);
         }
 
         for (Map.Entry<Long, Integer> entry : map.entrySet()) {

--- a/src/test/java/net/datafaker/TwitterTest.java
+++ b/src/test/java/net/datafaker/TwitterTest.java
@@ -1,5 +1,6 @@
 package net.datafaker;
 
+import net.datafaker.repeating.Repeat;
 import org.junit.Test;
 
 import java.util.Date;
@@ -38,6 +39,7 @@ public class TwitterTest extends AbstractFakerTest {
     }
 
     @Test
+    @Repeat(times = 100)
     public void testLongTwitterIdLength() {
         int expectedLength = 25;
         String generatedID = faker.twitter().twitterId(expectedLength);


### PR DESCRIPTION
Sometimes `net.datafaker.TwitterTest#testLongTwitterIdLength` fails (exception below) because it could happen that length of `id1 + id2` less than expectedLength.
To reproduce it usually it is enough to add `@Repeat(times = 100 )` for `net.datafaker.TwitterTest#testLongTwitterIdLength`

This PR fixes this behavior

The exception
```
testLongTwitterIdLength(net.datafaker.TwitterTest)  Time elapsed: 0.005 sec  <<< ERROR!
java.lang.IllegalArgumentException: bound must be positive
	at java.base/java.util.Random.nextInt(Random.java:388)
	at net.datafaker.service.RandomService.nextInt(RandomService.java:29)
	at net.datafaker.Twitter.twitterId(Twitter.java:85)
	at net.datafaker.TwitterTest.testLongTwitterIdLength(TwitterTest.java:43)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
```
