### PR TITLE
Add null rate for fake collections

### DIFF
--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -12,18 +12,23 @@ import java.util.function.Supplier;
 public class FakeCollection<T> {
     private final RandomService randomService;
     private final List<Supplier<T>> suppliers;
+    private final double nullRate;
     private final int minLength;
     private final int maxLength;
 
-    private FakeCollection(List<Supplier<T>> suppliers, int minLength, int maxLength, RandomService randomService) {
+    private FakeCollection(List<Supplier<T>> suppliers, int minLength, int maxLength, RandomService randomService, double nullRate) {
         this.suppliers = suppliers;
         this.minLength = minLength;
         this.maxLength = maxLength;
         this.randomService = randomService;
+        this.nullRate = nullRate;
     }
 
     public T singleton() {
-        return suppliers.get(randomService.nextInt(suppliers.size())).get();
+        if (nullRate == 0d || randomService.nextDouble() >= nullRate) {
+            return suppliers.get(randomService.nextInt(suppliers.size())).get();
+        }
+        return null;
     }
 
     public List<T> get() {
@@ -39,6 +44,7 @@ public class FakeCollection<T> {
         private final List<Supplier<T>> suppliers = new ArrayList<>();
         private int minLength = -1; // negative means same as maxLength
         private int maxLength = 10;
+        private double nullRate = 0d;
         private Faker faker;
 
         public Builder<T> faker(Faker faker) {
@@ -53,6 +59,14 @@ public class FakeCollection<T> {
 
         public Builder<T> maxLen(int maxLength) {
             this.maxLength = maxLength;
+            return this;
+        }
+
+        public Builder<T> nullRate(double nullRate) {
+            if (nullRate < 0 || nullRate > 1) {
+                throw new IllegalArgumentException("Null rate should be between 0 and 1");
+            }
+            this.nullRate = nullRate;
             return this;
         }
 
@@ -76,7 +90,7 @@ public class FakeCollection<T> {
                 randomService = faker.random();
             }
 
-            return new FakeCollection<>(suppliers, minLength, maxLength, randomService);
+            return new FakeCollection<>(suppliers, minLength, maxLength, randomService, nullRate);
         }
     }
 

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -4,6 +4,8 @@ import net.datafaker.fileformats.Format;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.Random;
@@ -16,6 +18,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FakeCollectionTest extends AbstractFakerTest {
@@ -30,6 +33,31 @@ public class FakeCollectionTest extends AbstractFakerTest {
         for (String name : names) {
             assertThat(name, matchesRegularExpression("[a-zA-Z']+"));
         }
+    }
+
+    @Test
+    public void generateNullCollection() {
+        List<String> names = new FakeCollection.Builder<String>()
+            .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
+            .nullRate(1d)
+            .minLen(3)
+            .maxLen(5).build().get();
+        assertThat(names.size(), is(lessThanOrEqualTo(5)));
+        assertThat(names.size(), is(greaterThanOrEqualTo(3)));
+        for (String name : names) {
+            assertNull(name);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {Long.MIN_VALUE, Integer.MIN_VALUE, -1, -0.3, 2, 3, Integer.MAX_VALUE, Double.MAX_VALUE})
+    public void illegalNullRate(double nullRate) {
+        Assertions.assertThrows(IllegalArgumentException.class,
+            () -> new FakeCollection.Builder<String>()
+                .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
+                .nullRate(nullRate)
+                .minLen(3)
+                .maxLen(5).build().get(), "Not thrown for nullRate " + nullRate);
     }
 
     @Test


### PR DESCRIPTION
The PR adds support of null rate for fake collections e.g.
```java
List<String> names = new FakeCollection.Builder<String>()
            .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
            .nullRate(1d)
            .minLen(3)
            .maxLen(5).build().get();
```
will generate collection of nulls
or 
```java
List<String> names = new FakeCollection.Builder<String>()
            .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
            .nullRate(0.3)
            .minLen(3)
            .maxLen(5).build().get();
```
will generate collection with about 30% of nulls.
By default `nullRate` is 0, i.e. no nulls will be generated