### PR TITLE
Cache expressions for keys

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -44,6 +44,7 @@ public class FakeValuesService {
     private final Map<String, Supplier<String>> expression2function = new WeakHashMap<>();
     private final Map<String, List<Supplier<String>>> rawExp2function = new WeakHashMap<>();
     private final Map<String, Generex> expression2generex = new WeakHashMap<>();
+    private final Map<String, String> key2Expression = new WeakHashMap<>();
 
     /**
      * Resolves YAML file using the most specific path first based on language and country code.
@@ -384,7 +385,13 @@ public class FakeValuesService {
      * #{Person.hello_someone} will result in a method call to person.helloSomeone();
      */
     public String resolve(String key, Object current, Faker root) {
-        final String expression = safeFetch(key, null);
+        String expression = root == null ? key2Expression.get(key) : null;
+        if (expression == null) {
+            expression = safeFetch(key, null);
+            if (root == null) {
+                key2Expression.put(key, expression);
+            }
+        }
 
         if (expression == null) {
             throw new RuntimeException(key + " resulted in null expression");


### PR DESCRIPTION
Small speedup.
For generation of different formats it could bring up to 30% e.g. for csv
before
```
Benchmark                            Mode  Cnt     Score     Error   Units
JmhTest._csv                        thrpt    5    30.206 ±   0.538  ops/ms
```

after
```
Benchmark                            Mode  Cnt     Score     Error   Units
JmhTest._csv                        thrpt    5    40.923 ±   0.455  ops/ms
```