### PR TITLE
Use locale for toUpperCase, toLowerCase, decimal format symbols

### DIFF
--- a/src/main/java/net/datafaker/Commerce.java
+++ b/src/main/java/net/datafaker/Commerce.java
@@ -1,14 +1,17 @@
 package net.datafaker;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class Commerce {
     private final Faker faker;
+    private final DecimalFormatSymbols decimalFormatSymbols;
 
     protected Commerce(Faker faker) {
         this.faker = faker;
+        decimalFormatSymbols = new DecimalFormatSymbols(faker.getLocale());
     }
 
     public String color() {
@@ -51,7 +54,7 @@ public class Commerce {
 
     public String price(double min, double max) {
         double price = min + (faker.random().nextDouble() * (max - min));
-        return new DecimalFormat("#0.00").format(price);
+        return new DecimalFormat("#0.00", decimalFormatSymbols).format(price);
     }
 
     public String promotionCode() {

--- a/src/main/java/net/datafaker/Company.java
+++ b/src/main/java/net/datafaker/Company.java
@@ -76,7 +76,7 @@ public class Company {
     }
 
     private String domainName() {
-        return UNWANTED_CHARACTERS.matcher(name().toLowerCase()).replaceAll("");
+        return UNWANTED_CHARACTERS.matcher(name().toLowerCase(faker.getLocale())).replaceAll("");
     }
 
     private String domainSuffix() {

--- a/src/main/java/net/datafaker/Crypto.java
+++ b/src/main/java/net/datafaker/Crypto.java
@@ -1,6 +1,7 @@
 package net.datafaker;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -39,7 +40,7 @@ public class Crypto {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
             String characters = faker.lorem().characters();
-            messageDigest.update(characters.getBytes(), 0, characters.length());
+            messageDigest.update(characters.getBytes(StandardCharsets.UTF_8), 0, characters.length());
             return new BigInteger(1, messageDigest.digest()).toString(16);
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
             throw new RuntimeException(noSuchAlgorithmException);

--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -86,7 +86,8 @@ public class Faker {
     }
 
     Locale getLocale() {
-        return fakeValuesService.getLocalesChain().get(0);
+        return fakeValuesService.getLocalesChain().isEmpty() || fakeValuesService.getLocalesChain().get(0) == null
+            ? Locale.ROOT : fakeValuesService.getLocalesChain().get(0);
     }
 
     /**

--- a/src/main/java/net/datafaker/File.java
+++ b/src/main/java/net/datafaker/File.java
@@ -22,7 +22,7 @@ public class File {
     public String fileName(String dirOrNull, String nameOrNull, String extensionOrNull, String separatorOrNull) {
         final String sep = separatorOrNull == null ? System.getProperty("file.separator") : separatorOrNull;
         final String dir = dirOrNull == null ? faker.internet().slug() : dirOrNull;
-        final String name = nameOrNull == null ? faker.lorem().word().toLowerCase() : nameOrNull;
+        final String name = nameOrNull == null ? faker.lorem().word().toLowerCase(faker.getLocale()) : nameOrNull;
         final String ext = extensionOrNull == null ? extension() : extensionOrNull;
         return dir + sep + name + "." + ext;
     }

--- a/src/test/java/net/datafaker/AddressTest.java
+++ b/src/test/java/net/datafaker/AddressTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.not;
 
 public class AddressTest extends AbstractFakerTest {
 
-    private static final char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+    private static final char decimalSeparator = new DecimalFormatSymbols(faker.getLocale()).getDecimalSeparator();
 
     @Test
     public void testStreetAddressStartsWithNumber() {

--- a/src/test/java/net/datafaker/CommerceTest.java
+++ b/src/test/java/net/datafaker/CommerceTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CommerceTest extends AbstractFakerTest {
 
-    private static final char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+    private static final char decimalSeparator = new DecimalFormatSymbols(faker.getLocale()).getDecimalSeparator();
 
     private static final String CAPITALIZED_WORD_REGEX = "[A-Z][a-z]+";
 

--- a/src/test/java/net/datafaker/FinanceTest.java
+++ b/src/test/java/net/datafaker/FinanceTest.java
@@ -49,7 +49,7 @@ public class FinanceTest extends AbstractFakerTest {
     public void costaRicaIbanMustBeValid() {
         final String givenCountryCode = "CR";
         final Faker faker = new Faker();
-        final String ibanFaker = faker.finance().iban(givenCountryCode).toUpperCase();
+        final String ibanFaker = faker.finance().iban(givenCountryCode).toUpperCase(faker.getLocale());
         assertTrue(fr.marcwrobel.jbanking.iban.Iban.isValid(ibanFaker));
     }
 }


### PR DESCRIPTION
The part about usage locales within `toUpperCase`, `toLowerCase` and `DecimalFormatSymbols`