### PR TITLE
Use Map of collections instead of collection to speed up access by path

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -95,4 +95,8 @@ public class FakeValues implements FakeValuesInterface {
     boolean supportsPath(String path) {
         return this.path.equals(path);
     }
+
+    public String getPath() {
+        return path;
+    }
 }

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -1,29 +1,30 @@
 package net.datafaker.service;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class FakeValuesGrouping implements FakeValuesInterface {
 
-    private final List<FakeValues> fakeValuesList = new ArrayList<>();
+    private final Map<String, Collection<FakeValues>> fakeValues = new HashMap<>();
 
-    public void add(FakeValues fakeValues) {
-        fakeValuesList.add(fakeValues);
+    public void add(FakeValues fakeValue) {
+        fakeValues.putIfAbsent(fakeValue.getPath(), new ArrayList<>());
+        fakeValues.get(fakeValue.getPath()).add(fakeValue);
     }
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Map get(String key) {
         Map result = null;
-        for (FakeValues fakeValues : fakeValuesList) {
-            if (fakeValues.supportsPath(key)) {
-                if (result != null) {
-                    final Map newResult = fakeValues.get(key);
-                    result.putAll(newResult);
-                } else {
-                    result = fakeValues.get(key);
-                }
+        for (FakeValues fakeValues : fakeValues.getOrDefault(key, Collections.emptyList())) {
+            if (result != null) {
+                final Map newResult = fakeValues.get(key);
+                result.putAll(newResult);
+            } else {
+                result = fakeValues.get(key);
             }
         }
         return result;

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -511,7 +511,13 @@ public class FakeValuesService {
      * @throws RuntimeException if there's a problem invoking the method or it doesn't exist.
      */
     private String resolveFakerObjectAndMethod(Faker faker, String key, List<String> args) {
-        final String[] classAndMethod = DOT.split(key, 2);
+        int index = key.indexOf('.');
+        final String[] classAndMethod;
+        if (index == -1) {
+            classAndMethod = new String[] {key};
+        } else {
+            classAndMethod = new String[] {key.substring(0, index), index == key.length() - 1 ? "" : key.substring(index + 1)};
+        }
 
         try {
             String fakerMethodName = UNDERSCORE.matcher(classAndMethod[0]).replaceAll("");
@@ -522,7 +528,7 @@ public class FakeValuesService {
             }
             Object objectWithMethodToInvoke = fakerAccessor.invoke(faker);
             String nestedMethodName = UNDERSCORE.matcher(classAndMethod[1]).replaceAll("");
-            final MethodAndCoercedArgs accessor = accessor(objectWithMethodToInvoke, UNDERSCORE.matcher(classAndMethod[1]).replaceAll(""), args);
+            final MethodAndCoercedArgs accessor = accessor(objectWithMethodToInvoke, nestedMethodName, args);
             if (accessor == null) {
                 throw new Exception("Can't find method on "
                         + objectWithMethodToInvoke.getClass().getSimpleName()


### PR DESCRIPTION
Another PR to speed up `faker.expression` a bit. 
The idea is to use map to access fakevalues in `FakeValuesGrouping` which is O(1) instead of collection which in O(n)

Some measurements shows about 20-30% improvement
before
```
Benchmark                            Mode  Cnt    Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  533.255 ± 22.638  ops/ms
JmhTest._letterifyExpression        thrpt    5  531.161 ± 12.172  ops/ms
JmhTest._optionsExpression          thrpt    5  370.678 ± 16.982  ops/ms
JmhTest._regexifyExpression         thrpt    5  238.741 ± 15.081  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  337.323 ±  1.139  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   67.555 ±  6.570  ops/ms
```
after
```
Benchmark                            Mode  Cnt    Score   Error   Units
JmhTest._bothifyExpression          thrpt    5  617.794 ± 5.524  ops/ms
JmhTest._letterifyExpression        thrpt    5  626.325 ± 7.130  ops/ms
JmhTest._optionsExpression          thrpt    5  438.888 ± 9.530  ops/ms
JmhTest._regexifyExpression         thrpt    5  256.661 ± 8.576  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  405.579 ± 2.753  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5  106.244 ± 1.232  ops/ms
```

code for benchmark is still same as at https://github.com/datafaker-net/datafaker/pull/25