### PR TITLE
Move file loading for english locale to static

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -1,14 +1,18 @@
 package net.datafaker.service;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import net.datafaker.service.files.EnFile;
+
+import java.util.*;
 
 public class FakeValuesGrouping implements FakeValuesInterface {
-
+    private static final FakeValuesGrouping ENGLISH_FAKE_VALUE_GROUPING = new FakeValuesGrouping();
     private final Map<String, Collection<FakeValues>> fakeValues = new HashMap<>();
+
+    static {
+        for (EnFile file : EnFile.getFiles()) {
+            ENGLISH_FAKE_VALUE_GROUPING.add(new FakeValues(Locale.ENGLISH, file.getFile(), file.getPath()));
+        }
+    }
 
     public void add(FakeValues fakeValue) {
         fakeValues.putIfAbsent(fakeValue.getPath(), new ArrayList<>());
@@ -28,5 +32,9 @@ public class FakeValuesGrouping implements FakeValuesInterface {
             }
         }
         return result;
+    }
+
+    public static FakeValuesGrouping getEnglishFakeValueGrouping() {
+        return ENGLISH_FAKE_VALUE_GROUPING;
     }
 }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -60,11 +60,7 @@ public class FakeValuesService {
         for (final Locale l : localesChain) {
             boolean isEnglish = l.equals(Locale.ENGLISH);
             if (isEnglish) {
-                FakeValuesGrouping fakeValuesGrouping = new FakeValuesGrouping();
-                for (EnFile file : EnFile.getFiles()) {
-                    fakeValuesGrouping.add(new FakeValues(l, file.getFile(), file.getPath()));
-                }
-                all.add(fakeValuesGrouping);
+                all.add(FakeValuesGrouping.getEnglishFakeValueGrouping());
             } else {
                 all.add(new FakeValues(l));
             }


### PR DESCRIPTION
Since loading of files for English locale consume lots of time for init of Faker and at the same time files are always same. The PR extracts this loading to static which could drastically speed up initFaker
before
```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest.initFaker                   thrpt    5   237.218 ± 10.073  ops/ms
```
after
```
Benchmark                            Mode  Cnt     Score     Error   Units
JmhTest.initFaker                   thrpt    5  4181.729 ± 192.370  ops/ms
```