### PR TITLE
Make exception message configurable in FakeValuesService#resolve

### DIFF
--- a/src/main/java/net/datafaker/Address.java
+++ b/src/main/java/net/datafaker/Address.java
@@ -62,7 +62,7 @@ public class Address {
     }
 
     public String countyByZipCode(String postCode) {
-        return faker.fakeValuesService().resolve("address.county_by_postcode." + postCode, this, faker);
+        return faker.fakeValuesService().resolve("address.county_by_postcode." + postCode, this, faker, () -> "County are not configured for postcode " + postCode);
     }
 
     public String streetSuffix() {

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -378,13 +378,24 @@ public class FakeValuesService {
     }
 
     /**
-     * Resolves a key to a method on an object.
+     * Resolves a key to a method on an object or throws an exception.
      * <p>
      * #{hello} with result in a method call to current.hello();
      * <p>
      * #{Person.hello_someone} will result in a method call to person.helloSomeone();
      */
     public String resolve(String key, Object current, Faker root) {
+        return resolve(key, current, root, () -> key + " resulted in null expression");
+    }
+
+    /**
+     * Resolves a key to a method on an object or throws an exception with specified message.
+     * <p>
+     * #{hello} with result in a method call to current.hello();
+     * <p>
+     * #{Person.hello_someone} will result in a method call to person.helloSomeone();
+     */
+    public String resolve(String key, Object current, Faker root, Supplier<String> exceptionMessage) {
         String expression = root == null ? key2Expression.get(key) : null;
         if (expression == null) {
             expression = safeFetch(key, null);
@@ -394,7 +405,7 @@ public class FakeValuesService {
         }
 
         if (expression == null) {
-            throw new RuntimeException(key + " resulted in null expression");
+            throw new RuntimeException(exceptionMessage.get());
         }
 
         return resolveExpression(expression, current, root);

--- a/src/test/java/net/datafaker/AbstractFakerTest.java
+++ b/src/test/java/net/datafaker/AbstractFakerTest.java
@@ -39,6 +39,10 @@ public class AbstractFakerTest {
 
     @BeforeAll
     public static void setup() {
-        faker = new Faker();
+        faker = getFaker();
+    }
+
+    protected static Faker getFaker() {
+        return faker == null ? new Faker() : faker;
     }
 }

--- a/src/test/java/net/datafaker/AddressTest.java
+++ b/src/test/java/net/datafaker/AddressTest.java
@@ -3,16 +3,20 @@ package net.datafaker;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AddressTest extends AbstractFakerTest {
 
-    private static final char decimalSeparator = new DecimalFormatSymbols(faker.getLocale()).getDecimalSeparator();
+    private static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols(getFaker().getLocale()).getDecimalSeparator();
     public static final Condition<String> IS_A_NUMBER = new Condition<>(s -> {
         try {
             Double.valueOf(s);
@@ -36,7 +40,7 @@ public class AddressTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     public void testLatitude() {
-        String latStr = faker.address().latitude().replace(decimalSeparator, '.');
+        String latStr = faker.address().latitude().replace(DECIMAL_SEPARATOR, '.');
         assertThat(latStr).is(IS_A_NUMBER);
         Double lat = Double.valueOf(latStr);
         assertThat(lat).isGreaterThanOrEqualTo(-90.0);
@@ -45,7 +49,7 @@ public class AddressTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     public void testLongitude() {
-        String longStr = faker.address().longitude().replace(decimalSeparator, '.');
+        String longStr = faker.address().longitude().replace(DECIMAL_SEPARATOR, '.');
         assertThat(longStr).is(IS_A_NUMBER);
         Double lon = Double.valueOf(longStr);
         assertThat(lon).isGreaterThanOrEqualTo(-180.0);
@@ -138,6 +142,16 @@ public class AddressTest extends AbstractFakerTest {
     public void testCountyByZipCode() {
         final Faker localFaker = new Faker(new Locale("en-US"));
         assertThat(localFaker.address().countyByZipCode("47732")).isNotEmpty();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"1", "asd", "qwe", "wrong"})
+    void testCountyForWrongZipCode(String zipCode) {
+        final Faker localFaker = new Faker(new Locale("en-US"));
+        assertThatThrownBy(() -> localFaker.address().countyByZipCode(zipCode))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("County are not configured for postcode " + zipCode);
     }
 
     @Test

--- a/src/test/java/net/datafaker/CommerceTest.java
+++ b/src/test/java/net/datafaker/CommerceTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CommerceTest extends AbstractFakerTest {
 
-    private static final char decimalSeparator = new DecimalFormatSymbols(faker.getLocale()).getDecimalSeparator();
+    private static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols(getFaker().getLocale()).getDecimalSeparator();
 
     private static final String CAPITALIZED_WORD_REGEX = "[A-Z][a-z]+";
 
@@ -41,12 +41,12 @@ public class CommerceTest extends AbstractFakerTest {
 
     @Test
     public void testPrice() {
-        assertThat(faker.commerce().price()).matches("\\d{1,3}\\" + decimalSeparator + "\\d{2}");
+        assertThat(faker.commerce().price()).matches("\\d{1,3}\\" + DECIMAL_SEPARATOR + "\\d{2}");
     }
 
     @Test
     public void testPriceMinMax() {
-        assertThat(faker.commerce().price(100, 1000)).matches("\\d{3,4}\\" + decimalSeparator + "\\d{2}");
+        assertThat(faker.commerce().price(100, 1000)).matches("\\d{3,4}\\" + DECIMAL_SEPARATOR + "\\d{2}");
     }
 
     @Test

--- a/src/test/java/net/datafaker/service/FakeValuesTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesTest.java
@@ -1,5 +1,6 @@
 package net.datafaker.service;
 
+import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
The PR does 2 things
1. Allows to run single tests from _net.datafaker.AddressTest_ and _net.datafaker.CommerceTest_
2. Allows to configure exception message for _FakeValuesService#resolve_ to be able to be more precise wit the reason instead of just having something like 
```
resulted in null expression
at com.github.javafaker.service.FakeValuesService.resolve(FakeValuesService.java:308)
at com.github.javafaker.Address.countyByZipCode(Address.java:43)
```
e.g. like at https://github.com/DiUS/java-faker/issues/702
