### PR TITLE
Add flags to maven to show timestamps during build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  mvn_options: -B -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS  
+
 jobs:
   build:
     strategy:
@@ -26,7 +29,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn $mvn_options package --file pom.xml
       - uses: codecov/codecov-action@v1
         with:
           file: ./**/target/site/jacoco/jacoco.xml


### PR DESCRIPTION
Could be helpful to see where time is consuming

the result could be seen in build logs at https://github.com/datafaker-net/datafaker/runs/5303678498?check_suite_focus=true#step:4:7