### PR TITLE
Misprint in README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ String csv = Format.toCsv(
                  faker.<Name>collection()
                      .suppliers(() -> faker.name())
                      .build())
-                 .headers(() -> "firstName", () -> "lastname")
+                 .headers(() -> "first_name", () -> "last_name")
                  .columns(Name::firstName, Name::lastName)
                  .separator(" ; ")
                  .limit(2).build().get();


### PR DESCRIPTION
The trivial change fixing misprint in example for csv