### PR TITLE
Update VIN_REGEX used for Vehicle class

### DIFF
--- a/src/main/java/net/datafaker/Vehicle.java
+++ b/src/main/java/net/datafaker/Vehicle.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 public class Vehicle {
     private final Faker faker;
 
-    static final String VIN_REGEX = "([A-HJ-NPS-Z0-9]){3}[A-HJ-NPS-Z0-9]{5}[A-HJ-NPS-Z0-9]{1}[A-HJ-NPS-Z0-9]{1}[A-HJ-NPS-Z0-0]{1}[A-HJ-NPS-Z0-9]{1}\\d{5}";
+    static final String VIN_REGEX = "([A-HJ-NPR-Z0-9]){3}[A-HJ-NPR-Z0-9]{5}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-0]{1}[A-HJ-NPR-Z0-9]{1}\\d{5}";
 
     public Vehicle(Faker faker) {
         this.faker = faker;


### PR DESCRIPTION
The old regex used would skip the 'R' character when generating vins. It was a pretty small problem and required only simple changes, so I didn't raise an issue or write any tests.

Let me know if I need to do anything else !!!!