### PR TITLE
Add singleton to fake collections

### DIFF
--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -15,6 +15,13 @@ public class FakeCollection<T> {
     private final int minLength;
     private final int maxLength;
 
+    private FakeCollection(List<Supplier<T>> suppliers, int minLength, int maxLength, RandomService randomService) {
+        this.suppliers = suppliers;
+        this.minLength = minLength;
+        this.maxLength = maxLength;
+        this.randomService = randomService;
+    }
+
     public T singleton() {
         return suppliers.get(randomService.nextInt(suppliers.size())).get();
     }
@@ -26,13 +33,6 @@ public class FakeCollection<T> {
             result.add(singleton());
         }
         return result;
-    }
-
-    private FakeCollection(List<Supplier<T>> suppliers, int minLength, int maxLength, RandomService randomService) {
-        this.suppliers = suppliers;
-        this.minLength = minLength;
-        this.maxLength = maxLength;
-        this.randomService = randomService;
     }
 
     public static class Builder<T> {

--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -15,6 +15,10 @@ public class FakeCollection<T> {
     private final int minLength;
     private final int maxLength;
 
+    public T singleton() {
+        return suppliers.get(randomService.nextInt(suppliers.size())).get();
+    }
+
     public List<T> get() {
         List<T> result = new ArrayList<>();
         int size = randomService.nextInt(minLength, maxLength);

--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -23,7 +23,7 @@ public class FakeCollection<T> {
         List<T> result = new ArrayList<>();
         int size = randomService.nextInt(minLength, maxLength);
         while (result.size() < size) {
-            result.add(suppliers.get(randomService.nextInt(suppliers.size())).get());
+            result.add(singleton());
         }
         return result;
     }

--- a/src/main/java/net/datafaker/fileformats/Format.java
+++ b/src/main/java/net/datafaker/fileformats/Format.java
@@ -3,8 +3,6 @@ package net.datafaker.fileformats;
 import net.datafaker.FakeCollection;
 
 import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
 
 public class Format {
     public static <T> Csv.CsvCollectionBasedBuilder<T> toCsv(FakeCollection<T> collection) {

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -2,6 +2,7 @@ package net.datafaker;
 
 import net.datafaker.fileformats.Format;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FakeCollectionTest extends AbstractFakerTest {
@@ -232,5 +234,13 @@ public class FakeCollectionTest extends AbstractFakerTest {
             }
         }
         assertEquals(limit - 1, numberOfLines); // limit - 1 since for the last line there is no comma
+    }
+
+    @RepeatedTest(10)
+    public void singletonTest() {
+        int limit = 10;
+        assertNotNull(new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
+            .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
+            .build().singleton());
     }
 }


### PR DESCRIPTION
The PR adds `singleton` method for collections to generate just one object