### PR TITLE
Replace regexp parser with normal parser of directive and arguments

### DIFF
--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -3,7 +3,7 @@ package net.datafaker;
 import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.RandomService;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
 public class Faker {
     private final RandomService randomService;
     private final FakeValuesService fakeValuesService;
-    private final Map<Class<?>, Object> providersMap = new HashMap<>();
+    private final Map<Class<?>, Object> providersMap = new IdentityHashMap<>();
 
     public Faker() {
         this(Locale.ENGLISH);


### PR DESCRIPTION
Another PR with replacement of regexp
This one also adds + up to  70% for some cases
before
```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  1000.702 ±  9.367  ops/ms
JmhTest._letterifyExpression        thrpt    5   983.098 ± 18.326  ops/ms
JmhTest._optionsExpression          thrpt    5   675.234 ±  7.525  ops/ms
JmhTest._regexifyExpression         thrpt    5   310.129 ±  6.492  ops/ms
JmhTest.firstName                   thrpt    5   715.902 ± 13.890  ops/ms
JmhTest.initFaker                   thrpt    5   256.209 ±  0.784  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5   595.780 ±  5.652  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   166.082 ±  1.000  ops/ms
```

after
```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  1829.098 ± 16.737  ops/ms
JmhTest._letterifyExpression        thrpt    5  1775.457 ±  9.980  ops/ms
JmhTest._optionsExpression          thrpt    5  1052.901 ± 16.139  ops/ms
JmhTest._regexifyExpression         thrpt    5   366.460 ±  3.624  ops/ms
JmhTest.firstName                   thrpt    5   994.682 ±  8.504  ops/ms
JmhTest.initFaker                   thrpt    5   250.549 ±  2.140  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5   873.172 ± 20.675  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   233.320 ±  1.172  ops/ms
```