### PR TITLE
Add addPath at Faker's level

### DIFF
--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -89,8 +89,8 @@ First, create the custom provider which loads the data from a file:
 
         public InsectFromFile(Faker faker) {
             this.faker = faker;
-            faker.fakeValuesService().addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
-            faker.fakeValuesService().addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));
+            faker.addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
+            faker.addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));
         }
 
         public String ant() {

--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -3,6 +3,7 @@ package net.datafaker;
 import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.RandomService;
 
+import java.nio.file.Path;
 import java.util.IdentityHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -200,6 +201,17 @@ public class Faker {
 
     FakeValuesService fakeValuesService() {
         return this.fakeValuesService;
+    }
+
+    /**
+     * Allows to add paths to files with custom data. Data should be in YAML format.
+     *
+     * @param locale        the locale for which a path is going to be added.
+     * @param path          path to a file with YAML structure
+     * @throws IllegalArgumentException in case of invalid path
+     */
+    public void addPath(Locale locale, Path path) {
+        fakeValuesService().addPath(locale, path);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/net/datafaker/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/CustomFakerTest.java
@@ -44,8 +44,8 @@ public class CustomFakerTest {
 
         public InsectFromFile(Faker faker) {
             this.faker = faker;
-            faker.fakeValuesService().addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
-            faker.fakeValuesService().addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));
+            faker.addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
+            faker.addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));
         }
 
         public String ant() {
@@ -60,13 +60,13 @@ public class CustomFakerTest {
     @Test
     public void addNullExistingPath() {
         Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new Faker().fakeValuesService().addPath(Locale.ENGLISH, null));
+            () -> new Faker().addPath(Locale.ENGLISH, null));
     }
 
     @Test
     public void addNonExistingPath() {
         Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new Faker().fakeValuesService().addPath(Locale.ENGLISH, Paths.get("non-existing-file")));
+            () -> new Faker().addPath(Locale.ENGLISH, Paths.get("non-existing-file")));
     }
 
     @RepeatedTest(10)


### PR DESCRIPTION
The PR makes possible to add paths to custom faker's data not only from `net.datafaker` package