### PR TITLE
Allow nested json in builders

### DIFF
--- a/src/main/java/net/datafaker/fileformats/Json.java
+++ b/src/main/java/net/datafaker/fileformats/Json.java
@@ -28,7 +28,7 @@ public class Json {
         return generate(map);
     }
 
-    private String generate(Collection<Object> collection) {
+    private static String generate(Collection<Object> collection) {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         int i = 0;
@@ -43,7 +43,7 @@ public class Json {
         return sb.toString();
     }
 
-    private void value2String(Object value, StringBuilder sb) {
+    private static void value2String(Object value, StringBuilder sb) {
         if (value == null) {
             sb.append("null");
         } else if (value instanceof Integer
@@ -70,7 +70,7 @@ public class Json {
         }
     }
 
-    private String generate(Map<Supplier<String>, Supplier<Object>> map) {
+    private static String generate(Map<Supplier<String>, Supplier<Object>> map) {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         Set<String> keys = new HashSet<>();
@@ -178,6 +178,16 @@ public class Json {
             return this;
         }
 
+        public JsonFromCollectionBuilder<T> set(String key, Json value) {
+            map.put(t -> key, t -> value);
+            return this;
+        }
+
+        public JsonFromCollectionBuilder<T> set(String key, JsonForFakeCollection value) {
+            map.put(t -> key, t -> value);
+            return this;
+        }
+
         public JsonForFakeCollection<T> build() {
             return new JsonForFakeCollection<>(collection, map);
         }
@@ -228,7 +238,17 @@ public class Json {
                 }
                 sb.append("\": ");
                 Object value = entry.getValue().apply(record);
-                value2String(record, value, sb);
+                if (value instanceof JsonForFakeCollection) {
+                    sb.append(((JsonForFakeCollection<?>) value).generate());
+                } else if (value instanceof Collection) {
+                    sb.append(Json.generate((Collection) value));
+                } else if (value.getClass().isArray()) {
+                    sb.append(Json.generate(Arrays.asList((Object[]) value)));
+                } else if (value instanceof Json) {
+                    sb.append(((Json) value).generate());
+                } else {
+                    value2String(record, value, sb);
+                }
             }
             sb.append("}");
             return sb.toString();

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -195,4 +195,42 @@ public class FakeCollectionTest extends AbstractFakerTest {
 
         assertEquals(limit - 1, numberOfLines); // limit - 1 since for the last line there is no comma
     }
+
+    @Test
+    public void toNestedJson() {
+        final int limit = 2;
+        final String json =
+            Format.toJson(new FakeCollection.Builder<Name>().faker(faker)
+                    .suppliers(() -> faker.name())
+                    .maxLen(limit)
+                    .minLen(limit)
+                    .build())
+                .set("primaryAddress", Format.toJson()
+                    .set("country", () -> faker.address().country())
+                    .set("city", () -> faker.address().city())
+                    .set("zipcode", () -> faker.address().zipCode())
+                    .set("streetAddress", () -> faker.address().streetAddress())
+                    .build())
+                .set("secondaryAddresses", Format.toJson(new FakeCollection.Builder<Address>().faker(faker)
+                        .suppliers(() -> faker.address())
+                        .maxLen(1)
+                        .minLen(1)
+                        .build())
+                    .set("country", Address::country)
+                    .set("city", Address::city)
+                    .set("zipcode", Address::zipCode)
+                    .set("streetAddress", Address::streetAddress)
+                    .build())
+                .set("phones", name -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
+                .build()
+                .generate();
+
+        int numberOfLines = 0;
+        for (int i = 0; i < json.length(); i++) {
+            if (json.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            }
+        }
+        assertEquals(limit - 1, numberOfLines); // limit - 1 since for the last line there is no comma
+    }
 }


### PR DESCRIPTION
The PR adds possibility to builid complex json e.g.
```java
String json =
            Format.toJson(new FakeCollection.Builder<Name>().faker(faker)
                    .suppliers(() -> faker.name())
                    .maxLen(2)
                    .minLen(2)
                    .build())
                .set("address", Format.toJson(new FakeCollection.Builder<Address>().faker(faker)
                        .suppliers(() -> faker.address())
                        .maxLen(1)
                        .minLen(1)
                        .build())
                    .set("country", Address::country)
                    .set("city", Address::city)
                    .set("zipcode", Address::zipCode)
                    .set("streetAddress", Address::streetAddress)
                    .build())
                .set("phones", name -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
                .build()
                .generate();

        System.out.println(json);
```
gives
```json
[{"address": [{"country": "Haiti", "city": "South Lessieton", "zipcode": "71379", "streetAddress": "90936 Ciara Park"}], "phones": ["1-899-317-4300 x711", "098-661-2414 x24991", "127-945-3162 x652"]},
{"address": [{"country": "Poland", "city": "North Florinda", "zipcode": "37339", "streetAddress": "813 Caleb Causeway"}], "phones": ["073.403.8812 x12445", "1-653-715-5223 x89473", "1-249-065-1645 x9752"]}]

```

at the same time it is possible to have escaped json e.g. for address tag for the example above:
```java
String json =
            Format.toJson(new FakeCollection.Builder<Name>().faker(faker)
                    .suppliers(() -> faker.name())
                    .maxLen(2)
                    .minLen(2)
                    .build())
                .set("address", name -> Format.toJson(new FakeCollection.Builder<Address>().faker(faker)
                        .suppliers(() -> faker.address())
                        .maxLen(1)
                        .minLen(1)
                        .build())
                    .set("country", Address::country)
                    .set("city", Address::city)
                    .set("zipcode", Address::zipCode)
                    .set("streetAddress", Address::streetAddress)
                    .build().generate())
                .set("phones", name -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
                .build()
                .generate();

        System.out.println(json);
```
gives
```json
[{"address": "[{\"country\": \"Madagascar\", \"city\": \"MacGyvertown\", \"zipcode\": \"97390\", \"streetAddress\": \"831 Conn Lakes\"}]", "phones": ["(767) 552-5482 x141", "735-492-4731", "252-217-0313 x577"]},
{"address": "[{\"country\": \"Eritrea\", \"city\": \"North Lisette\", \"zipcode\": \"23811\", \"streetAddress\": \"731 Theodore Tunnel\"}]", "phones": ["(098) 635-6445", "(110) 048-1390 x000", "629.031.9988 x478"]}]

```