### PR TITLE
Add jdk18 to ci

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 8, 11, 17, 18 ]
         runs-on: [ ubuntu-latest, macos-latest, windows-latest ]
     name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
The PR adds the latest available java (jdk18)
So it now will contain 3 LTS + latest jdk