### PR TITLE
Speed up Lorem#characters and it's dependencies

### DIFF
--- a/src/main/java/net/datafaker/Lorem.java
+++ b/src/main/java/net/datafaker/Lorem.java
@@ -93,27 +93,31 @@ public class Lorem {
         char[] buffer = new char[fixedNumberOfCharacters];
         char[] special = new char[]{'!', '@', '#', '$', '%', '^', '&', '*'};
         char[] number = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
-        char[] All = (new String(special) + new String(characters)).toCharArray();
-        char[] SpecialAndLetter = (new String(special) + new String(letters)).toCharArray();
+        char[] all = new char[special.length + characters.length];
+        System.arraycopy(special, 0, all, 0, special.length);
+        System.arraycopy(characters, 0, all, special.length, characters.length);
+        char[] specialAndLetter = new char[special.length + letters.length];
+        System.arraycopy(special, 0, specialAndLetter, 0, special.length);
+        System.arraycopy(letters, 0, specialAndLetter, special.length, letters.length);
 
         int cnt = 0;
         if (includeUppercase) {
-            char TheUpper = Character.toUpperCase(letters[faker.random().nextInt(letters.length)]);
+            char theUpper = Character.toUpperCase(letters[faker.random().nextInt(letters.length)]);
             if (cnt > fixedNumberOfCharacters - 1) return "";
-            buffer[cnt++] = TheUpper;
+            buffer[cnt++] = theUpper;
 
         }
 
         if (includeSpecial) {
-            char TheSpecial = special[faker.random().nextInt(special.length)];
+            char theSpecial = special[faker.random().nextInt(special.length)];
             if (cnt > fixedNumberOfCharacters - 1) return "";
-            buffer[cnt++] = TheSpecial;
+            buffer[cnt++] = theSpecial;
         }
 
         if (includeDigit) {
-            char TheNum = number[faker.random().nextInt(number.length)];
+            char theNum = number[faker.random().nextInt(number.length)];
             if (cnt > fixedNumberOfCharacters - 1) return "";
-            buffer[cnt++] = TheNum;
+            buffer[cnt++] = theNum;
         }
 
 
@@ -121,13 +125,13 @@ public class Lorem {
             char randomCharacter;
 
             if (includeSpecial && !includeDigit) {
-                randomCharacter = SpecialAndLetter[faker.random().nextInt(SpecialAndLetter.length)];
+                randomCharacter = specialAndLetter[faker.random().nextInt(specialAndLetter.length)];
             } else if (!includeSpecial && includeDigit) {
                 randomCharacter = characters[faker.random().nextInt(characters.length)];
             } else if (!includeSpecial && !includeDigit) {
                 randomCharacter = letters[faker.random().nextInt(letters.length)];
             } else {                                            //includeSpecial && includeDigit
-                randomCharacter = All[faker.random().nextInt(All.length)];
+                randomCharacter = all[faker.random().nextInt(all.length)];
             }
 
             if (includeUppercase && faker.bool().bool()) {
@@ -137,7 +141,7 @@ public class Lorem {
         }
 
         shuffle(buffer);
-        return new String(buffer);
+        return String.valueOf(buffer);
     }
 
     private void shuffle(char[] buffer) {

--- a/src/main/java/net/datafaker/service/RandomService.java
+++ b/src/main/java/net/datafaker/service/RandomService.java
@@ -69,7 +69,7 @@ public class RandomService {
         return min + (nextDouble() * (max - min));
     }
 
-    public Boolean nextBoolean() {
+    public boolean nextBoolean() {
         return random.nextBoolean();
     }
 

--- a/src/test/java/net/datafaker/InternetPasswordTest.java
+++ b/src/test/java/net/datafaker/InternetPasswordTest.java
@@ -10,13 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class InternetPasswordTest extends AbstractFakerTest {
     @Test
     public void testPassword1000() {
+        final Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
+        final Pattern digitPattern = Pattern.compile("[0-9]");
         for (int i = 0; i < 1000; i++) {
             String password = faker.internet().password(8, 16, true, true, true);
-
-            Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
             Matcher specialCharacterMatcher = specialCharacterPattern.matcher(password);
-
-            Pattern digitPattern = Pattern.compile("[0-9]");
             Matcher digitMatcher = digitPattern.matcher(password);
 
             boolean isPasswordContainsSpecialCharacter = specialCharacterMatcher.find();


### PR DESCRIPTION
The PR speeds up a bit _Lorem#characters_ and it's dependencies e.g. _Internet#password_

before
```
Benchmark           Mode  Cnt     Score    Error   Units
JmhTest._password  thrpt    5  4710.876 ± 45.822  ops/ms
```

after
```
Benchmark           Mode  Cnt     Score    Error   Units
JmhTest._password  thrpt    5  5254.761 ± 21.613  ops/ms
```

benchmark

```java

@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Benchmark)
@Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})
public class JmhTest {

    private static final Faker FAKER = new Faker();

    public static void main(String[] args) throws RunnerException {

        Options opt = new OptionsBuilder()
            .include(JmhTest.class.getSimpleName())
            .forks(1)
            .build();

        new Runner(opt).run();
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void _password(Blackhole blackhole) {
        blackhole.consume(FAKER.internet().password(8, 16));
    }

}
```