### PR TITLE
Replace Regexp with split or concat if possible

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -26,7 +26,6 @@ public class FakeValuesService {
     private static final Pattern EXPRESSION_PATTERN = Pattern.compile("#\\{([a-z0-9A-Z_.]+)\\s?((?:,?'([^']+)')*)}");
     private static final Pattern EXPRESSION_ARGUMENTS_PATTERN = Pattern.compile("'(.*?)'");
     private static final Pattern LOCALE = Pattern.compile("[-_]");
-    private static final Pattern DOT = Pattern.compile("\\.");
     private static final Pattern A_TO_Z = Pattern.compile("([A-Z])");
     private static final Pattern UNDERSCORE = Pattern.compile("_");
 
@@ -181,7 +180,7 @@ public class FakeValuesService {
      *            dot. E.g. name.first_name
      */
     public Object fetchObject(String key) {
-        String[] path = DOT.split(key);
+        String[] path = split(key, '.');
 
         Object result = null;
         for (FakeValuesInterface fakeValuesInterface : fakeValuesList) {
@@ -198,6 +197,30 @@ public class FakeValuesService {
             if (result != null) {
                 break;
             }
+        }
+        return result;
+    }
+
+    private String[] split(String string, char sep) {
+        int size = 0;
+        for (int i = 0; i < string.length(); i++) {
+            if (string.charAt(i) == sep) size++;
+        }
+        String[] result = new String[size + 1];
+        StringBuilder sb = new StringBuilder();
+        int j = 0;
+        for (int i = 0; i < string.length(); i++) {
+            if (string.charAt(i) == sep) {
+                if (sb.length() > 0) {
+                    result[j++] = sb.toString();
+                }
+                sb.setLength(0);
+            } else {
+                sb.append(string.charAt(i));
+            }
+        }
+        if (j == size) {
+            result[j] = sb.toString();
         }
         return result;
     }
@@ -385,7 +408,8 @@ public class FakeValuesService {
             }
 
             resolved = resolveExpression(resolved, current, root);
-            result = result.replaceFirst(Pattern.quote(escapedDirective), Matcher.quoteReplacement(resolved));
+            int index = result.indexOf(escapedDirective);
+            result = (index == 0 ? "" : result.substring(0, index)) + resolved + result.substring(index + escapedDirective.length());
         }
         return result;
     }


### PR DESCRIPTION
The PR replaces slow regexp with concat and split
some results of measurements (for some scenarios it gives up to 40%)
before
```
Benchmark                            Mode  Cnt    Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  601.265 ± 11.568  ops/ms
JmhTest._letterifyExpression        thrpt    5  619.345 ± 10.733  ops/ms
JmhTest._optionsExpression          thrpt    5  445.589 ±  4.059  ops/ms
JmhTest._regexifyExpression         thrpt    5  255.194 ±  4.645  ops/ms
JmhTest.firstName                   thrpt    5  476.731 ±  4.385  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  393.700 ±  2.009  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5  102.284 ±  1.653  ops/ms
```
after
```
JmhTest._bothifyExpression          thrpt    5   935.122 ± 11.105  ops/ms
JmhTest._letterifyExpression        thrpt    5  1030.602 ±  7.873  ops/ms
JmhTest._optionsExpression          thrpt    5   645.699 ±  5.159  ops/ms
JmhTest._regexifyExpression         thrpt    5   302.839 ±  5.554  ops/ms
JmhTest.firstName                   thrpt    5   700.601 ±  4.588  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5   588.784 ±  4.202  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   155.224 ±  1.289  ops/ms

```

benchmark code 
```java


@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Benchmark)
@Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})
public class JmhTest {

    private static final Faker FAKER = new Faker();
    public static void main(String[] args) throws RunnerException {

        Options opt = new OptionsBuilder()
                .include(JmhTest.class.getSimpleName())
                .forks(1)
                .build();

        new Runner(opt).run();
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void _optionsExpression(Blackhole blackhole) {
        blackhole.consume(FAKER.expression("#{options.option 'a','b','c','d'}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void _letterifyExpression(Blackhole blackhole) {
        blackhole.consume(FAKER.expression("#{letterify '????','true'}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void _regexifyExpression(Blackhole blackhole) {
        blackhole.consume(FAKER.expression("#{regexify '\\.\\*\\?\\+'}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void _bothifyExpression(Blackhole blackhole) {
        blackhole.consume(FAKER.expression("#{bothify '????','false'}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void oneMethodCallExpression(Blackhole blackhole) {
        blackhole.consume(FAKER.expression("#{number.number_between '1','10'}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void threeMethodsCallExpression(Blackhole blackhole) {
        blackhole.consume(FAKER.expression("#{Name.first_name} #{Name.first_name} #{Name.last_name}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void firstName(Blackhole blackhole) {
        blackhole.consume(FAKER.name().firstName());
    }
}

```