### PR TITLE
Use common-text's wordutils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <additionalparam>-Xdoclint:none</additionalparam>
 
         <commons-lang3.version>3.12.0</commons-lang3.version>
+        <commons-text.version>1.9</commons-text.version>
         <commons-validator.version>1.7</commons-validator.version>
         <generex.version>1.0.2</generex.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -128,6 +129,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -1,7 +1,7 @@
 package net.datafaker.script;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;


### PR DESCRIPTION
`org.apache.commons.lang3.text.WordUtils` is deprecated and javadoc recommends using of `org.apache.commons.text.WordUtils`