### PR TITLE
Add faker#collection as a synonym for new FakeCollection.Builder()

### DIFF
--- a/docs/documentation/collections.md
+++ b/docs/documentation/collections.md
@@ -9,7 +9,7 @@ For example, the following code will generate a list of first and last names wit
 
     ``` java 
     List<String> names = 
-        new FakeCollection.Builder<String>()
+        faker.<String>collection()
             .suppliers(
                 () -> faker.name().firstName(), 
                 () -> faker.name().lastName())
@@ -24,7 +24,7 @@ A list can also contain different types:
 
     ``` java 
     List<Object> objects = 
-        new FakeCollection.Builder<>()
+        faker.collection()
             .suppliers(
                 () -> faker.name().firstName(), 
                 () -> faker.random().nextInt(100))
@@ -39,7 +39,7 @@ By default, it's value is 0, i.e. no null values will be generated.
 
     ``` java 
     List<Object> objects = 
-        new FakeCollection.Builder<>()
+        faker.collection()
             .suppliers(
                 () -> faker.name().firstName(), 
                 () -> faker.random().nextInt(100))
@@ -54,7 +54,7 @@ And to generate a collection with only about 30% values of null `nullRate(0.3)` 
 
     ``` java 
     List<Object> objects = 
-        new FakeCollection.Builder<>()
+        faker.collection()
             .suppliers(
                 () -> faker.name().firstName(), 
                 () -> faker.random().nextInt(100))

