### PR TITLE
Apply min of limits for csv: min of elements in collection and limit …

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ more examples about that at https://www.datafaker.net/documentation/collections/
 #### csv
 ```java
 String csv = Format.toCsv(
-                Csv.Column.of("first_name", () -> faker.name().firstName()),
-                Csv.Column.of("last_name", () -> faker.name().lastName()))
-            .header(true)
-            .separator(" ; ")
-            .limit(2).build().get(); 
+                 faker.<Name>collection()
+                     .suppliers(() -> faker.name())
+                     .build())
+                 .headers(() -> "firstName", () -> "lastname")
+                 .columns(Name::firstName, Name::lastName)
+                 .separator(" ; ")
+                 .limit(2).build().get();
 // "first_name" ; "last_name"
 // "Kimberely" ; "Considine"
 // "Mariela" ; "Krajcik"

--- a/src/main/java/net/datafaker/fileformats/Csv.java
+++ b/src/main/java/net/datafaker/fileformats/Csv.java
@@ -25,7 +25,7 @@ public class Csv<T> {
         this.quote = quote;
         this.withHeader = withHeader;
         this.columns = columns;
-        this.limit = limit;
+        this.limit = limit == -1 && collection == null ? 10 : limit;
     }
 
     public String get() {
@@ -38,7 +38,7 @@ public class Csv<T> {
         }
 
         List<T> res = collection == null ? null : collection.get();
-        for (int line = 0; line < (res == null ? limit : res.size()); line++) {
+        for (int line = 0; line < (res == null ? limit : limit != -1 ? Math.min(limit, res.size()) : res.size()); line++) {
             int rowNum = line;
             addLine(sb, integer -> columns.get(integer).getValue(res == null || res.isEmpty() ? null : res.get(rowNum)));
         }
@@ -157,7 +157,7 @@ public class Csv<T> {
             for (int i = 0; i < (columnValues == null ? 0 : columnValues.length); i++) {
                 cols.add(CollectionColumn.of(headers == null ? null : headers[i], columnValues[i]));
             }
-            return new Csv<>(collection, getSeparator(), getQuote(), isWithHeader(), cols, collection == null ? getLimit() : -1);
+            return new Csv<>(collection, getSeparator(), getQuote(), isWithHeader(), cols, getLimit());
         }
     }
 
@@ -165,7 +165,7 @@ public class Csv<T> {
     public static abstract class CsvBuilder {
         private String separator = ",";
         private char quote = '"';
-        private int limit = 10;
+        private int limit = -1;
         private boolean withHeader = true;
 
         public <T extends CsvBuilder> T header(boolean withHeader) {

--- a/src/test/java/net/datafaker/fileformats/CsvTest.java
+++ b/src/test/java/net/datafaker/fileformats/CsvTest.java
@@ -1,9 +1,10 @@
 package net.datafaker.fileformats;
 
 import net.datafaker.AbstractFakerTest;
-import net.datafaker.Faker;
 import net.datafaker.Name;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,18 +78,53 @@ public class CsvTest extends AbstractFakerTest {
         assertThat(csv).isEqualTo(expected);
     }
 
-    @Test
-    void test() {
-        Faker faker = new Faker();
-        String json = Format.toJson(
+    @ParameterizedTest
+    @ValueSource(ints = {0, 2, 3, 10, 20, 100})
+    public void testLimitForCsv(int limit) {
+        String csv = Format.toCsv(
                 faker.<Name>collection()
-                    .suppliers(faker::name)
-                    .maxLen(2)
+                    .suppliers(() -> faker.name())
+                    .maxLen(limit + 1)
                     .build())
-            .set("firstName", Name::firstName)
-            .set("lastName", Name::lastName)
-            .build()
-            .generate();
-        System.out.println(json);
+            .headers(() -> "firstName", () -> "lastname")
+            .columns(Name::firstName, Name::lastName)
+            .separator(" : ")
+            .header(false)
+            .limit(limit)
+            .build().get();
+
+        int numberOfLines = 0;
+        for (int i = 0; i < csv.length(); i++) {
+            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            }
+        }
+
+        assertThat(numberOfLines).isEqualTo(limit);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 2, 3, 10, 20, 100})
+    public void testLimitForCollection(int limit) {
+        String csv = Format.toCsv(
+                faker.<Name>collection()
+                    .suppliers(() -> faker.name())
+                    .maxLen(limit)
+                    .build())
+            .headers(() -> "firstName", () -> "lastname")
+            .columns(Name::firstName, Name::lastName)
+            .separator(" : ")
+            .header(false)
+            .limit(limit + 1)
+            .build().get();
+
+        int numberOfLines = 0;
+        for (int i = 0; i < csv.length(); i++) {
+            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            }
+        }
+
+        assertThat(numberOfLines).isEqualTo(limit);
     }
 }


### PR DESCRIPTION
There are cases where both minimums could be specified e.g.
```java
String csv = Format.toCsv(
                faker.<Name>collection()
                    .suppliers(() -> faker.name())
                    .maxLen(limit1)
                    .build())
            .headers(() -> "firstName", () -> "lastname")
            .columns(Name::firstName, Name::lastName)
            .separator(" : ")
            .header(false)
            .limit(limit2)
            .build().get();
```
In this scenario the PR limits the number of lines by `min(limit1, limit2)`