### PR TITLE
Use ThreadLocalRandom wherever possible since it is available since 1.7

### DIFF
--- a/src/main/java/net/datafaker/Lorem.java
+++ b/src/main/java/net/datafaker/Lorem.java
@@ -28,14 +28,14 @@ public class Lorem {
     }
 
     public String characters(int minimumLength, int maximumLength) {
-        return characters(faker.random().nextInt(minimumLength, maximumLength), false);
+        return characters(faker.random().nextInt(minimumLength, maximumLength + 1), false);
     }
 
     public String characters(int minimumLength, int maximumLength, boolean includeUppercase) {
         if (minimumLength == maximumLength) {
             return characters(minimumLength, includeUppercase);
         } else {
-            return characters(faker.random().nextInt(minimumLength, maximumLength), includeUppercase);
+            return characters(faker.random().nextInt(minimumLength, maximumLength + 1), includeUppercase);
         }
     }
 
@@ -43,7 +43,7 @@ public class Lorem {
         if (minimumLength == maximumLength) {
             return characters(minimumLength, includeUppercase, includeDigit);
         } else {
-            return characters(faker.random().nextInt(minimumLength, maximumLength), includeUppercase, includeDigit);
+            return characters(faker.random().nextInt(minimumLength, maximumLength + 1), includeUppercase, includeDigit);
         }
     }
 
