### PR TITLE
Add Options.subset

### DIFF
--- a/src/main/java/net/datafaker/Options.java
+++ b/src/main/java/net/datafaker/Options.java
@@ -1,6 +1,11 @@
 package net.datafaker;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @since 0.8.0
@@ -25,6 +30,40 @@ public class Options {
     }
 
     /**
+     * Returns a random unique subset of elements from an varargs.
+     *
+     * @param size    The size of subset to return.
+     * @param options The varargs to take a random element from.
+     * @param <E>     The type of the elements in the varargs.
+     * @return A randomly selected unique subset from the varargs.
+     * If size is negative then {@code IllegalArgumentException} will be thrown.
+     * If size is zero then an empty subset will be returned.
+     * If size is larger than a unique set from options then all options will be returned.
+     */
+    public final <E> Set<E> subset(int size, E... options) {
+        if (size < 0) {
+            throw new IllegalArgumentException("size should be not negative");
+        }
+        if (size == 0) {
+            return Collections.emptySet();
+        }
+        List<E> opts = Stream.of(options).distinct().collect(Collectors.toList());
+        if (size >= opts.size()) {
+            return new HashSet<>(opts);
+        }
+        int i = 0;
+        Set<E> set = new HashSet<>();
+        while (i < size) {
+            int randomIndex = faker.random().nextInt(opts.size());
+            set.add(opts.get(randomIndex));
+            opts.remove(randomIndex);
+            i++;
+        }
+
+        return set;
+    }
+
+    /**
      * Returns a random String element from an varargs.
      *
      * @param options The varargs to take a random element from.
@@ -32,6 +71,39 @@ public class Options {
      */
     public String option(String... options) {
         return options[faker.random().nextInt(options.length)];
+    }
+
+    /**
+     * Returns a random unique subset of elements from an varargs.
+     *
+     * @param size    The size of subset to return.
+     * @param options The varargs to take a random element from.
+     * @return A randomly selected unique subset from the varargs.
+     * If size is negative then {@code IllegalArgumentException} will be thrown.
+     * If size is zero then an empty subset will be returned.
+     * If size is larger than a unique set from options then all options will be returned.
+     */
+    public final Set<String> subset(int size, String... options) {
+        if (size < 0) {
+            throw new IllegalArgumentException("size should be not negative");
+        }
+        if (size == 0) {
+            return Collections.emptySet();
+        }
+        List<String> opts = Stream.of(options).distinct().collect(Collectors.toList());
+        if (size >= opts.size()) {
+            return new HashSet<>(opts);
+        }
+        int i = 0;
+        Set<String> set = new HashSet<>();
+        while (i < size) {
+            int randomIndex = faker.random().nextInt(opts.size());
+            set.add(opts.get(randomIndex));
+            opts.remove(randomIndex);
+            i++;
+        }
+
+        return set;
     }
 
     /**

--- a/src/test/java/net/datafaker/OptionsTest.java
+++ b/src/test/java/net/datafaker/OptionsTest.java
@@ -9,28 +9,29 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class OptionsTest extends AbstractFakerTest {
+class OptionsTest extends AbstractFakerTest {
 
     private String[] options;
 
     @BeforeEach
-    public void setupOptions() {
+    void setupOptions() {
         options = new String[]{"A", "B", "C"};
     }
 
     @Test
-    public void testOptionWithArray() {
+    void testOptionWithArray() {
         assertThat(faker.options().option(options)).isIn(options);
     }
 
     @Test
-    public void testOptionWithVarargsString() {
+    void testOptionWithVarargsString() {
         assertThat(faker.options().option("A", "B", "C")).isIn(options);
     }
 
     @Test
-    public void testOptionWithVarargs() {
+    void testOptionWithVarargs() {
         Integer[] integerOptions = new Integer[]{1, 3, 4, 5};
         assertThat(faker.options().option(1, 3, 4, 5)).isIn(integerOptions);
         Long[] longOptions = new Long[]{1L, 3L, 4L, 5L};
@@ -52,12 +53,70 @@ public class OptionsTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testOptionWithEnum() {
+    void testSubset() {
+        Integer[] integerOptions = new Integer[]{1, 3, 4, 5};
+        assertThat(faker.options().subset(1, integerOptions))
+            .doesNotContainAnyElementsOf(Arrays.asList(2, 6))
+            .containsAnyElementsOf(Arrays.asList(integerOptions));
+        Long[] longOptions = new Long[]{1L, 3L, 4L, 5L};
+        assertThat(faker.options().subset(1, longOptions))
+            .doesNotContainAnyElementsOf(Arrays.asList(2L, 6L))
+            .containsAnyElementsOf(Arrays.asList(longOptions));
+
+        assertThat(faker.options().subset(longOptions.length, longOptions))
+            .doesNotContainAnyElementsOf(Arrays.asList(2L, 6L))
+            .containsAnyElementsOf(Arrays.asList(longOptions))
+            .hasSize(longOptions.length);
+
+        assertThat(faker.options().subset(longOptions.length + 1, longOptions))
+            .doesNotContainAnyElementsOf(Arrays.asList(2L, 6L))
+            .containsAnyElementsOf(Arrays.asList(longOptions))
+            .hasSize(longOptions.length);
+
+        String[] strOptions = new String[]{"1", "2", "3"};
+        assertThat(faker.options().subset(strOptions.length + 1, strOptions))
+            .doesNotContainAnyElementsOf(Arrays.asList("q", "w"))
+            .containsAnyElementsOf(Arrays.asList(strOptions))
+            .hasSize(strOptions.length);
+
+        assertThat(faker.options().subset(1, strOptions))
+            .doesNotContainAnyElementsOf(Arrays.asList("q", "w"))
+            .containsAnyElementsOf(Arrays.asList(strOptions))
+            .hasSize(1);
+
+    }
+
+    @Test
+    void testSubsetWithDuplicate() {
+        Object[] array = new Object[]{1, 1, 2, 2};
+        assertThat(faker.options().subset(5, array))
+            .hasSize(2);
+        String[] strArray = new String[]{"a", "s", "s", "a"};
+        assertThat(faker.options().subset(Integer.MAX_VALUE, strArray))
+            .hasSize(2);
+    }
+
+    @Test
+    void testEmptySubset() {
+        Object[] array = new Object[]{1, 2, 3};
+        assertThat(faker.options().subset(0, array))
+            .isEmpty();
+        assertThatThrownBy(() -> faker.options().subset(-1, array))
+            .isInstanceOf(IllegalArgumentException.class);
+        String[] strArray = new String[]{"1", "2", "3"};
+        assertThat(faker.options().subset(0, strArray))
+            .isEmpty();
+        assertThatThrownBy(() -> faker.options().subset(-1, strArray))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testOptionWithEnum() {
         assertThat(faker.options().option(Day.class)).isIn(Day.values());
     }
 
     @Test
-    public void testNextArrayElement() {
+    void testNextArrayElement() {
         Integer[] array = new Integer[]{1, 2, 3, 5, 8, 13, 21};
 
         for (int i = 1; i < 10; i++) {
@@ -66,14 +125,14 @@ public class OptionsTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNextListElement() {
+    void testNextListElement() {
         List<Integer> list = Arrays.asList(1, 2, 3, 5, 8, 13, 21);
         for (int i = 1; i < 10; i++) {
             assertThat(faker.options().nextElement(list)).isIn(list);
         }
     }
 
-    public enum Day {
+    enum Day {
         MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
     }
 }


### PR DESCRIPTION
The PR adds `subset` to pick a  subset of unique elements from provided options limited by size e.g.
```java
faker.options().subset(2, new String[]{"abc", "def", "ghi", "abc"});
```
will return a set with 2 unique elements.
If a specified size is 0 it will return empty set.
If a specified size is larger than a number of unique elements in options then it will return a set with all unique options