### PR TITLE
Use array for ports in Sip, use spy only when needed in tests

### DIFF
--- a/src/main/java/net/datafaker/Sip.java
+++ b/src/main/java/net/datafaker/Sip.java
@@ -2,8 +2,6 @@ package net.datafaker;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.util.ArrayList;
-
 /**
  * Faker class for generating Session Initiation Protocol (SIP) related data.
  *
@@ -11,15 +9,12 @@ import java.util.ArrayList;
  */
 public final class Sip {
     private final Faker faker;
-    private final ArrayList<Integer> portPool;
+    private final int[] portPool = new int[5001];
 
     public Sip(final Faker faker) {
         this.faker = faker;
-        int port = 40000;
-        portPool = new ArrayList<>();
-        while (port <= 50000) {
-            portPool.add(port);
-            port = port + 2;
+        for (int i = 0; i < portPool.length; i++) {
+            portPool[i] = 40000 + 2 * i;
         }
     }
 
@@ -57,7 +52,7 @@ public final class Sip {
      * @return an RTP UDP 5 digit port int, e.g. 40002.
      */
     public int rtpPort() {
-        return portPool.get(faker.random().nextInt(0, portPool.size()));
+        return portPool[faker.random().nextInt(0, portPool.length)];
     }
 
     /**

--- a/src/test/java/net/datafaker/AbstractFakerTest.java
+++ b/src/test/java/net/datafaker/AbstractFakerTest.java
@@ -16,7 +16,6 @@ public class AbstractFakerTest {
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
 
-    @Spy
     protected Faker faker;
 
     @Before
@@ -29,5 +28,6 @@ public class AbstractFakerTest {
         for (Handler h : handlers) {
             h.setLevel(Level.INFO);
         }
+        faker = new Faker();
     }
 }

--- a/src/test/java/net/datafaker/NameTest.java
+++ b/src/test/java/net/datafaker/NameTest.java
@@ -3,6 +3,7 @@ package net.datafaker;
 import net.datafaker.repeating.Repeat;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 
 import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,6 +13,9 @@ import static org.mockito.Mockito.doReturn;
 
 
 public class NameTest extends AbstractFakerTest {
+
+    @Spy
+    private Faker mockedFaker;
 
     @Test
     public void testName() {
@@ -71,10 +75,10 @@ public class NameTest extends AbstractFakerTest {
 
     @Test
     public void testUsernameWithSpaces() {
-        final Name name = Mockito.spy(new Name(faker));
+        final Name name = Mockito.spy(new Name(mockedFaker));
         doReturn("Compound Name").when(name).firstName();
-        doReturn(name).when(faker).name();
-        assertThat(faker.name().username(), matchesRegularExpression("^(\\w+)\\.(\\w+)$"));
+        doReturn(name).when(mockedFaker).name();
+        assertThat(mockedFaker.name().username(), matchesRegularExpression("^(\\w+)\\.(\\w+)$"));
     }
 
     @Test

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -38,6 +39,9 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
 
     private static final Long MILLIS_IN_AN_HOUR = 1000 * 60 * 60L;
     private static final Long MILLIS_IN_A_DAY = MILLIS_IN_AN_HOUR * 24;
+
+    @Spy
+    private Faker mockedFaker;
 
     @Mock
     private RandomService randomService;
@@ -100,27 +104,27 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     public void regexifyDirective() {
         final DummyService dummy = mock(DummyService.class);
 
-        String value = fakeValuesService.resolve("property.regexify1", dummy, faker);
+        String value = fakeValuesService.resolve("property.regexify1", dummy, mockedFaker);
         assertThat(value, is(oneOf("55", "44", "45", "54")));
-        verify(faker).regexify("[45]{2}");
+        verify(mockedFaker).regexify("[45]{2}");
     }
 
     @Test
     public void regexifySlashFormatDirective() {
         final DummyService dummy = mock(DummyService.class);
 
-        String value = fakeValuesService.resolve("property.regexify_slash_format", dummy, faker);
+        String value = fakeValuesService.resolve("property.regexify_slash_format", dummy, mockedFaker);
         assertThat(value, is(oneOf("55", "44", "45", "54")));
-        verify(faker).regexify("[45]{2}");
+        verify(mockedFaker).regexify("[45]{2}");
     }
 
     @Test
     public void regexifyDirective2() {
         final DummyService dummy = mock(DummyService.class);
 
-        String value = fakeValuesService.resolve("property.regexify_cell", dummy, faker);
+        String value = fakeValuesService.resolve("property.regexify_cell", dummy, mockedFaker);
         assertThat(value, is(oneOf("479", "459")));
-        verify(faker).regexify("4[57]9");
+        verify(mockedFaker).regexify("4[57]9");
     }
 
     @Test
@@ -132,12 +136,12 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         doReturn("Yo!").when(dummy).hello();
 
         // when
-        final String actual = fakeValuesService.resolve("property.simpleResolution", dummy, faker);
+        final String actual = fakeValuesService.resolve("property.simpleResolution", dummy, mockedFaker);
 
         // then
         assertThat(actual, is("Yo!"));
         verify(dummy).hello();
-        verifyNoMoreInteractions(faker);
+        verifyNoMoreInteractions(mockedFaker);
     }
 
     @Test
@@ -145,15 +149,15 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         // given
         final Superhero person = mock(Superhero.class);
         final DummyService dummy = mock(DummyService.class);
-        doReturn(person).when(faker).superhero();
+        doReturn(person).when(mockedFaker).superhero();
         doReturn("Luke Cage").when(person).name();
 
         // when
-        final String actual = fakeValuesService.resolve("property.advancedResolution", dummy, faker);
+        final String actual = fakeValuesService.resolve("property.advancedResolution", dummy, mockedFaker);
 
         // then
         assertThat(actual, is("Luke Cage"));
-        verify(faker).superhero();
+        verify(mockedFaker).superhero();
         verify(person).name();
     }
 
@@ -168,7 +172,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         doReturn("Yo!").when(dummy).hello();
 
         // when
-        final String actual = fakeValuesService.resolve("property.resolutionWithList", dummy, faker);
+        final String actual = fakeValuesService.resolve("property.resolutionWithList", dummy, mockedFaker);
 
         // then
         assertThat(actual, is("Yo!"));
@@ -180,18 +184,18 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         // given
         final Superhero person = mock(Superhero.class);
         final DummyService dummy = mock(DummyService.class);
-        doReturn(person).when(faker).superhero();
+        doReturn(person).when(mockedFaker).superhero();
 
         doReturn("Yo Superman!").when(dummy).hello();
         doReturn("up up and away").when(person).descriptor();
 
         // when
-        String actual = fakeValuesService.resolve("property.multipleResolution", dummy, faker);
+        String actual = fakeValuesService.resolve("property.multipleResolution", dummy, mockedFaker);
 
         // then
         assertThat(actual, is("Yo Superman! up up and away"));
 
-        verify(faker).superhero();
+        verify(mockedFaker).superhero();
         verify(person).descriptor();
         verify(dummy).hello();
     }
@@ -323,11 +327,11 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
         when(dummy.hello()).thenReturn("1").thenReturn("2");
 
         // when
-        final String actual = fakeValuesService.resolve("property.sameResolution", dummy, faker);
+        final String actual = fakeValuesService.resolve("property.sameResolution", dummy, mockedFaker);
 
         // then
         assertThat(actual, is("1 2"));
-        verifyNoMoreInteractions(faker);
+        verifyNoMoreInteractions(mockedFaker);
     }
 
     @Test


### PR DESCRIPTION
The PR makes use of array instead of `ArrayList` in `Sip` to avoid boxing and autosizing.
Also it makes use of mocked `Faker` only in case it is required
 This gives improvement for benchmark 
```java
 @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void initFaker(Blackhole blackhole) {
        blackhole.consume(new Faker());
    }
```

before
```
JmhTest.initFaker                   thrpt    5   26.509 ±  0.214  ops/ms
```

after
```
JmhTest.initFaker                   thrpt    5    44.192 ± 0.733  ops/ms
```