### PR TITLE
Add missing md2 and sha384

### DIFF
--- a/src/main/java/net/datafaker/Crypto.java
+++ b/src/main/java/net/datafaker/Crypto.java
@@ -11,12 +11,20 @@ public class Crypto {
         this.faker = faker;
     }
 
+    public String md2() {
+        return generateString("MD2");
+    }
+
     public String md5() {
         return generateString("MD5");
     }
 
     public String sha1() {
         return generateString("SHA-1");
+    }
+
+    public String sha384() {
+        return generateString("SHA-384");
     }
 
     public String sha256() {

--- a/src/test/java/net/datafaker/CryptoTest.java
+++ b/src/test/java/net/datafaker/CryptoTest.java
@@ -2,11 +2,19 @@ package net.datafaker;
 
 import org.junit.Test;
 
+import java.security.Security;
+import java.util.Arrays;
+
 import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class CryptoTest extends AbstractFakerTest {
+
+    @Test
+    public void testMd2() {
+        assertThat(faker.crypto().md2(), matchesRegularExpression("[a-z\\d]+"));
+    }
 
     @Test
     public void testMd5() {
@@ -21,6 +29,11 @@ public class CryptoTest extends AbstractFakerTest {
     @Test
     public void testSha256() {
         assertThat(faker.crypto().sha256(), matchesRegularExpression("[a-z\\d]+"));
+    }
+
+    @Test
+    public void testSha384() {
+        assertThat(faker.crypto().sha384(), matchesRegularExpression("[a-z\\d]+"));
     }
 
     @Test


### PR DESCRIPTION
It looks like there are missing `md2` and `sha384`. The PR adds support for them

If there is no objections I'll merge it soon