--- a/docs/documentation/file-formats.md
+++ b/docs/documentation/file-formats.md
@@ -54,7 +54,7 @@ It's also possible to generate JSON output:
     ``` java
     Faker faker = new Faker();
     String json = Format.toJson(
-                    new FakeCollection.Builder<Name>().faker(faker)
+                    faker.<Name>collection()
                         .suppliers(() -> faker.name())
                         .maxLen(2)
                         .minLen(2)
@@ -63,7 +63,7 @@ It's also possible to generate JSON output:
                     .set("lastName", Name::lastName)
                     .set("address",
                         Format.toJson(
-                            new FakeCollection.Builder<Address>().faker(faker)
+                            faker.<Address>collection()
                                 .suppliers(() -> faker.address())
                                 .maxLen(1)
                                 .minLen(1)
@@ -73,7 +73,7 @@ It's also possible to generate JSON output:
                         .set("zipcode", Address::zipCode)
                         .set("streetAddress", Address::streetAddress)
                         .build())
-                    .set("phones", name -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
+                    .set("phones", name -> faker.<String>collection().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
                     .build()
                     .generate();
         System.out.println(json);
@@ -93,7 +93,7 @@ Another example with json payload
     ``` java
         Faker faker = new Faker();
         String json = Format.toJson(
-                        new FakeCollection.Builder<Name>().faker(faker)
+                        faker.<Name>collection().faker(faker)
                             .suppliers(faker::name)
                             .maxLen(2)
                             .minLen(2)
@@ -102,7 +102,7 @@ Another example with json payload
                         .set("lastName", Name::lastName)
                         .set("payload", payload ->
                                     Format.toJson(
-                                            new FakeCollection.Builder<Address>().faker(faker)
+                                            faker.<Address>collection()
                                             .suppliers(faker::address)
                                             .maxLen(1)
                                             .minLen(1)
@@ -112,7 +112,7 @@ Another example with json payload
                                     .set("zipcode", Address::zipCode)
                                     .set("streetAddress", Address::streetAddress)
                                     .build().generate())
-                        .set("phones", name -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
+                        .set("phones", name -> faker.<String>collection().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
                         .build()
                         .generate();
         System.out.println(json);
@@ -136,8 +136,8 @@ The following is an example on how to use it:
     Map<Supplier<String>, Supplier<Object>> map = new LinkedHashMap<>();
     Map<Supplier<String>, Supplier<Object>> address = new LinkedHashMap<>();
     Map<Supplier<String>, Supplier<Object>> phones = new LinkedHashMap<>();
-    phones.put(() -> "worknumbers", () -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get());
-    phones.put(() -> "cellphones", () -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get());
+    phones.put(() -> "worknumbers", () -> faker.<String>collection().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get());
+    phones.put(() -> "cellphones", () -> faker.<String>collection().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get());
     address.put(() -> "city", () -> faker.address().city());
     address.put(() -> "country", () -> faker.address().country());
     address.put(() -> "streetAddress", () -> faker.address().streetAddress());
@@ -162,13 +162,13 @@ attributes using randomly generated data in the following way:
     public static void main(String[] args) {
         Faker faker = new Faker();
 
-        Collection<Xml.XmlNode> address = new FakeCollection.Builder<Xml.XmlNode>()
+        Collection<Xml.XmlNode> address = faker.<Xml.XmlNode>collection()
                 .suppliers(() -> new Xml.XmlNode("address",
                         map(entry("country", faker.address().country()),
                                 entry("city", faker.address().city()), entry("streetAddress", faker.address().streetAddress())), Collections.emptyList()))
                 .maxLen(3).build().get();
 
-        Collection<Xml.XmlNode> persons = new FakeCollection.Builder<Xml.XmlNode>()
+        Collection<Xml.XmlNode> persons = faker.<Xml.XmlNode>collection()
                 .suppliers(() -> new Xml.XmlNode("person",
                         map(entry("firstname", faker.name().firstName()),
                                 entry("lastname", faker.name().lastName())),
@@ -232,13 +232,13 @@ In case you only want to generate XML elements, without any attributes, that pos
 
     ``` java
     Faker faker = new Faker();
-    Collection<Xml.XmlNode> address = new FakeCollection.Builder<Xml.XmlNode>()
+    Collection<Xml.XmlNode> address = faker.<Xml.XmlNode>collection()
             .suppliers(() -> new Xml.XmlNode("address",
                     of(new Xml.XmlNode("country", faker.address().country()),
                             new Xml.XmlNode("city", faker.address().city()),
                             new Xml.XmlNode("streetAddress", faker.address().streetAddress()))))
             .maxLen(4).build().get();
-    Collection<Xml.XmlNode> persons = new FakeCollection.Builder<Xml.XmlNode>()
+    Collection<Xml.XmlNode> persons = faker.<Xml.XmlNode>collection()
             .suppliers(() -> new Xml.XmlNode("person",
                     of(new Xml.XmlNode("firstname", faker.name().firstName()),
                             new Xml.XmlNode("lastname", faker.name().lastName()),

--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -224,6 +224,14 @@ public class Faker {
         return result;
     }
 
+    /**
+     *
+     * @return builder to build {@code FakeCollection}
+     */
+    public <T> FakeCollection.Builder<T> collection() {
+        return new FakeCollection.Builder<T>().faker(this);
+    }
+
     public Address address() {
         return getProvider(Address.class, () -> new Address(this));
     }

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class FakeCollectionTest extends AbstractFakerTest {
     @Test
     public void generateCollection() {
-        List<String> names = new FakeCollection.Builder<String>()
+        List<String> names = faker.<String>collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
             .minLen(3)
             .maxLen(5).build().get();
@@ -28,7 +28,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
 
     @Test
     public void generateNullCollection() {
-        List<String> names = new FakeCollection.Builder<String>()
+        List<String> names = faker.<String>collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
             .nullRate(1d)
             .minLen(3)
@@ -44,7 +44,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     @ValueSource(doubles = {Long.MIN_VALUE, Integer.MIN_VALUE, -1, -0.3, 2, 3, Integer.MAX_VALUE, Double.MAX_VALUE})
     public void illegalNullRate(double nullRate) {
         assertThatThrownBy(
-            () -> new FakeCollection.Builder<String>()
+            () -> faker.collection()
                 .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
                 .nullRate(nullRate)
                 .minLen(3)
@@ -57,7 +57,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     public void generateCollectionWithRepeatableFaker() {
         Faker seededFaker = new Faker(new Random(10L));
 
-        List<String> names = new FakeCollection.Builder<String>()
+        List<String> names = faker.<String>collection()
             .faker(seededFaker)
             .suppliers(() -> seededFaker.name().firstName(), () -> seededFaker.name().lastName())
             .minLen(1)
@@ -70,7 +70,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
 
     @Test
     public void generateCollectionWithDifferentObjects() {
-        List<Object> objects = new FakeCollection.Builder<>()
+        List<Object> objects = faker.collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.random().nextInt(100))
             .maxLen(5).build().get();
         assertThat(objects).hasSize(5);
@@ -82,7 +82,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     @Test
     public void checkWrongArguments() {
         assertThatThrownBy(() ->
-            new FakeCollection.Builder<String>()
+            faker.collection()
                 .suppliers(() -> faker.name().firstName())
                 .minLen(10)
                 .maxLen(5).build().get())
@@ -172,7 +172,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     @Test
     public void differentNumberOfHeadersAndColumns() {
         assertThatThrownBy(() -> Format.toCsv(
-                new FakeCollection.Builder<Name>()
+                faker.<Name>collection()
                     .suppliers(() -> faker.name())
                     .minLen(3)
                     .maxLen(5)
@@ -187,7 +187,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
         String separator = "$$$";
         int limit = 5;
         String csv = Format.toCsv(
-                new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
+                faker.<Data>collection().minLen(limit).maxLen(limit)
                     .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
                     .build())
             .headers(() -> "name", () -> "value", () -> "range", () -> "unit")
@@ -213,7 +213,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     public void toJson() {
         int limit = 10;
         String json = Format.toJson(
-                new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
+                faker.<Data>collection().minLen(limit).maxLen(limit)
                     .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
                     .build())
             .set("name", Data::name)
@@ -237,7 +237,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     public void toNestedJson() {
         final int limit = 2;
         final String json =
-            Format.toJson(new FakeCollection.Builder<Name>().faker(faker)
+            Format.toJson(faker.collection()
                     .suppliers(() -> faker.name())
                     .maxLen(limit)
                     .minLen(limit)
@@ -248,7 +248,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
                     .set("zipcode", () -> faker.address().zipCode())
                     .set("streetAddress", () -> faker.address().streetAddress())
                     .build())
-                .set("secondaryAddresses", Format.toJson(new FakeCollection.Builder<Address>().faker(faker)
+                .set("secondaryAddresses", Format.toJson(faker.<Address>collection()
                         .suppliers(() -> faker.address())
                         .maxLen(1)
                         .minLen(1)
@@ -258,7 +258,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
                     .set("zipcode", Address::zipCode)
                     .set("streetAddress", Address::streetAddress)
                     .build())
-                .set("phones", name -> new FakeCollection.Builder<String>().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
+                .set("phones", name -> faker.collection().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
                 .build()
                 .generate();
 
@@ -274,7 +274,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     @RepeatedTest(10)
     public void singletonTest() {
         int limit = 10;
-        assertThat(new FakeCollection.Builder<Data>().minLen(limit).maxLen(limit)
+        assertThat(faker.<Data>collection().minLen(limit).maxLen(limit)
             .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
             .build().singleton()).isNotNull();
     }


### PR DESCRIPTION
The PR adds synonym for `new FakeCollection.Builder<>()` 

now it is possible to create collection like 
```java
faker.collection()
            .suppliers(
                () -> faker.name().firstName(), 
                () -> faker.random().nextInt(100))
            .maxLen(5)
            .build().get();
```
The old approach keeps working as well