### PR TITLE
Add fake collections

### DIFF
--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -1,0 +1,62 @@
+package net.datafaker;
+
+import net.datafaker.service.RandomService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class FakeCollection<T> {
+    private final RandomService randomService = new RandomService();
+    private final List<Supplier<T>> suppliers;
+    private final int minLength;
+    private final int maxLength;
+
+    public List<T> get() {
+        List<T> result = new ArrayList<>();
+        int size = randomService.nextInt(minLength, maxLength);
+        while (result.size() < size) {
+            result.add(suppliers.get(randomService.nextInt(suppliers.size())).get());
+        }
+        return result;
+    }
+
+    public FakeCollection(List<Supplier<T>> suppliers, int minLength, int maxLength) {
+        this.suppliers = suppliers;
+        this.minLength = minLength;
+        this.maxLength = maxLength;
+    }
+
+    public static class Builder<T> {
+        private final List<Supplier<T>> suppliers = new ArrayList<>();
+        private int minLength = -1; // negative means same as maxLength
+        private int maxLength = 10;
+
+        public Builder<T> minLen(int minLength) {
+            this.minLength = minLength;
+            return this;
+        }
+
+        public Builder<T> maxLen(int maxLength) {
+            this.maxLength = maxLength;
+            return this;
+        }
+
+        @SafeVarargs
+        public final Builder<T> suppliers(Supplier<T>... suppliers) {
+            Objects.requireNonNull(suppliers);
+            this.suppliers.addAll(Arrays.asList(suppliers));
+            return this;
+        }
+
+        public FakeCollection<T> build() {
+            if (minLength > maxLength || maxLength < 0) {
+                throw new IllegalArgumentException("Max length must be not less than min length and not negative");
+            }
+            minLength = minLength < 0 ? maxLength : minLength;
+            return new FakeCollection<T>(suppliers, minLength, maxLength);
+        }
+    }
+}

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -1,0 +1,47 @@
+package net.datafaker;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static net.datafaker.matchers.MatchesRegularExpression.matchesRegularExpression;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FakeCollectionTest extends AbstractFakerTest {
+    @Test
+    public void generateCollection() {
+        List<String> names = new FakeCollection.Builder<String>()
+                .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
+                .minLen(3)
+                .maxLen(5).build().get();
+        assertThat(names.size(), is(lessThanOrEqualTo(5)));
+        assertThat(names.size(), is(greaterThanOrEqualTo(3)));
+        for (String name : names) {
+            assertThat(name, matchesRegularExpression("[a-zA-Z']+"));
+        }
+    }
+
+    @Test
+    public void generateCollectionWithDifferentObjects() {
+        List<Object> objects = new FakeCollection.Builder<>()
+                .suppliers(() -> faker.name().firstName(), () -> faker.random().nextInt(100))
+                .maxLen(5).build().get();
+        assertEquals(5, objects.size());
+        for (Object object : objects) {
+            assertTrue(object instanceof Integer || object instanceof String);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkWrongArguments() {
+        new FakeCollection.Builder<String>()
+                .suppliers(() -> faker.name().firstName())
+                .minLen(10)
+                .maxLen(5).build().get();
+    }
+}


### PR DESCRIPTION
The PR adds support of fake collections

e.g. will generate a list of first and last names with size `[3, 5]`
```java
List<String> names = new FakeCollection.Builder<String>()
                .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
                .minLen(3)
                .maxLen(5).build().get();
```
List could contain different types e.g.
```java
List<Object> objects = new FakeCollection.Builder<>()
                .suppliers(() -> faker.name().firstName(), () -> faker.random().nextInt(100))
                .maxLen(5).build().get();
```