### PR TITLE
Use valueOf instead of reflection for base types

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -8,6 +8,8 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -625,16 +627,37 @@ public class FakeValuesService {
                         String enumArg = args.get(i).substring(args.get(i).indexOf(".") + 1);
                         coercedArgument = method.invoke(null, enumArg);
                     }
-                } else if (toType == Character.class) {
-                    coercedArgument = args.get(i) == null ? null : args.get(i).charAt(0);
                 } else {
-                    final Constructor<?> ctor = toType.getConstructor(String.class);
                     if (isVarArg) {
+                        final Constructor<?> ctor = toType.getConstructor(String.class);
                         coercedArgument = Array.newInstance(toType, args.size() - i);
                         for (int j = i; j < args.size(); j++) {
                             Array.set(coercedArgument, j - i, ctor.newInstance(args.get(j)));
                         }
+                    } else if (toType == Character.class) {
+                        coercedArgument = args.get(i) == null ? null : args.get(i).charAt(0);
+                    } else if (CharSequence.class.isAssignableFrom(toType)) {
+                        coercedArgument = args.get(i);
+                    } else if (Boolean.class.isAssignableFrom(toType)) {
+                        coercedArgument = Boolean.valueOf(args.get(i));
+                    } else if (Integer.class.isAssignableFrom(toType)) {
+                        coercedArgument = Integer.valueOf(args.get(i));
+                    } else if (Long.class.isAssignableFrom(toType)) {
+                        coercedArgument = Long.valueOf(args.get(i));
+                    } else if (Double.class.isAssignableFrom(toType)) {
+                        coercedArgument = Double.valueOf(args.get(i));
+                    } else if (Float.class.isAssignableFrom(toType)) {
+                        coercedArgument = Float.valueOf(args.get(i));
+                    } else if (Byte.class.isAssignableFrom(toType)) {
+                        coercedArgument = Byte.valueOf(args.get(i));
+                    } else if (Short.class.isAssignableFrom(toType)) {
+                        coercedArgument = Short.valueOf(args.get(i));
+                    } else if (BigDecimal.class.isAssignableFrom(toType)) {
+                        coercedArgument = new BigDecimal(args.get(i));
+                    } else if (BigInteger.class.isAssignableFrom(toType)) {
+                        coercedArgument = new BigInteger(args.get(i));
                     } else {
+                        final Constructor<?> ctor = toType.getConstructor(String.class);
                         coercedArgument = ctor.newInstance(args.get(i));
                     }
                 }


### PR DESCRIPTION
Use `valueOf` at least for some base types allows to speed up some cases about 10%
before
```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  1000.702 ±  9.367  ops/ms
JmhTest._letterifyExpression        thrpt    5   983.098 ± 18.326  ops/ms
JmhTest._optionsExpression          thrpt    5   675.234 ±  7.525  ops/ms
JmhTest._regexifyExpression         thrpt    5   310.129 ±  6.492  ops/ms
JmhTest.firstName                   thrpt    5   715.902 ± 13.890  ops/ms
JmhTest.initFaker                   thrpt    5   256.209 ±  0.784  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5   595.780 ±  5.652  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   166.082 ±  1.000  ops/ms

```

after
```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  1067.565 ± 19.236  ops/ms
JmhTest._letterifyExpression        thrpt    5  1084.404 ±  3.447  ops/ms
JmhTest._optionsExpression          thrpt    5   676.119 ±  5.613  ops/ms
JmhTest._regexifyExpression         thrpt    5   321.421 ±  4.367  ops/ms
JmhTest.firstName                   thrpt    5   749.823 ±  6.373  ops/ms
JmhTest.initFaker                   thrpt    5   260.371 ±  1.357  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5   630.570 ±  3.218  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   165.601 ±  2.339  ops/ms
```