### PR TITLE
Introduce Format and generalise logic for csv

### DIFF
--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -76,6 +76,7 @@ public class FakeCollection<T> {
         }
     }
 
+    @Deprecated // use net.datafaker.fileformats.Format.toCsv
     public CsvBuilder<T> toCsv() {
         return new CsvBuilder<T>().collection(this);
     }

--- a/src/main/java/net/datafaker/fileformats/Csv.java
+++ b/src/main/java/net/datafaker/fileformats/Csv.java
@@ -1,36 +1,46 @@
 package net.datafaker.fileformats;
 
+import net.datafaker.FakeCollection;
+
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public class Csv {
+public class Csv<T> {
+    private final FakeCollection<T> collection;
     private final String separator;
-    private final String lineSeparator = System.lineSeparator();
     private final char quote;
-    private final List<Column> columns;
-    private final int limit;
     private final boolean withHeader;
+    private final List<CollectionColumn<T>> columns;
+    private final int limit;
 
-    private Csv(List<Column> columns, String separator, char quote, boolean withHeader, int limit) {
+    Csv(FakeCollection<T> collection, String separator, char quote, boolean withHeader, List<CollectionColumn<T>> columns, int limit) {
+        this.collection = collection;
         this.separator = separator;
-        this.columns = columns;
-        this.limit = limit;
         this.quote = quote;
         this.withHeader = withHeader;
+        this.columns = columns;
+        this.limit = limit;
     }
 
     public String get() {
+        if (columns == null) {
+            throw new IllegalArgumentException("Length of headers should be equal to length of columns");
+        }
         StringBuilder sb = new StringBuilder();
         if (withHeader) {
             addLine(sb, integer -> columns.get(integer).getName());
         }
 
-        for (int line = 0; line < limit; line++) {
-            addLine(sb, integer -> columns.get(integer).getValue());
+        List<T> res = collection == null ? null : collection.get();
+        for (int line = 0; line < (res == null ? limit : res.size()); line++) {
+            int rowNum = line;
+            addLine(sb, integer -> columns.get(integer).getValue(res == null || res.isEmpty() ? null : res.get(rowNum)));
         }
         return sb.toString();
     }
@@ -46,75 +56,151 @@ public class Csv {
                 result.append(header.charAt(j));
             }
             result.append(quote);
-            result.append(i == columns.size() - 1 ? lineSeparator : separator);
+            result.append(i == columns.size() - 1 ? System.lineSeparator() : separator);
         }
     }
 
-    public static class Column {
-        private final String name;
-        private final Supplier<String> valueSupplier;
+    public static class Column extends CollectionColumn<String> {
+        private Column(Supplier<String> name, Supplier<String> valueSupplier) {
+            super(name, valueSupplier);
+        }
 
-        public Column(String name, Supplier<String> valueSupplier) {
+        public static Column of(String name, Supplier<String> valueSupplier) {
+            return new Column(() -> name, valueSupplier);
+        }
+
+        public static Column of(Supplier<String> name, Supplier<String> valueSupplier) {
+            return new Column(name, valueSupplier);
+        }
+    }
+
+    public static class CollectionColumn<T> {
+        private final Supplier<String> name;
+        private final Function<T, String> valueSupplier;
+
+        private CollectionColumn(Supplier<String> name, Supplier<String> valueSupplier) {
+            this.name = name;
+            this.valueSupplier = t -> valueSupplier.get();
+        }
+
+        private CollectionColumn(Supplier<String> name, Function<T, String> valueSupplier) {
             this.name = name;
             this.valueSupplier = valueSupplier;
         }
 
-        public static Column of(String name, Supplier<String> valueSupplier) {
-            return new Column(name, valueSupplier);
+        public static <T> CollectionColumn<T> of(Supplier<String> name, Function<T, String> valueSupplier) {
+            return new CollectionColumn<T>(name, valueSupplier);
         }
 
         public String getName() {
-            return name;
+            return name.get();
         }
 
-        public Supplier<String> getValueSupplier() {
-            return valueSupplier;
-        }
-
-        public String getValue() {
-            return valueSupplier.get();
+        public String getValue(T object) {
+            return valueSupplier.apply(object);
         }
     }
 
-    public static class CsvBuilder {
-        private String separator = ",";
-        private char quote = '"';
-        private final List<Column> columns = new ArrayList<>();
-        private boolean withHeader = true;
-        private int limit = 10;
+    public static class CsvColumnBasedBuilder<T, U extends CollectionColumn<T>> extends CsvBuilder {
+        private List<U> columns = new ArrayList<>();
 
-        public CsvBuilder separator(String separator) {
-            this.separator = separator;
+        public final CsvColumnBasedBuilder<T, U> columns(List<U> columns) {
+            this.columns = columns;
             return this;
         }
 
-        public CsvBuilder quote(char quote) {
-            this.quote = quote;
-            return this;
-        }
-
-        public final CsvBuilder columns(Column... columns) {
+        @SafeVarargs
+        public final CsvColumnBasedBuilder<T, U> columns(U... columns) {
+            this.columns = new ArrayList<>(columns.length);
             this.columns.addAll(Arrays.asList(columns));
             return this;
         }
 
-        public CsvBuilder columns(Collection<Column> columns) {
-            this.columns.addAll(columns);
-            return this;
-        }
-
-        public CsvBuilder limit(int limit) {
-            this.limit = limit;
-            return this;
-        }
-
-        public CsvBuilder header(boolean withHeader) {
-            this.withHeader = withHeader;
-            return this;
-        }
-
         public Csv build() {
-            return new Csv(columns, separator, quote, withHeader, limit);
+            return new Csv(null, getSeparator(), getQuote(), isWithHeader(), columns, getLimit());
         }
+    }
+
+    public static class CsvCollectionBasedBuilder<T> extends CsvBuilder {
+        protected FakeCollection<T> collection;
+        protected Supplier<String>[] headers;
+        protected Function<T, String>[] columnValues;
+
+        CsvCollectionBasedBuilder<T> collection(FakeCollection<T> collection) {
+            this.collection = collection;
+            return this;
+        }
+
+        @SafeVarargs
+        public final CsvCollectionBasedBuilder<T> headers(Supplier<String>... headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        @SafeVarargs
+        public final CsvCollectionBasedBuilder<T> columns(Function<T, String>... columns) {
+            this.columnValues = columns;
+            return this;
+        }
+
+        @SafeVarargs
+        public final CsvCollectionBasedBuilder<T> columns(Supplier<String>... columns) {
+            this.columnValues = Stream.of(columns).map(c -> (Function<T, String>) t -> c.get()).collect(Collectors.toList()).toArray(new Function[0]);
+            return this;
+        }
+
+        public Csv<T> build() {
+            List<CollectionColumn<T>> cols = columnValues == null ? Collections.emptyList() : new ArrayList<>(columnValues.length);
+            for (int i = 0; i < (columnValues == null ? 0 : columnValues.length); i++) {
+                cols.add(CollectionColumn.of(headers == null ? null : headers[i], columnValues[i]));
+            }
+            return new Csv<>(collection, getSeparator(), getQuote(), isWithHeader(), cols, collection == null ? getLimit() : -1);
+        }
+    }
+
+
+    public static abstract class CsvBuilder {
+        private String separator = ",";
+        private char quote = '"';
+        private int limit = 10;
+        private boolean withHeader = true;
+
+        public <T extends CsvBuilder> T header(boolean withHeader) {
+            this.withHeader = withHeader;
+            return (T) this;
+        }
+
+        public <T extends CsvBuilder> T separator(String separator) {
+            this.separator = separator;
+            return (T) this;
+        }
+
+        public <T extends CsvBuilder> T quote(char quote) {
+            this.quote = quote;
+            return (T) this;
+        }
+
+        public <T extends CsvBuilder> T limit(int limit) {
+            this.limit = limit;
+            return (T) this;
+        }
+
+        public String getSeparator() {
+            return separator;
+        }
+
+        public char getQuote() {
+            return quote;
+        }
+
+        public int getLimit() {
+            return limit;
+        }
+
+        public boolean isWithHeader() {
+            return withHeader;
+        }
+
+        public abstract Csv build();
     }
 }

--- a/src/main/java/net/datafaker/fileformats/Format.java
+++ b/src/main/java/net/datafaker/fileformats/Format.java
@@ -1,0 +1,19 @@
+package net.datafaker.fileformats;
+
+import net.datafaker.FakeCollection;
+
+import java.util.List;
+
+public class Format {
+    public static <T> Csv.CsvCollectionBasedBuilder<T> toCsv(FakeCollection<T> collection) {
+        return new Csv.CsvCollectionBasedBuilder<T>().collection(collection);
+    }
+
+    public static Csv.CsvColumnBasedBuilder<String, Csv.Column> toCsv(Csv.Column... columns) {
+        return new Csv.CsvColumnBasedBuilder<String, Csv.Column>().columns(columns);
+    }
+
+    public static Csv.CsvColumnBasedBuilder<String, Csv.Column> toCsv(List<Csv.Column> columns) {
+        return new Csv.CsvColumnBasedBuilder<String, Csv.Column>().columns(columns);
+    }
+}

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -1,5 +1,6 @@
 package net.datafaker;
 
+import net.datafaker.fileformats.Format;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -148,10 +149,10 @@ public class FakeCollectionTest extends AbstractFakerTest {
     public void myTest() {
         String separator = "$$$";
         int limit = 5;
-        String csv = new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
-            .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
-            .build()
-            .toCsv()
+        String csv = Format.toCsv(
+                new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
+                    .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
+                    .build())
             .headers(() -> "name", () -> "value", () -> "range", () -> "unit")
             .columns(Data::name, Data::value, Data::range, Data::unit)
             .separator(separator)
@@ -166,6 +167,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
                 numberOfSeparator++;
             }
         }
+        System.out.println(csv);
 
         assertEquals(limit + 1, numberOfLines); // limit + 1 line for header
         assertEquals((limit + 1) * (4 - 1), numberOfSeparator); // number of lines * (number of columns - 1)

--- a/src/test/java/net/datafaker/fileformats/CsvTest.java
+++ b/src/test/java/net/datafaker/fileformats/CsvTest.java
@@ -4,7 +4,7 @@ import net.datafaker.AbstractFakerTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,8 +14,7 @@ public class CsvTest extends AbstractFakerTest {
     public void csvTest() {
         String separator = "@@@";
         int limit = 20;
-        String csv = new Csv.CsvBuilder()
-            .columns(Csv.Column.of("first_name", () -> faker.name().firstName()),
+        String csv = Format.toCsv(Csv.Column.of("first_name", () -> faker.name().firstName()),
                 Csv.Column.of("last_name", () -> faker.name().lastName()),
                 Csv.Column.of("address", () -> faker.address().streetAddress()))
             .header(true)
@@ -39,11 +38,10 @@ public class CsvTest extends AbstractFakerTest {
     public void csvTestWithQuotes() {
         String separator = "$$$";
         int limit = 20;
-        Collection<Csv.Column> columns = new ArrayList<>();
+        List<Csv.Column> columns = new ArrayList<>();
         columns.add(Csv.Column.of("first_name", () -> faker.expression("#{Name.first_name}")));
         columns.add(Csv.Column.of("last_name", () -> faker.expression("#{Name.last_name}")));
-        String csv = new Csv.CsvBuilder()
-            .columns(columns)
+        String csv = Format.toCsv(columns)
             .header(true)
             .separator(separator)
             .quote('%')
@@ -64,8 +62,7 @@ public class CsvTest extends AbstractFakerTest {
 
     @Test
     public void testCsvWithComma() {
-        String csv = new Csv.CsvBuilder()
-            .columns(
+        String csv = Format.toCsv(
                 Csv.Column.of("values", () -> "1,2,3"),
                 Csv.Column.of("title", () -> "The \"fabulous\" artist"))
             .header(true)


### PR DESCRIPTION
The PR generalize `toCsv` for fake collections and simple column based.
Now for both it could be done with `Format.toCsv` e.g.

```java
        String csv = Format.toCsv(
                Csv.Column.of("values", () -> "1,2,3"),
                Csv.Column.of("title", () -> "The \"fabulous\" artist"))
            .header(true)
            .separator(",")
            .limit(1).build().get();
```

or

```java
        String separator = "$$$";
        int limit = 5;
        String csv = Format.toCsv(
                new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
                    .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
                    .build())
            .headers(() -> "name", () -> "value", () -> "range", () -> "unit")
            .columns(Data::name, Data::value, Data::range, Data::unit)
            .separator(separator)
            .build().get();
```