### PR TITLE
Cache mapping of raw expressions to suppliers

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class FakeValuesService {
     private static final Pattern LOCALE = Pattern.compile("[-_]");
@@ -41,6 +42,7 @@ public class FakeValuesService {
 
     private final Map<Class<?>, Map<String, Collection<Method>>> class2methodsCache = new IdentityHashMap<>();
     private final Map<String, Supplier<String>> expression2function = new WeakHashMap<>();
+    private final Map<String, List<Supplier<String>>> rawExp2function = new WeakHashMap<>();
     private final Map<String, Generex> expression2generex = new WeakHashMap<>();
 
     /**
@@ -408,32 +410,42 @@ public class FakeValuesService {
      * {@link Faker#address()}'s {@link net.datafaker.Address#streetName()}.
      */
     protected String resolveExpression(String expression, Object current, Faker root) {
-        List<String> expressions = splitExpressions(expression);
-        for (int i = 0; i < expressions.size(); i++) {
-            // odd are expressions, even are not expressions, just strings
-            if (i % 2 == 0) {
-                continue;
-            }
-            String expr = expressions.get(i);
-            final Supplier<String> supplier = expression2function.get(expr);
-            String resolved = supplier == null ? null : supplier.get();
-            if (resolved == null) {
-                int j = 0;
-                while (j < expr.length() && !Character.isWhitespace(expr.charAt(j))) j++;
-                String directive = expr.substring(0, j);
-                while (j < expr.length() && Character.isWhitespace(expr.charAt(j))) j++;
-                String arguments = j == expr.length() ? "" : expr.substring(j);
-                String[] args = splitArguments(arguments);
-
-                resolved = resolveExpression(expr, directive, args, current, root);
-                if (resolved == null) {
-                    throw new RuntimeException("Unable to resolve #{" + expr + "} directive.");
+        List<Supplier<String>> expressionSuppliers = rawExp2function.get(expression);
+        if (expressionSuppliers == null) {
+            List<String> expressions = splitExpressions(expression);
+            expressionSuppliers = new ArrayList<>(expressions.size());
+            for (int i = 0; i < expressions.size(); i++) {
+                // odd are expressions, even are not expressions, just strings
+                if (i % 2 == 0) {
+                    final int index = i;
+                    expressionSuppliers.add(() -> expressions.get(index));
+                    continue;
                 }
+                String expr = expressions.get(i);
+                final Supplier<String> supplier = expression2function.get(expr);
+                String resolved = supplier == null ? null : supplier.get();
+                if (resolved == null) {
+                    int j = 0;
+                    while (j < expr.length() && !Character.isWhitespace(expr.charAt(j))) j++;
+                    String directive = expr.substring(0, j);
+                    while (j < expr.length() && Character.isWhitespace(expr.charAt(j))) j++;
+                    String arguments = j == expr.length() ? "" : expr.substring(j);
+                    String[] args = splitArguments(arguments);
+
+                    resolved = resolveExpression(expr, directive, args, current, root);
+                    if (resolved == null) {
+                        throw new RuntimeException("Unable to resolve #{" + expr + "} directive.");
+                    }
+                }
+                String r = resolved;
+                expressionSuppliers.add(() -> resolveExpression(r, current, root));
             }
-            expressions.set(i, resolveExpression(resolved, current, root));
+            if (current == null) {
+                rawExp2function.put(expression, expressionSuppliers);
+            }
         }
 
-        return String.join("", expressions);
+        return expressionSuppliers.stream().map(Supplier::get).collect(Collectors.joining());
     }
 
     private static String[] splitArguments(String arguments) {


### PR DESCRIPTION

This change drastically speeds up almost all cases

```
Benchmark                            Mode  Cnt     Score    Error   Units
JmhTest._bothifyExpression          thrpt    5  4538.392 ± 60.038  ops/ms
JmhTest._letterifyExpression        thrpt    5  4834.415 ± 89.559  ops/ms
JmhTest._optionsExpression          thrpt    5  4894.174 ± 59.062  ops/ms
JmhTest._regexifyExpression         thrpt    5  2099.060 ± 35.080  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  4688.254 ± 71.117  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   590.847 ±  7.354  ops/ms
```
after
```
Benchmark                            Mode  Cnt      Score     Error   Units
JmhTest._bothifyExpression          thrpt    5  19174.442 ± 295.380  ops/ms
JmhTest._letterifyExpression        thrpt    5  19171.794 ± 258.306  ops/ms
JmhTest._optionsExpression          thrpt    5  19258.219 ± 127.240  ops/ms
JmhTest._regexifyExpression         thrpt    5  19091.245 ± 145.238  ops/ms
JmhTest.oneMethodCallExpression     thrpt    5  19141.204 ±  97.692  ops/ms
JmhTest.threeMethodsCallExpression  thrpt    5   6760.780 ± 117.027  ops/ms
```