@@ -57,7 +57,7 @@ public class Lorem {
 
     public String characters(int minimumLength, int maximumLength,
                              boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
-        return characters(faker.random().nextInt(minimumLength, maximumLength),
+        return characters(faker.random().nextInt(minimumLength, maximumLength + 1),
             includeUppercase, includeSpecial, includeDigit);
     }
 

--- a/src/main/java/net/datafaker/Number.java
+++ b/src/main/java/net/datafaker/Number.java
@@ -14,7 +14,7 @@ public class Number {
      * Returns a random number from 0-9 (both inclusive)
      */
     public int randomDigit() {
-        return decimalBetween(0, 10).intValue();
+        return numberBetween(0, 10);
     }
 
     /**
@@ -32,7 +32,7 @@ public class Number {
      */
     public int numberBetween(int min, int max) {
         if (min == max) return min;
-        return decimalBetween(min, max).intValue();
+        return intBetween(min, max);
     }
 
     /**
@@ -43,7 +43,7 @@ public class Number {
      */
     public long numberBetween(long min, long max) {
         if (min == max) return min;
-        return decimalBetween(min, max).longValue();
+        return longBetween(min, max);
     }
 
     /**
@@ -51,10 +51,12 @@ public class Number {
      * @param strict         whether or not the generated value should have exactly <code>numberOfDigits</code>
      */
     public long randomNumber(int numberOfDigits, boolean strict) {
-        long max = (long) Math.pow(10, numberOfDigits);
+        long max = 1;
+        for (int i = 0; i < numberOfDigits; i++) max *= 10;
         if (strict) {
-            long min = (long) Math.pow(10, numberOfDigits - 1);
-            return faker.random().nextLong(max - min) + min;
+            long min = numberOfDigits <= 1 ? 0 : 1;
+            for (int i = 0; i < numberOfDigits - 1; i++) min *= 10;
+            return faker.random().nextLong(min, max);
         }
 
         return faker.random().nextLong(max);
@@ -64,7 +66,7 @@ public class Number {
      * Returns a random number
      */
     public long randomNumber() {
-        int numberOfDigits = decimalBetween(1, 10).intValue();
+        int numberOfDigits = intBetween(1, 10);
         return randomNumber(numberOfDigits, false);
     }
 
@@ -103,12 +105,20 @@ public class Number {
         return trueMin.add(trueMax.subtract(trueMin).multiply(random));
     }
 
+    private int intBetween(int min, int max) {
+        return faker.random().nextInt(min, max);
+    }
+
+    private long longBetween(long min, long max) {
+        return faker.random().nextLong(min, max);
+    }
+
     public String digits(int count) {
-        final StringBuilder tmp = new StringBuilder();
+        final char[] result = new char[count];
         for (int i = 0; i < count; i++) {
-            tmp.append(randomDigit());
+            result[i] = (char) ('0' + randomDigit());
         }
-        return tmp.toString();
+        return String.valueOf(result);
     }
 
     public String digit() {

--- a/src/main/java/net/datafaker/Number.java
+++ b/src/main/java/net/datafaker/Number.java
@@ -21,7 +21,7 @@ public class Number {
      * Returns a random number from 1-9 (both inclusive)
      */
     public int randomDigitNotZero() {
-        return decimalBetween(1, 10).intValue();
+        return intBetween(1, 10);
     }
 
     /**

--- a/src/main/java/net/datafaker/service/RandomService.java
+++ b/src/main/java/net/datafaker/service/RandomService.java
@@ -1,9 +1,10 @@
 package net.datafaker.service;
 
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class RandomService {
-    private static final Random SHARED_RANDOM = new Random();
+    private static final Random SHARED_RANDOM = ThreadLocalRandom.current();
     private final Random random;
 
     /**
@@ -29,8 +30,9 @@ public class RandomService {
         return random.nextInt(n);
     }
 
-    public Integer nextInt(int min, int max) {
-        return random.nextInt((max - min) + 1) + min;
+    public int nextInt(int min, int max) {
+        if (min == max) return min;
+        return ThreadLocalRandom.current().nextInt(min, max);
     }
 
     @SuppressWarnings("unused")
@@ -42,23 +44,13 @@ public class RandomService {
         return random.nextLong();
     }
 
-    // lifted from http://stackoverflow.com/questions/2546078/java-random-long-number-in-0-x-n-range
     public long nextLong(long n) {
-        if (n <= 0) {
-            throw new IllegalArgumentException("bound must be positive");
-        }
-
-        long bits, val;
-        do {
-            long randomLong = random.nextLong();
-            bits = (randomLong << 1) >>> 1;
-            val = bits % n;
-        } while (bits - val + (n - 1) < 0L);
-        return val;
+        return ThreadLocalRandom.current().nextLong(n);
     }
 
     public long nextLong(long min, long max) {
-        return min + (long) (nextDouble() * (max - min));
+        if (min == max) return min;
+        return ThreadLocalRandom.current().nextLong(min, max);
     }
 
     public double nextDouble() {
@@ -66,7 +58,8 @@ public class RandomService {
     }
 
     public double nextDouble(double min, double max) {
-        return min + (nextDouble() * (max - min));
+        if (min == max) return min;
+        return ThreadLocalRandom.current().nextDouble(min, max);
     }
 
     public boolean nextBoolean() {


### PR DESCRIPTION
Suddenly this relatively simple change also speeds up some cases

before 
```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  4277.270 ± 41.760  ops/ms
JmhTest._csv                        thrpt    5    35.568 ±  0.919  ops/ms
JmhTest._letterifyExpression        thrpt    5  4629.480 ± 62.134  ops/ms
JmhTest._optionsExpression          thrpt    5  4846.367 ± 34.680  ops/ms
JmhTest._regexifyExpression         thrpt    5  2070.759 ± 23.280  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  2309.779 ± 26.963  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   565.426 ±  5.828  ops/ms
```

after
```

Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  4538.392 ± 60.038  ops/ms
JmhTest._csv                        thrpt    5    37.199 ±  0.434  ops/ms
JmhTest._letterifyExpression        thrpt    5  4834.415 ± 89.559  ops/ms
JmhTest._optionsExpression          thrpt    5  4894.174 ± 59.062  ops/ms
JmhTest._regexifyExpression         thrpt    5  2099.060 ± 35.080  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  4688.254 ± 71.117  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   590.847 ±  7.354  ops/ms
```