### PR TITLE
Add templatify function to fill templates

### DIFF
--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -4,6 +4,7 @@ import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.RandomService;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 
 /**
@@ -382,6 +383,35 @@ public class Faker {
      * @return The output string based on the input pattern
      */
     public String examplify(String example) {return fakeValuesService.examplify(example);}
+
+    /**
+     * Returns a string with the '?' characters in the parameter replaced with random option from available options.
+     * <p>
+     * For example, the string "ABC??EFG" could be replaced with a string like "ABCtestтестEFG"
+     * if passed options are new String[]{"test", "тест"}.
+     *
+     * @param string  Template for string generation
+     * @param options Options to use while filling the template
+     * @return Generated string
+     */
+    public String templatify(String string, char char2replace, String... options) {
+        return fakeValuesService().templatify(string, char2replace, options);
+    }
+
+    /**
+     * Returns a string with the characters in the keys of optionsMap parameter replaced with random option from values.
+     *
+     * <p>
+     * For example, the string "ABC$$EFG" could be replaced with a string like "ABCtestтестEFG"
+     * if passed for key '$' there is value new String[]{"test", "тест"} in optionsMap
+     *
+     * @param string       Template for string generation
+     * @param optionsMap   Map with replacement rules
+     * @return Generated string
+     */
+    public String templatify(String string, Map<Character, String[]> optionsMap) {
+        return fakeValuesService().templatify(string, optionsMap);
+    }
 
     public RandomService random() {
         return this.randomService;

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -3,12 +3,14 @@ package net.datafaker;
 import net.datafaker.repeating.Repeat;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Random;
 
 import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -69,6 +71,15 @@ public class FakerTest extends AbstractFakerTest {
     @Test
     public void numerifyShouldLeaveNonSpecialCharactersAlone() {
         assertThat(faker.numerify("####123"), matchesRegularExpression("\\d{4}123"));
+    }
+
+    @Test
+    public void templatify() {
+        assertThat(faker.templatify("12??34", '?', "тест", "test", "测试测试").length(), equalTo(12));
+        assertThat(faker.templatify("12??34",
+                Collections.singletonMap('1', new String[]{"тест", "test", "测试测试"})).length(), equalTo(9));
+        assertThat(faker.templatify("12??34",
+                Collections.singletonMap('1', new String[]{""})).length(), equalTo(5));
     }
 
     @Test
@@ -160,6 +171,7 @@ public class FakerTest extends AbstractFakerTest {
         assertThat(faker.expression("#{bothify '????','true'}"), matchesRegularExpression("[A-Z]{4}"));
         assertThat(faker.expression("#{bothify '????','false'}"), matchesRegularExpression("[a-z]{4}"));
         assertThat(faker.expression("#{letterify '????','true'}"), matchesRegularExpression("[A-Z]{4}"));
+        assertThat(faker.expression("#{templatify '????','?','1','2','q','r'}"), matchesRegularExpression("(1|2|q|r){4}"));
         assertThat(faker.expression("#{Name.first_name} #{Name.first_name} #{Name.last_name}"), matchesRegularExpression("[a-zA-Z']+ [a-zA-Z']+ [a-zA-Z']+"));
         assertThat(faker.expression("#{number.number_between '1','10'}"), matchesRegularExpression("[1-9]"));
         assertThat(faker.expression("#{color.name}"), matchesRegularExpression("[a-z\\s]+"));


### PR DESCRIPTION
There are already present several functions to generate a string by template e.g.
`net.datafaker.Faker#letterify` or `net.datafaker.Faker#numerify`.

The problem is that `letterify` could fill template only with ascii symbols and `numerify` only with digits and it is impossible to fill one `?` with several symbols.

The idea of this PR is providing of `xrify` (not sure about naming, probably there might be better options) which takes a template and a set of string options which could be used to fill it e.g.

E.g. if I want to fill `?` with some Russian or Chinese strings
```
faker.templatify("12??34", '?', "тест", "test", "测试测试")
```