### PR TITLE
Use static faker as global faker in tests and method local as faker w…

### DIFF
--- a/src/test/java/net/datafaker/AbstractFakerTest.java
+++ b/src/test/java/net/datafaker/AbstractFakerTest.java
@@ -2,6 +2,7 @@ package net.datafaker;
 
 import net.datafaker.repeating.RepeatRule;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -16,7 +17,7 @@ public class AbstractFakerTest {
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
 
-    protected Faker faker;
+    protected static Faker faker;
 
     @Before
     public void before() {
@@ -28,6 +29,10 @@ public class AbstractFakerTest {
         for (Handler h : handlers) {
             h.setLevel(Level.INFO);
         }
+    }
+
+    @BeforeClass
+    public static void setup() {
         faker = new Faker();
     }
 }

--- a/src/test/java/net/datafaker/AddressTest.java
+++ b/src/test/java/net/datafaker/AddressTest.java
@@ -131,20 +131,20 @@ public class AddressTest extends AbstractFakerTest {
 
     @Test
     public void testZipCodeByState() {
-        faker = new Faker(new Locale("en-US"));
-        assertThat(faker.address().zipCodeByState(faker.address().stateAbbr()), matchesRegularExpression("[0-9]{5}"));
+        final Faker localFaker = new Faker(new Locale("en-US"));
+        assertThat(localFaker.address().zipCodeByState(localFaker.address().stateAbbr()), matchesRegularExpression("[0-9]{5}"));
     }
 
     @Test
     public void testHungarianZipCodeByState() {
-        faker = new Faker(new Locale("hu"));
-        assertThat(faker.address().zipCodeByState(faker.address().stateAbbr()), matchesRegularExpression("[0-9]{4}"));
+        final Faker localFaker = new Faker(new Locale("hu"));
+        assertThat(localFaker.address().zipCodeByState(localFaker.address().stateAbbr()), matchesRegularExpression("[0-9]{4}"));
     }
 
     @Test
     public void testCountyByZipCode() {
-        faker = new Faker(new Locale("en-US"));
-        assertThat(faker.address().countyByZipCode("47732"), not(is(emptyOrNullString())));
+        final Faker localFaker = new Faker(new Locale("en-US"));
+        assertThat(localFaker.address().countyByZipCode("47732"), not(is(emptyOrNullString())));
     }
 
     @Test
@@ -168,20 +168,20 @@ public class AddressTest extends AbstractFakerTest {
 
     @Test
     public void testZipIsFiveChars() {
-        faker = new Faker(new Locale("en-us"));
-        assertThat(faker.address().zipCode().length(), is(5));
+        final Faker localFaker = new Faker(new Locale("en-us"));
+        assertThat(localFaker.address().zipCode().length(), is(5));
     }
 
     @Test
     public void testZipPlus4IsTenChars() {
-        faker = new Faker(new Locale("en-us"));
-        assertThat(faker.address().zipCodePlus4().length(), is(10));  // includes dash
+        final Faker localFaker = new Faker(new Locale("en-us"));
+        assertThat(localFaker.address().zipCodePlus4().length(), is(10));  // includes dash
     }
 
     @Test
     public void testZipPlus4IsNineDigits() {
-        faker = new Faker(new Locale("en-us"));
-        final String[] zipCodeParts = faker.address().zipCodePlus4().split("-");
+        final Faker localFaker = new Faker(new Locale("en-us"));
+        final String[] zipCodeParts = localFaker.address().zipCodePlus4().split("-");
         assertThat(zipCodeParts[0], matchesRegularExpression("[0-9]{5}"));
         assertThat(zipCodeParts[1], matchesRegularExpression("[0-9]{4}"));
     }

--- a/src/test/java/net/datafaker/NameTest.java
+++ b/src/test/java/net/datafaker/NameTest.java
@@ -46,10 +46,10 @@ public class NameTest extends AbstractFakerTest {
 
     @Test
     public void testFullNameArabic() {
-        faker = new Faker(new Locale("ar"));
+        Faker localFaker = new Faker(new Locale("ar"));
 
         for (int i = 0; i < 25; i++) {
-            assertThat(faker.name().fullName(), matchesRegularExpression("^[\\u0600-\\u06FF\\u0750-\\u077F ]+$"));
+            assertThat(localFaker.name().fullName(), matchesRegularExpression("^[\\u0600-\\u06FF\\u0750-\\u077F ]+$"));
         }
     }
 


### PR DESCRIPTION
This will speed up tests.

Currently faker is initialized before each test and huge amount of time is spent for yaml parsing. 
The PR makes `faker` static and initialized `beforeclass` to cope with this