### PR TITLE
Add csv generation

### DIFF
--- a/src/main/java/net/datafaker/Csv.java
+++ b/src/main/java/net/datafaker/Csv.java
@@ -1,0 +1,119 @@
+package net.datafaker;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class Csv {
+    private final String separator;
+    private final String lineSeparator = System.lineSeparator();
+    private final char quote;
+    private final List<Column> columns;
+    private final int limit;
+    private final boolean withHeader;
+    private Csv(List<Column> columns, String separator, char quote, boolean withHeader, int limit) {
+        this.separator = separator;
+        this.columns = columns;
+        this.limit = limit;
+        this.quote = quote;
+        this.withHeader = withHeader;
+    }
+
+    public String get() {
+        StringBuilder sb = new StringBuilder();
+        if (withHeader) {
+            addLine(sb, integer -> columns.get(integer).getName());
+        }
+
+        for (int line = 0; line < limit; line++) {
+            addLine(sb, integer -> columns.get(integer).getValue());
+        }
+        return sb.toString();
+    }
+
+    private void addLine(StringBuilder result, Function<Integer, String> function) {
+        for (int i = 0; i < columns.size(); i++) {
+            result.append(quote);
+            String header = String.valueOf(function.apply(i));
+            for (int j = 0; j < header.length(); j++) {
+                if (quote == header.charAt(j)) {
+                    result.append(quote);
+                }
+                result.append(header.charAt(j));
+            }
+            result.append(quote);
+            result.append(i == columns.size() - 1 ? lineSeparator : separator);
+        }
+    }
+
+    public static class Column {
+        private final String name;
+        private final Supplier<String> valueSupplier;
+
+        public Column(String name, Supplier<String> valueSupplier) {
+            this.name = name;
+            this.valueSupplier = valueSupplier;
+        }
+
+        public static Column of(String name, Supplier<String> valueSupplier) {
+            return new Column(name, valueSupplier);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Supplier<String> getValueSupplier() {
+            return valueSupplier;
+        }
+
+        public String getValue() {
+            return valueSupplier.get();
+        }
+    }
+
+    public static class CsvBuilder {
+        private String separator = ",";
+        private char quote = '"';
+        private final List<Column> columns = new ArrayList<>();
+        private boolean withHeader = true;
+        private int limit = 10;
+
+        public CsvBuilder separator(String separator) {
+            this.separator = separator;
+            return this;
+        }
+
+        public CsvBuilder quote(char quote) {
+            this.quote = quote;
+            return this;
+        }
+
+        public final CsvBuilder columns(Column... columns) {
+            this.columns.addAll(Arrays.asList(columns));
+            return this;
+        }
+
+        public CsvBuilder columns(Collection<Column> columns) {
+            this.columns.addAll(columns);
+            return this;
+        }
+
+        public CsvBuilder limit(int limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public CsvBuilder header(boolean withHeader) {
+            this.withHeader = withHeader;
+            return this;
+        }
+
+        public Csv build() {
+            return new Csv(columns, separator, quote, withHeader, limit);
+        }
+    }
+}

--- a/src/test/java/net/datafaker/CsvTest.java
+++ b/src/test/java/net/datafaker/CsvTest.java
@@ -1,0 +1,63 @@
+package net.datafaker;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class CsvTest extends AbstractFakerTest {
+
+    @Test
+    public void csvTest() {
+        String separator = "@@@";
+        int limit = 20;
+        String csv = new Csv.CsvBuilder()
+                .columns(Csv.Column.of("first_name", () -> faker.name().firstName()),
+                        Csv.Column.of("last_name", () -> faker.name().lastName()),
+                        Csv.Column.of("address", () -> faker.address().streetAddress()))
+                .header(true)
+                .separator(separator)
+                .limit(limit).build().get();
+        int numberOfLines = 0;
+        int numberOfSeparator = 0;
+        for (int i = 0; i < csv.length(); i++) {
+            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            } else if (csv.regionMatches(i, separator, 0, separator.length())) {
+                numberOfSeparator++;
+            }
+        }
+
+        assertEquals(limit + 1, numberOfLines); // limit + 1 line for header
+        assertEquals((limit + 1) * 2, numberOfSeparator); // number of lines * (number of columns - 1)
+    }
+
+    @Test
+    public void csvTestWithQuotes() {
+        String separator = "$$$";
+        int limit = 20;
+        Collection<Csv.Column> columns = new ArrayList<>();
+        columns.add(Csv.Column.of("first_name", () -> faker.expression("#{Name.first_name}")));
+        columns.add(Csv.Column.of("last_name", () -> faker.expression("#{Name.last_name}")));
+        String csv = new Csv.CsvBuilder()
+                .columns(columns)
+                .header(true)
+                .separator(separator)
+                .quote('%')
+                .limit(limit).build().get();
+        int numberOfLines = 0;
+        int numberOfSeparator = 0;
+        for (int i = 0; i < csv.length(); i++) {
+            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            } else if (csv.regionMatches(i, separator, 0, separator.length())) {
+                numberOfSeparator++;
+            }
+        }
+
+        assertEquals(limit + 1, numberOfLines); // limit + 1 line for header
+        assertEquals((limit + 1) * (columns.size() - 1), numberOfSeparator); // number of lines * (number of columns - 1)
+    }
+}


### PR DESCRIPTION
The PR adds support for csv generation
number and names of columns could be specified
separator and quotes could be specified with `separator()` and `quote()`
number of lines could be specified via `limit()`
with or without header also could be specified with `header()`
e.g. 
```
System.out.println(new Csv.CsvBuilder()
                .columns(Csv.Column.of("first_name", () -> faker.name().firstName()),
                        Csv.Column.of("last_name", () -> faker.name().lastName()),
                        Csv.Column.of("address", () -> faker.address().streetAddress()))
                .header(true)
                .separator(" ; ")
                .limit(5).build().get());
```

will generate something like that
```
"first_name" ; "last_name" ; "address"
"Jonah" ; "Kovacek" ; "009 Wilkinson Summit"
"John" ; "Murphy" ; "379 McCullough Locks"
"Colby" ; "Bins" ; "93534 Stevie Gardens"
"Wade" ; "Herzog" ; "83108 Willy Road"
"Marg" ; "Effertz" ; "415 Gene Plaza"
```