### PR TITLE
Harden access modifiers in tests

### DIFF
--- a/src/test/java/net/datafaker/AbstractFakerTest.java
+++ b/src/test/java/net/datafaker/AbstractFakerTest.java
@@ -38,7 +38,7 @@ public class AbstractFakerTest {
     }
 
     @BeforeAll
-    public static void setup() {
+    static void setup() {
         faker = getFaker();
     }
 

--- a/src/test/java/net/datafaker/AddressTest.java
+++ b/src/test/java/net/datafaker/AddressTest.java
@@ -14,7 +14,7 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class AddressTest extends AbstractFakerTest {
+class AddressTest extends AbstractFakerTest {
 
     private static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols(getFaker().getLocale()).getDecimalSeparator();
     public static final Condition<String> IS_A_NUMBER = new Condition<>(s -> {
@@ -27,19 +27,19 @@ public class AddressTest extends AbstractFakerTest {
     }, "Is a number");
 
     @Test
-    public void testStreetAddressStartsWithNumber() {
+    void testStreetAddressStartsWithNumber() {
         final String streetAddressNumber = faker.address().streetAddress();
         assertThat(streetAddressNumber).matches("[0-9]+ .+");
     }
 
     @Test
-    public void testStreetAddressIsANumber() {
+    void testStreetAddressIsANumber() {
         final String streetAddressNumber = faker.address().streetAddressNumber();
         assertThat(streetAddressNumber).matches("[0-9]+");
     }
 
     @RepeatedTest(100)
-    public void testLatitude() {
+    void testLatitude() {
         String latStr = faker.address().latitude().replace(DECIMAL_SEPARATOR, '.');
         assertThat(latStr).is(IS_A_NUMBER);
         Double lat = Double.valueOf(latStr);
@@ -48,7 +48,7 @@ public class AddressTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testLongitude() {
+    void testLongitude() {
         String longStr = faker.address().longitude().replace(DECIMAL_SEPARATOR, '.');
         assertThat(longStr).is(IS_A_NUMBER);
         Double lon = Double.valueOf(longStr);
@@ -57,7 +57,7 @@ public class AddressTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testLocaleLatitude() {
+    void testLocaleLatitude() {
         Faker engFaker = new Faker(Locale.ENGLISH);
         String engLatStr = engFaker.address().latitude();
         assertThat(engLatStr).matches("-?\\d{1,3}\\.\\d+");
@@ -68,7 +68,7 @@ public class AddressTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testLocaleLongitude() {
+    void testLocaleLongitude() {
         Faker engFaker = new Faker(Locale.ENGLISH);
         String engLatStr = engFaker.address().longitude();
         assertThat(engLatStr).matches("-?\\d{1,3}\\.\\d+");
@@ -79,42 +79,42 @@ public class AddressTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testTimeZone() {
+    void testTimeZone() {
         assertThat(faker.address().timeZone()).matches("[A-Za-z_]+/[A-Za-z_]+[/A-Za-z_]*");
     }
 
     @Test
-    public void testState() {
+    void testState() {
         assertThat(faker.address().state()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void testCity() {
+    void testCity() {
         assertThat(faker.address().city()).matches("[A-Za-z'() ]+");
     }
 
     @Test
-    public void testCityName() {
+    void testCityName() {
         assertThat(faker.address().cityName()).matches("[A-Za-z'() ]+");
     }
 
     @Test
-    public void testCountry() {
+    void testCountry() {
         assertThat(faker.address().country()).matches("[A-Za-z\\- &.,'()\\d]+");
     }
 
     @Test
-    public void testCountryCode() {
+    void testCountryCode() {
         assertThat(faker.address().countryCode()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void testStreetAddressIncludeSecondary() {
+    void testStreetAddressIncludeSecondary() {
         assertThat(faker.address().streetAddress(true)).isNotEmpty();
     }
 
     @Test
-    public void testCityWithLocaleFranceAndSeed() {
+    void testCityWithLocaleFranceAndSeed() {
         long seed = 1L;
         Faker firstFaker = new Faker(Locale.FRANCE, new Random(seed));
         Faker secondFaker = new Faker(Locale.FRANCE, new Random(seed));
@@ -122,24 +122,24 @@ public class AddressTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testFullAddress() {
+    void testFullAddress() {
         assertThat(faker.address().fullAddress()).isNotEmpty();
     }
 
     @Test
-    public void testZipCodeByState() {
+    void testZipCodeByState() {
         final Faker localFaker = new Faker(new Locale("en-US"));
         assertThat(localFaker.address().zipCodeByState(localFaker.address().stateAbbr())).matches("[0-9]{5}");
     }
 
     @Test
-    public void testHungarianZipCodeByState() {
+    void testHungarianZipCodeByState() {
         final Faker localFaker = new Faker(new Locale("hu"));
         assertThat(localFaker.address().zipCodeByState(localFaker.address().stateAbbr())).matches("[0-9]{4}");
     }
 
     @Test
-    public void testCountyByZipCode() {
+    void testCountyByZipCode() {
         final Faker localFaker = new Faker(new Locale("en-US"));
         assertThat(localFaker.address().countyByZipCode("47732")).isNotEmpty();
     }
@@ -155,44 +155,44 @@ public class AddressTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testStreetPrefix() {
+    void testStreetPrefix() {
         assertThat(faker.address().streetPrefix()).isNotEmpty();
     }
 
     @Test
-    public void testStreetSuffix() {
+    void testStreetSuffix() {
         assertThat(faker.address().streetSuffix()).isNotEmpty();
     }
 
     @Test
-    public void testCityPrefix() {
+    void testCityPrefix() {
         assertThat(faker.address().cityPrefix()).isNotEmpty();
     }
 
     @Test
-    public void testCitySuffix() {
+    void testCitySuffix() {
         assertThat(faker.address().citySuffix()).isNotEmpty();
     }
 
     @RepeatedTest(10)
-    public void testMailbox() {
+    void testMailbox() {
         assertThat(faker.address().mailBox()).matches("PO Box [0-9]{2,4}");
     }
 
     @Test
-    public void testZipIsFiveChars() {
+    void testZipIsFiveChars() {
         final Faker localFaker = new Faker(new Locale("en-us"));
         assertThat(localFaker.address().zipCode().length()).isEqualTo(5);
     }
 
     @Test
-    public void testZipPlus4IsTenChars() {
+    void testZipPlus4IsTenChars() {
         final Faker localFaker = new Faker(new Locale("en-us"));
         assertThat(localFaker.address().zipCodePlus4().length()).isEqualTo(10);  // includes dash
     }
 
     @Test
-    public void testZipPlus4IsNineDigits() {
+    void testZipPlus4IsNineDigits() {
         final Faker localFaker = new Faker(new Locale("en-us"));
         final String[] zipCodeParts = localFaker.address().zipCodePlus4().split("-");
         assertThat(zipCodeParts[0]).matches("[0-9]{5}");

--- a/src/test/java/net/datafaker/AncientTest.java
+++ b/src/test/java/net/datafaker/AncientTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AncientTest extends AbstractFakerTest {
+class AncientTest extends AbstractFakerTest {
 
     @Test
-    public void god() {
+    void god() {
         assertThat(faker.ancient().god()).matches("\\w+");
     }
 
     @Test
-    public void primordial() {
+    void primordial() {
         assertThat(faker.ancient().primordial()).matches("\\w+");
     }
 
     @Test
-    public void titan() {
+    void titan() {
         assertThat(faker.ancient().titan()).matches("\\w+");
     }
 
     @Test
-    public void hero() {
+    void hero() {
         assertThat(faker.ancient().hero()).matches("(?U)\\w+");
     }
 

--- a/src/test/java/net/datafaker/AnimalTest.java
+++ b/src/test/java/net/datafaker/AnimalTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AnimalTest extends AbstractFakerTest {
+class AnimalTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.animal().name()).matches("[A-Za-z ]+");
     }
 

--- a/src/test/java/net/datafaker/AppTest.java
+++ b/src/test/java/net/datafaker/AppTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AppTest extends AbstractFakerTest {
+class AppTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.app().name()).matches("([\\w-]+ ?)+");
     }
 
     @Test
-    public void testVersion() {
+    void testVersion() {
         assertThat(faker.app().version()).matches("\\d\\.(\\d){1,2}(\\.\\d)?");
     }
 
     @Test
-    public void testAuthor() {
+    void testAuthor() {
         assertThat(faker.app().author()).matches("([\\w']+[-&,\\.]? ?){2,9}");
     }
 }

--- a/src/test/java/net/datafaker/ApplianceTest.java
+++ b/src/test/java/net/datafaker/ApplianceTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ApplianceTest extends AbstractFakerTest {
+class ApplianceTest extends AbstractFakerTest {
 
     @Test
-    public void brand() {
+    void brand() {
         assertThat(faker.appliance().brand()).matches("[A-Za-z .-]+");
     }
 
     @Test
-    public void equipment() {
+    void equipment() {
         assertThat(faker.appliance().equipment()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/AquaTeenHungerForceTest.java
+++ b/src/test/java/net/datafaker/AquaTeenHungerForceTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AquaTeenHungerForceTest extends AbstractFakerTest {
+class AquaTeenHungerForceTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.aquaTeenHungerForce().character()).matches("[A-Za-z .]+");
     }
 }

--- a/src/test/java/net/datafaker/ArtistTest.java
+++ b/src/test/java/net/datafaker/ArtistTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ArtistTest extends AbstractFakerTest {
+class ArtistTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.artist().name()).matches("(\\w+ ?){1,2}");
     }
 }

--- a/src/test/java/net/datafaker/AustraliaTest.java
+++ b/src/test/java/net/datafaker/AustraliaTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AustraliaTest extends AbstractFakerTest {
+class AustraliaTest extends AbstractFakerTest {
 
     @Test
-    public void locations() {
+    void locations() {
         assertThat(faker.australia().locations()).isNotEmpty();
     }
 
     @Test
-    public void animals() {
+    void animals() {
         assertThat(faker.australia().animals()).isNotEmpty();
     }
 
     @Test
-    public void states() {
+    void states() {
         assertThat(faker.australia().states()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/AvatarTest.java
+++ b/src/test/java/net/datafaker/AvatarTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AvatarTest extends AbstractFakerTest {
+class AvatarTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void testAvatar() {
+    void testAvatar() {
         String avatar = faker.avatar().image();
         assertThat(avatar).matches("^https://s3.amazonaws\\.com/uifaces/faces/twitter/[a-zA-Z0-9_]+/128\\.jpg$");
     }

--- a/src/test/java/net/datafaker/AviationTest.java
+++ b/src/test/java/net/datafaker/AviationTest.java
@@ -4,40 +4,40 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AviationTest extends AbstractFakerTest {
+class AviationTest extends AbstractFakerTest {
 
     @Test
-    public void airport() {
+    void airport() {
         assertThat(faker.aviation().airport()).matches("\\w{4}");
     }
 
     @Test
-    public void aircraft() {
+    void aircraft() {
         assertThat(faker.aviation().aircraft()).isNotEmpty();
     }
 
     @Test
-    public void metar() {
+    void metar() {
         assertThat(faker.aviation().METAR()).isNotEmpty();
     }
 
     @Test
-    public void flight_ICAO() {
+    void flight_ICAO() {
         assertThat(faker.aviation().flight("ICAO")).matches("[A-Z]{3}[0-9]+");
     }
 
     @Test
-    public void flight_IATA() {
+    void flight_IATA() {
         assertThat(faker.aviation().flight("IATA")).matches("[A-Z]{2}[0-9]+");
     }
 
     @Test
-    public void flight_default() {
+    void flight_default() {
         assertThat(faker.aviation().flight()).matches("[A-Z]{2}[0-9]+");
     }
 
     @Test
-    public void airline() {
+    void airline() {
         assertThat(faker.aviation().airline()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/Babylon5Test.java
+++ b/src/test/java/net/datafaker/Babylon5Test.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Babylon5Test extends AbstractFakerTest {
+class Babylon5Test extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.babylon5().character()).isNotEmpty();
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.babylon5().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BackToTheFutureTest.java
+++ b/src/test/java/net/datafaker/BackToTheFutureTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BackToTheFutureTest extends AbstractFakerTest {
+class BackToTheFutureTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.backToTheFuture().character()).isNotEmpty();
     }
 
     @Test
-    public void date() {
+    void date() {
         assertThat(faker.backToTheFuture().date()).matches("([A-za-z]{3,8}) ([1-9]|[1-2]\\d|3[0-1]), (18[8-9]\\d|19[0-9]\\d|200\\d|201[0-5])");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.backToTheFuture().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BarcodeTest.java
+++ b/src/test/java/net/datafaker/BarcodeTest.java
@@ -4,16 +4,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BarcodeTest extends AbstractFakerTest {
+class BarcodeTest extends AbstractFakerTest {
 
     @Test
-    public void type() {
+    void type() {
         assertThat(faker.barcode().type()).matches("(Code(128|39|93))|([EJ])AN(-\\d{1,2})*|Codabar|UCC|UPC(-([AE]))*|IS([BS])N|ITF|" +
                 "Ames\\sCode|NW-7|Monarch|Code\\s2\\sof\\s7|Rationalized|ANSI/AIM BC3-1995|USD-4|" +
                 "GS1 Databar|MSI Plessey");
     }
 
-    public static boolean isBarcodeValid(long barcode) {
+    private static boolean isBarcodeValid(long barcode) {
         char[] array = String.valueOf(barcode).toCharArray();
         int sum = 0;
         for (int i = 0; i < array.length; i++) {
@@ -27,55 +27,55 @@ public class BarcodeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testEan13() {
+    void testEan13() {
         assertThat(String.valueOf(faker.barcode().ean13())).matches("[0-9]{13}");
     }
 
     @Test
-    public void testGtin13() {
+    void testGtin13() {
         assertThat(String.valueOf(faker.barcode().gtin13())).matches("[0-9]{13}");
     }
 
     @Test
-    public void testEan8() {
+    void testEan8() {
         assertThat(String.valueOf(faker.barcode().ean8())).matches("[0-9]{8}");
     }
 
     @Test
-    public void testGtin8() {
+    void testGtin8() {
         assertThat(String.valueOf(faker.barcode().gtin8())).matches("[0-9]{8}");
     }
 
     @Test
-    public void testGtin14Length() {
+    void testGtin14Length() {
         assertThat(String.valueOf(faker.barcode().gtin14())).matches("[0-9]{14}");
     }
 
     @Test
-    public void testGtin12Length() {
+    void testGtin12Length() {
         assertThat(String.valueOf(faker.barcode().gtin12())).matches("[0-9]{12}");
     }
 
     @Test
-    public void testGtin12CheckSum() {
+    void testGtin12CheckSum() {
         long barcode = faker.barcode().gtin12();
         assertThat(BarcodeTest.isBarcodeValid(barcode)).isTrue();
     }
 
     @Test
-    public void testGtin14CheckSum() {
+    void testGtin14CheckSum() {
         long barcode = faker.barcode().gtin14();
         assertThat(BarcodeTest.isBarcodeValid(barcode)).isTrue();
     }
 
     @Test
-    public void testEan8CheckSum() {
+    void testEan8CheckSum() {
         long barcode = faker.barcode().ean8();
         assertThat(BarcodeTest.isBarcodeValid(barcode)).isTrue();
     }
 
     @Test
-    public void testEan13CheckSum() {
+    void testEan13CheckSum() {
         long barcode = faker.barcode().ean13();
         char[] array = String.valueOf(barcode).toCharArray();
         int sum = 0;

--- a/src/test/java/net/datafaker/BasketballTest.java
+++ b/src/test/java/net/datafaker/BasketballTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BasketballTest extends AbstractFakerTest {
+class BasketballTest extends AbstractFakerTest {
 
     @Test
-    public void testPositions() {
+    void testPositions() {
         assertThat(faker.basketball().positions()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testTeams() {
+    void testTeams() {
         assertThat(faker.basketball().teams()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testCoaches() {
+    void testCoaches() {
         assertThat(faker.basketball().coaches()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testPlayers() {
+    void testPlayers() {
         assertThat(faker.basketball().players()).matches("[\\p{L}'()., 0-9-’]+");
     }
 }

--- a/src/test/java/net/datafaker/Battlefield1Test.java
+++ b/src/test/java/net/datafaker/Battlefield1Test.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Battlefield1Test extends AbstractFakerTest {
+class Battlefield1Test extends AbstractFakerTest {
 
     @RepeatedTest(50)
-    public void classes() {
+    void classes() {
         assertThat(faker.battlefield1().classes()).matches("[A-Za-z ]+");
     }
 
     @RepeatedTest(200)
-    public void weapon() {
+    void weapon() {
         assertThat(faker.battlefield1().weapon()).matches("[A-Za-z0-9,\\- .()/]+");
     }
 
     @RepeatedTest(200)
-    public void vehicle() {
+    void vehicle() {
         assertThat(faker.battlefield1().vehicle()).matches("[A-Za-z0-9,\\- .()/]+");
     }
 
     @RepeatedTest(100)
-    public void map() {
+    void map() {
         assertThat(faker.battlefield1().map()).matches("[A-Za-z0-9,\\- .()']+");
     }
 
     @RepeatedTest(20)
-    public void faction() {
+    void faction() {
         assertThat(faker.battlefield1().faction()).matches("[A-Za-z,\\- ]+");
     }
 }

--- a/src/test/java/net/datafaker/BeerTest.java
+++ b/src/test/java/net/datafaker/BeerTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BeerTest extends AbstractFakerTest {
+class BeerTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.beer().name()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testStyle() {
+    void testStyle() {
         assertThat(faker.beer().style()).matches("[A-Za-z'() 0-9-]+");
     }
 
     @Test
-    public void testHop() {
+    void testHop() {
         assertThat(faker.beer().hop()).matches("[A-Za-z'’(). 0-9-]+");
     }
 
     @Test
-    public void testMalt() {
+    void testMalt() {
         assertThat(faker.beer().malt()).matches("[A-Za-z'() 0-9-]+");
     }
 
     @Test
-    public void testYeast() {
+    void testYeast() {
         assertThat(faker.beer().yeast()).matches("[\\p{L}'() 0-9-ö]+");
     }
 }

--- a/src/test/java/net/datafaker/BloodTypeTest.java
+++ b/src/test/java/net/datafaker/BloodTypeTest.java
@@ -5,20 +5,20 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class BloodTypeTest extends AbstractFakerTest {
+class BloodTypeTest extends AbstractFakerTest {
 
     @Test
-    public void abo_types() {
+    void abo_types() {
         assertThat(faker.bloodtype().abo_types()).matches("[A-Za-z]+");
     }
 
     @Test
-    public void rh_types() {
+    void rh_types() {
         assertThat(faker.bloodtype().rh_types()).matches("[A-Za-z+-]+");
     }
 
     @Test
-    public void p_types() {
+    void p_types() {
         assertThat(faker.bloodtype().p_types()).matches("[A-Za-z0-9]+");
     }
 

--- a/src/test/java/net/datafaker/BojackHorsemanTest.java
+++ b/src/test/java/net/datafaker/BojackHorsemanTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BojackHorsemanTest extends AbstractFakerTest {
+class BojackHorsemanTest extends AbstractFakerTest {
 
     @Test
-    public void testCharacters1() {
+    void testCharacters1() {
         assertThat(faker.bojackHorseman().characters()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testQuotes1() {
+    void testQuotes1() {
         assertThat(faker.bojackHorseman().quotes()).isNotEmpty();
     }
 
     @Test
-    public void testTongueTwisters1() {
+    void testTongueTwisters1() {
         assertThat(faker.bojackHorseman().tongueTwisters()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BookTest.java
+++ b/src/test/java/net/datafaker/BookTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class BookTest extends AbstractFakerTest {
+class BookTest extends AbstractFakerTest {
 
     @Test
-    public void testTitle() {
+    void testTitle() {
         assertThat(faker.book().title()).matches("([\\p{L}'\\-?]+[!,]? ?){2,9}");
     }
 
     @Test
-    public void testAuthor() {
+    void testAuthor() {
         assertThat(faker.book().author()).matches("([\\w']+\\.? ?){2,3}");
     }
 
     @Test
-    public void testPublisher() {
+    void testPublisher() {
         assertThat(faker.book().publisher()).matches("([\\p{L}'&\\-]+[,.]? ?){1,5}");
     }
 
     @Test
-    public void testGenre() {
+    void testGenre() {
         assertThat(faker.book().genre()).matches("([\\w/]+ ?){2,4}");
     }
 }

--- a/src/test/java/net/datafaker/BoolTest.java
+++ b/src/test/java/net/datafaker/BoolTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BoolTest extends AbstractFakerTest {
+class BoolTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
-    public void testBool() {
+    void testBool() {
         assertThat(faker.bool().bool()).isIn(true, false);
     }
 }

--- a/src/test/java/net/datafaker/BossaNovaTest.java
+++ b/src/test/java/net/datafaker/BossaNovaTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BossaNovaTest extends AbstractFakerTest {
+class BossaNovaTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void artists() {
+    void artists() {
         assertThat(faker.bossaNova().artist()).matches("[A-Za-z .-]+");
     }
 
     @RepeatedTest(10)
-    public void songs() {
+    void songs() {
         assertThat(faker.bossaNova().song()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BreakingBadTest.java
+++ b/src/test/java/net/datafaker/BreakingBadTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BreakingBadTest extends AbstractFakerTest {
+class BreakingBadTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void character() {
+    void character() {
         assertThat(faker.breakingBad().character()).matches("[\\p{L}A-Za-z0-9 .\\-;']+");
     }
 
     @RepeatedTest(10)
-    public void episodes() {
+    void episodes() {
         assertThat(faker.breakingBad().episode()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BrooklynNineNineTest.java
+++ b/src/test/java/net/datafaker/BrooklynNineNineTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BrooklynNineNineTest extends AbstractFakerTest {
+class BrooklynNineNineTest extends AbstractFakerTest {
 
     @Test
-    public void characters() {
+    void characters() {
         assertThat(faker.brooklynNineNine().characters()).isNotEmpty();
     }
 
     @Test
-    public void quotes() {
+    void quotes() {
         assertThat(faker.brooklynNineNine().quotes()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BuffyTest.java
+++ b/src/test/java/net/datafaker/BuffyTest.java
@@ -4,29 +4,29 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BuffyTest extends AbstractFakerTest {
+class BuffyTest extends AbstractFakerTest {
     @Test
-    public void testCharacters() {
+    void testCharacters() {
         assertThat(faker.buffy().characters()).isNotEmpty();
     }
 
     @Test
-    public void testQuotes() {
+    void testQuotes() {
         assertThat(faker.buffy().quotes()).isNotEmpty();
     }
 
     @Test
-    public void testCelebrities() {
+    void testCelebrities() {
         assertThat(faker.buffy().celebrities()).isNotEmpty();
     }
 
     @Test
-    public void testBigBads() {
+    void testBigBads() {
         assertThat(faker.buffy().bigBads()).isNotEmpty();
     }
 
     @Test
-    public void testEpisodes() {
+    void testEpisodes() {
         assertThat(faker.buffy().episodes()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/BusinessTest.java
+++ b/src/test/java/net/datafaker/BusinessTest.java
@@ -4,19 +4,19 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BusinessTest extends AbstractFakerTest {
+class BusinessTest extends AbstractFakerTest {
     @Test
-    public void creditCardNumber() {
+    void creditCardNumber() {
         assertThat(faker.business().creditCardNumber()).isNotEmpty();
     }
 
     @Test
-    public void creditCardType() {
+    void creditCardType() {
         assertThat(faker.business().creditCardType()).isNotEmpty();
     }
 
     @Test
-    public void creditCardExpiry() {
+    void creditCardExpiry() {
         assertThat(faker.business().creditCardExpiry()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/CNPJTest.java
+++ b/src/test/java/net/datafaker/CNPJTest.java
@@ -7,13 +7,13 @@ import static java.lang.Integer.parseInt;
 import static net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil.isCNPJValid;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CNPJTest extends AbstractFakerTest {
+class CNPJTest extends AbstractFakerTest {
 
     /**
      * A valid CNPJ is either a real number or a generated valid number.
      */
     @RepeatedTest(1000)
-    public void isValidCNPJ() {
+    void isValidCNPJ() {
         CNPJ cnpj = faker.cnpj();
         assertThat(isCNPJValid(cnpj.valid())).describedAs("Current value " + cnpj).isTrue();
     }
@@ -22,13 +22,13 @@ public class CNPJTest extends AbstractFakerTest {
      * A invalid CNPJ is that does not meet the requirements of the algorithm
      */
     @RepeatedTest(1000)
-    public void isInvalidCNPJ() {
+    void isInvalidCNPJ() {
         CNPJ cnpj = faker.cnpj();
         assertThat(isCNPJValid(cnpj.invalid())).describedAs("Current value " + cnpj).isFalse();
     }
 
     @Test
-    public void valid_multiBranchIsTrue_shouldGenerateCNPJWithBranchNumberGreaterThan0001() {
+    void valid_multiBranchIsTrue_shouldGenerateCNPJWithBranchNumberGreaterThan0001() {
         String cnpj = faker.cnpj().valid(true, true);
         String branch = cnpj.substring(11, 15);
 
@@ -44,7 +44,7 @@ public class CNPJTest extends AbstractFakerTest {
     }
 
     @Test
-    public void invalid_multiBranchIsTrue_shouldGenerateCNPJWithBranchNumberGreaterThan0001() {
+    void invalid_multiBranchIsTrue_shouldGenerateCNPJWithBranchNumberGreaterThan0001() {
         String cnpj = faker.cnpj().invalid(true, true);
         String branch = cnpj.substring(11, 15);
 
@@ -64,7 +64,7 @@ public class CNPJTest extends AbstractFakerTest {
      * Eg: 11.111.111/0001-11
      */
     @Test
-    public void formattedCNPJ() {
+    void formattedCNPJ() {
         final String cnpjExpression = "(^\\d{2}\\x2E\\d{3}\\x2E\\d{3}\\x2F\\d{4}\\x2D\\d{2}$)";
 
         assertThat(faker.cnpj().valid()).matches(cnpjExpression);

--- a/src/test/java/net/datafaker/CPFTest.java
+++ b/src/test/java/net/datafaker/CPFTest.java
@@ -6,13 +6,13 @@ import static net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil.isCPFValid
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class CPFTest extends AbstractFakerTest {
+class CPFTest extends AbstractFakerTest {
 
     /**
      * A valid CPF is either a real number or a generated valid number.
      */
     @RepeatedTest(100)
-    public void isValidCPF() {
+    void isValidCPF() {
         assertThat(isCPFValid(faker.cpf().valid())).isTrue();
     }
 
@@ -20,7 +20,7 @@ public class CPFTest extends AbstractFakerTest {
      * A invalid CPF is that dos not meet the requirements of the algorithm
      */
     @RepeatedTest(100)
-    public void isInvalidCPF() {
+    void isInvalidCPF() {
         assertThat(isCPFValid(faker.cpf().invalid())).isFalse();
     }
 
@@ -29,7 +29,7 @@ public class CPFTest extends AbstractFakerTest {
      * Eg: 111.111.111-11
      */
     @RepeatedTest(100)
-    public void formattedCPF() {
+    void formattedCPF() {
         final String cpfExpression = "(^\\d{3}\\x2E\\d{3}\\x2E\\d{3}\\x2D\\d{2}$)";
 
         assertThat(faker.cpf().valid()).matches(cpfExpression);

--- a/src/test/java/net/datafaker/CatTest.java
+++ b/src/test/java/net/datafaker/CatTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CatTest extends AbstractFakerTest {
+class CatTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.cat().name()).matches("[A-Za-z'() 0-9-]+");
     }
 
     @Test
-    public void breed() {
+    void breed() {
         assertThat(faker.cat().breed()).matches("[A-Za-z'() 0-9-,]+");
     }
 
     @Test
-    public void registry() {
+    void registry() {
         assertThat(faker.cat().registry()).matches("[A-Za-zé'() 0-9-]+");
     }
 }

--- a/src/test/java/net/datafaker/ChuckNorrisTest.java
+++ b/src/test/java/net/datafaker/ChuckNorrisTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChuckNorrisTest extends AbstractFakerTest {
+class ChuckNorrisTest extends AbstractFakerTest {
 
     @Test
-    public void testFact() {
+    void testFact() {
         assertThat(faker.chuckNorris().fact()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/CodeTest.java
+++ b/src/test/java/net/datafaker/CodeTest.java
@@ -10,12 +10,12 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CodeTest extends AbstractFakerTest {
+class CodeTest extends AbstractFakerTest {
 
     private static final ISBNValidator ISBN_VALIDATOR = ISBNValidator.getInstance(false);
 
     @RepeatedTest(100)
-    public void isbn10DefaultIsNoSeparator() {
+    void isbn10DefaultIsNoSeparator() {
         String isbn10 = faker.code().isbn10();
 
         assertIsValidISBN10(isbn10);
@@ -23,7 +23,7 @@ public class CodeTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void isbn13DefaultIsNoSeparator() {
+    void isbn13DefaultIsNoSeparator() {
         String isbn13 = faker.code().isbn13();
 
         assertIsValidISBN13(isbn13);
@@ -31,7 +31,7 @@ public class CodeTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testIsbn10() {
+    void testIsbn10() {
         final String isbn10NoSep = faker.code().isbn10(false);
         final String isbn10Sep = faker.code().isbn10(true);
 
@@ -42,7 +42,7 @@ public class CodeTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testIsbn13() {
+    void testIsbn13() {
         final String isbn13NoSep = faker.code().isbn13(false);
         final String isbn13Sep = faker.code().isbn13(true);
 
@@ -62,7 +62,7 @@ public class CodeTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testOverrides() {
+    void testOverrides() {
         Faker faker = new Faker(new Locale("test"));
 
         final String isbn10Sep = faker.code().isbn10(true);
@@ -74,12 +74,12 @@ public class CodeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void asin() {
+    void asin() {
         assertThat(faker.code().asin()).matches("B000([A-Z]|\\d){6}");
     }
 
     @Test
-    public void imei() {
+    void imei() {
         String imei = faker.code().imei();
 
         assertThat(imei).matches("\\A[\\d.:\\-\\s]+\\z");
@@ -87,43 +87,43 @@ public class CodeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void ean8() {
+    void ean8() {
         assertThat(faker.code().ean8()).matches("\\d{8}");
     }
 
     @Test
-    public void gtin8() {
+    void gtin8() {
         assertThat(faker.code().gtin8()).matches("\\d{8}");
     }
 
     @Test
-    public void ean13() {
+    void ean13() {
         String ean13 = faker.code().ean13();
         assertThat(ean13).matches("\\d{13}");
         assertThat(EAN13CheckDigit.EAN13_CHECK_DIGIT.isValid(ean13)).isTrue();
     }
 
     @Test
-    public void gtin13() {
+    void gtin13() {
         String gtin13 = faker.code().gtin13();
         assertThat(gtin13).matches("\\d{13}");
         assertThat(EAN13CheckDigit.EAN13_CHECK_DIGIT.isValid(gtin13)).isTrue();
     }
 
     @Test
-    public void isbnGs1() {
+    void isbnGs1() {
         String isbnGs1 = faker.code().isbnGs1();
         assertThat(isbnGs1).matches("978|979");
     }
 
     @Test
-    public void isbnGroup() {
+    void isbnGroup() {
         String isbnGroup = faker.code().isbnGroup();
         assertThat(isbnGroup).matches("[01]");
     }
 
     @RepeatedTest(100)
-    public void isbnRegistrant() {
+    void isbnRegistrant() {
         String isbnRegistrant = faker.code().isbnRegistrant();
         assertThat(isbnRegistrant).matches("[0-9]{1,7}-[0-9]{1,6}");
     }

--- a/src/test/java/net/datafaker/CoinTest.java
+++ b/src/test/java/net/datafaker/CoinTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CoinTest extends AbstractFakerTest {
+class CoinTest extends AbstractFakerTest {
 
     @Test
-    public void coinFlip() {
+    void coinFlip() {
         assertThat(faker.coin().flip()).matches("\\w+");
     }
 }

--- a/src/test/java/net/datafaker/ColorTest.java
+++ b/src/test/java/net/datafaker/ColorTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ColorTest extends AbstractFakerTest {
+class ColorTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.color().name()).matches("(\\w+ ?){1,2}");
     }
 
     @Test
-    public void testHex() {
+    void testHex() {
         assertThat(faker.color().hex()).matches("^#[0-9A-F]{6}$");
     }
 
     @Test
-    public void testHexNoHashSign() {
+    void testHexNoHashSign() {
         assertThat(faker.color().hex(false)).matches("^[0-9A-F]{6}$");
     }
 }

--- a/src/test/java/net/datafaker/CommerceTest.java
+++ b/src/test/java/net/datafaker/CommerceTest.java
@@ -6,7 +6,7 @@ import java.text.DecimalFormatSymbols;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CommerceTest extends AbstractFakerTest {
+class CommerceTest extends AbstractFakerTest {
 
     private static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols(getFaker().getLocale()).getDecimalSeparator();
 
@@ -15,47 +15,47 @@ public class CommerceTest extends AbstractFakerTest {
     private static final String PROMOTION_CODE_REGEX = CAPITALIZED_WORD_REGEX + "(-" + CAPITALIZED_WORD_REGEX + ")*";
 
     @Test
-    public void testDepartment() {
+    void testDepartment() {
         assertThat(faker.commerce().department()).matches("(\\w+(, | & )?){1,3}");
     }
 
     @Test
-    public void testProductName() {
+    void testProductName() {
         assertThat(faker.commerce().productName()).matches("(\\w+ ?){3,4}");
     }
 
     @Test
-    public void testMaterial() {
+    void testMaterial() {
         assertThat(faker.commerce().material()).matches("\\w+");
     }
 
     @Test
-    public void testBrand() {
+    void testBrand() {
         assertThat(faker.commerce().brand()).matches("\\w+");
     }
 
     @Test
-    public void testVendor() {
+    void testVendor() {
         assertThat(faker.commerce().vendor()).matches("[A-Za-z'() 0-9-,]+");
     }
 
     @Test
-    public void testPrice() {
+    void testPrice() {
         assertThat(faker.commerce().price()).matches("\\d{1,3}\\" + DECIMAL_SEPARATOR + "\\d{2}");
     }
 
     @Test
-    public void testPriceMinMax() {
+    void testPriceMinMax() {
         assertThat(faker.commerce().price(100, 1000)).matches("\\d{3,4}\\" + DECIMAL_SEPARATOR + "\\d{2}");
     }
 
     @Test
-    public void testPromotionCode() {
+    void testPromotionCode() {
         assertThat(faker.commerce().promotionCode()).matches(PROMOTION_CODE_REGEX + PROMOTION_CODE_REGEX + "\\d{6}");
     }
 
     @Test
-    public void testPromotionCodeDigits() {
+    void testPromotionCodeDigits() {
         assertThat(faker.commerce().promotionCode(3)).matches(PROMOTION_CODE_REGEX + PROMOTION_CODE_REGEX + "\\d{3}");
     }
 }

--- a/src/test/java/net/datafaker/CompanyTest.java
+++ b/src/test/java/net/datafaker/CompanyTest.java
@@ -5,50 +5,50 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CompanyTest extends AbstractFakerTest {
+class CompanyTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.company().name()).matches("[A-Za-z\\-&', ]+");
     }
 
     @Test
-    public void testSuffix() {
+    void testSuffix() {
         assertThat(faker.company().suffix()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void testIndustry() {
+    void testIndustry() {
         assertThat(faker.company().industry()).matches("(\\w+([ ,&/-]{1,3})?){1,4}+");
     }
 
     @Test
-    public void testBuzzword() {
+    void testBuzzword() {
         assertThat(faker.company().buzzword()).matches("(\\w+[ /-]?){1,3}");
     }
 
     @Test
-    public void testCatchPhrase() {
+    void testCatchPhrase() {
         assertThat(faker.company().catchPhrase()).matches("(\\w+[ /-]?){1,9}");
     }
 
     @Test
-    public void testBs() {
+    void testBs() {
         assertThat(faker.company().bs()).matches("(\\w+[ /-]?){1,9}");
     }
 
     @Test
-    public void testLogo() {
+    void testLogo() {
         assertThat(faker.company().logo()).matches("https://pigment.github.io/fake-logos/logos/medium/color/\\d+\\.png");
     }
 
     @Test
-    public void testProfession() {
+    void testProfession() {
         assertThat(faker.company().profession()).matches("[a-z ]+");
     }
 
     @RepeatedTest(100)
-    public void testUrl() {
+    void testUrl() {
         String regexp = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])";
         assertThat(faker.company().url()).matches(regexp);
     }

--- a/src/test/java/net/datafaker/CountryTest.java
+++ b/src/test/java/net/datafaker/CountryTest.java
@@ -5,42 +5,41 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CountryTest extends AbstractFakerTest {
+class CountryTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void testFlag() {
+    void testFlag() {
         String flag = faker.country().flag();
         assertThat(flag).matches("^https://flags.fmcdn\\.net/data/flags/w580/[a-zA-Z0-9_]+\\.png$");
     }
 
-
     @Test
-    public void testCode2() {
+    void testCode2() {
         assertThat(faker.country().countryCode2()).matches("([a-z]{2})");
     }
 
     @Test
-    public void testCode3() {
+    void testCode3() {
         assertThat(faker.country().countryCode3()).matches("([a-z]{3})");
     }
 
     @Test
-    public void testCapital() {
+    void testCapital() {
         assertThat(faker.country().capital()).matches("([\\p{L}0-9+,. '-])+");
     }
 
     @Test
-    public void testCurrency() {
+    void testCurrency() {
         assertThat(faker.country().currency()).matches("([A-Za-zÀ-ÿ'’()-]+ ?)+");
     }
 
     @Test
-    public void testCurrencyCode() {
+    void testCurrencyCode() {
         assertThat(faker.country().currencyCode()).matches("([\\w-’í]+ ?)+");
     }
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.country().name()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/CryptoCoinTest.java
+++ b/src/test/java/net/datafaker/CryptoCoinTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CryptoCoinTest extends AbstractFakerTest {
+class CryptoCoinTest extends AbstractFakerTest {
 
     @Test
-    public void coin() {
+    void coin() {
         assertThat(faker.cryptoCoin().coin()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/CurrencyTest.java
+++ b/src/test/java/net/datafaker/CurrencyTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CurrencyTest extends AbstractFakerTest {
+class CurrencyTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.currency().name()).matches("[\\w'.\\-() ]+");
     }
 
     @Test
-    public void testCode() {
+    void testCode() {
         final Currency currency = faker.currency();
         assertThat(currency.code()).matches("[A-Z]{3}");
     }

--- a/src/test/java/net/datafaker/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/CustomFakerTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * This is a demo of how to create a custom faker and register a custom faker in it.
  */
-public class CustomFakerTest {
+class CustomFakerTest {
     public static class MyCustomFaker extends Faker {
         public Insect insect() {
             return getProvider(Insect.class, () -> new Insect(this));
@@ -56,37 +56,37 @@ public class CustomFakerTest {
     }
 
     @Test
-    public void addNullExistingPath() {
+    void addNullExistingPath() {
         assertThatThrownBy(() -> new Faker().addPath(Locale.ENGLISH, null))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void addNonExistingPath() {
+    void addNonExistingPath() {
         assertThatThrownBy(() -> new Faker().addPath(Locale.ENGLISH, Paths.get("non-existing-file")))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @RepeatedTest(10)
-    public void insectTest() {
+    void insectTest() {
         MyCustomFaker myFaker = new MyCustomFaker();
         assertThat(myFaker.insect().nextInsectName()).matches("[A-Za-z ]+");
     }
 
     @RepeatedTest(10)
-    public void insectTestExpression() {
+    void insectTestExpression() {
         MyCustomFaker myFaker = new MyCustomFaker();
         assertThat(myFaker.expression("#{Insect.nextInsectName}")).matches("[A-Za-z ]+");
     }
 
     @RepeatedTest(10)
-    public void insectAntTestExpressionFromFile() {
+    void insectAntTestExpressionFromFile() {
         MyCustomFaker myFaker = new MyCustomFaker();
         assertThat(myFaker.insectFromFile().ant()).matches("[A-Za-z ]+");
     }
 
     @RepeatedTest(10)
-    public void insectBeeTestExpressionFromFile() {
+    void insectBeeTestExpressionFromFile() {
         MyCustomFaker myFaker = new MyCustomFaker();
         assertThat(myFaker.insectFromFile().bee()).endsWith("bee");
     }

--- a/src/test/java/net/datafaker/DateAndTimeTest.java
+++ b/src/test/java/net/datafaker/DateAndTimeTest.java
@@ -22,10 +22,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * @author pmiklos
  */
-public class DateAndTimeTest extends AbstractFakerTest {
+class DateAndTimeTest extends AbstractFakerTest {
 
     @Test
-    public void testFutureDate() {
+    void testFutureDate() {
         Date now = new Date();
         for (int i = 0; i < 1000; i++) {
             Date future = faker.date().future(1, TimeUnit.SECONDS, now);
@@ -35,7 +35,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testFutureDateWithMinimum() {
+    void testFutureDateWithMinimum() {
         final Date now = new Date();
         for (int i = 0; i < 1000; i++) {
             Date future = faker.date().future(5, 4, TimeUnit.SECONDS);
@@ -46,7 +46,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPastDateWithMinimum() {
+    void testPastDateWithMinimum() {
         final Date now = new Date();
         for (int i = 0; i < 1000; i++) {
             Date past = faker.date().past(5, 4, TimeUnit.SECONDS);
@@ -57,7 +57,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPastDateWithReferenceDate() {
+    void testPastDateWithReferenceDate() {
         Date now = new Date();
 
         for (int i = 0; i < 1000; i++) {
@@ -68,14 +68,14 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPastDate() {
+    void testPastDate() {
         Date now = new Date();
         Date past = faker.date().past(100, TimeUnit.SECONDS);
         assertThat(past.getTime()).isLessThan(now.getTime());
     }
 
     @Test
-    public void testBetween() {
+    void testBetween() {
         Date now = new Date();
         Date then = new Date(now.getTime() + 1000);
 
@@ -87,7 +87,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testBetweenThenLargerThanNow() {
+    void testBetweenThenLargerThanNow() {
         Date now = new Date();
         Date then = new Date(now.getTime() + 1000);
         assertThatThrownBy(() -> faker.date().between(then, now))
@@ -96,7 +96,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testBirthday() {
+    void testBirthday() {
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         int currentMonth = Calendar.getInstance().get(Calendar.MONTH);
         int currentDay = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
@@ -111,7 +111,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testBirthdayWithAges() {
+    void testBirthdayWithAges() {
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         int currentMonth = Calendar.getInstance().get(Calendar.MONTH);
         int currentDay = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
@@ -130,13 +130,13 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void birthdayWithMask() {
+    void birthdayWithMask() {
         String pattern = "YYYY MM.dd";
         DateTimeFormatter.ofPattern(pattern).parse(faker.date().birthday(1, 50, pattern));
     }
 
     @Test
-    public void futureWithMask() {
+    void futureWithMask() {
         String pattern = "YYYY MM.dd mm:hh:ss";
         DateTimeFormatter.ofPattern(pattern).parse(faker.date().future(1, TimeUnit.HOURS, pattern));
         DateTimeFormatter.ofPattern(pattern).parse(faker.date().future(20, 1, TimeUnit.HOURS, pattern));
@@ -144,7 +144,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
     }
 
     @Test
-    public void pastWithMask() {
+    void pastWithMask() {
         String pattern = "YYYY MM.dd mm:hh:ss";
         DateTimeFormatter.ofPattern(pattern).parse(faker.date().past(1, TimeUnit.DAYS, pattern));
         DateTimeFormatter.ofPattern(pattern).parse(faker.date().past(20, 1, TimeUnit.DAYS, pattern));
@@ -153,14 +153,14 @@ public class DateAndTimeTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"null", "", "month", "year", "week"})
-    public void invalidDuration(String invalid) {
+    void invalidDuration(String invalid) {
         assertThatThrownBy(() -> faker.date().duration(faker.random().nextLong(), invalid))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest
     @MethodSource("generateDurationsWithMinMax")
-    public void durationTest(long minValue, long maxValue, ChronoUnit unit) {
+    void durationTest(long minValue, long maxValue, ChronoUnit unit) {
         Duration generated = faker.date().duration(minValue, maxValue, unit);
         Duration min = Duration.of(minValue, unit);
         Duration max = Duration.of(maxValue, unit);
@@ -173,7 +173,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("generateDurationsWithMaxOnly")
-    public void durationTest(long maxValue, ChronoUnit unit) {
+    void durationTest(long maxValue, ChronoUnit unit) {
         Duration generated = faker.date().duration(maxValue, unit);
         Duration max = Duration.of(maxValue, unit);
         assertThat(max.compareTo(generated) > 0 || maxValue == 0)
@@ -183,7 +183,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("generateDurationsFromStringWithMinMax")
-    public void durationTest(long minValue, long maxValue, String unit) {
+    void durationTest(long minValue, long maxValue, String unit) {
         Duration generated = faker.date().duration(minValue, maxValue, unit);
         Duration min = Duration.of(minValue, DateAndTime.str2durationUnit(unit));
         Duration max = Duration.of(maxValue, DateAndTime.str2durationUnit(unit));
@@ -195,7 +195,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("generateDurationsFromStringWithMaxOnly")
-    public void durationTest(long maxValue, String unit) {
+    void durationTest(long maxValue, String unit) {
         Duration generated = faker.date().duration(maxValue, unit);
         Duration max = Duration.of(maxValue, DateAndTime.str2durationUnit(unit));
         assertThat(max.compareTo(generated) > 0 || maxValue == 0).as("Duration must be lower than max value").isTrue();
@@ -203,7 +203,7 @@ public class DateAndTimeTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("generatePeriod")
-    public void maxLessThanMinPeriod(Period min, Period max) {
+    void maxLessThanMinPeriod(Period min, Period max) {
         assertThatThrownBy(() -> faker.date().period(min, max))
             .isInstanceOf(IllegalArgumentException.class);
     }

--- a/src/test/java/net/datafaker/DemographicTest.java
+++ b/src/test/java/net/datafaker/DemographicTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DemographicTest extends AbstractFakerTest {
+class DemographicTest extends AbstractFakerTest {
 
     @Test
-    public void race() {
+    void race() {
         assertThat(faker.demographic().race()).matches("(\\w+ ?)+");
     }
 
     @Test
-    public void educationalAttainment() {
+    void educationalAttainment() {
         assertThat(faker.demographic().educationalAttainment()).matches("(?U)([\\w'-]+ ?)+");
     }
 
     @Test
-    public void demonym() {
+    void demonym() {
         assertThat(faker.demographic().demonym()).matches("(?U)([\\w'-]+ ?)+");
     }
 
     @Test
-    public void maritalStatus() {
+    void maritalStatus() {
         assertThat(faker.demographic().maritalStatus()).matches("(\\w+ ?)+");
     }
 
     @Test
-    public void sex() {
+    void sex() {
         assertThat(faker.demographic().sex()).matches("\\w+");
     }
 }

--- a/src/test/java/net/datafaker/DessertTest.java
+++ b/src/test/java/net/datafaker/DessertTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DessertTest extends AbstractFakerTest {
+class DessertTest extends AbstractFakerTest {
 
     @Test
-    public void variety() {
+    void variety() {
         assertThat(faker.dessert().variety()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void topping() {
+    void topping() {
         assertThat(faker.dessert().topping()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void flavor() {
+    void flavor() {
         assertThat(faker.dessert().flavor()).matches("[A-Za-z ']+");
     }
 }

--- a/src/test/java/net/datafaker/DeviceTest.java
+++ b/src/test/java/net/datafaker/DeviceTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DeviceTest extends AbstractFakerTest {
+class DeviceTest extends AbstractFakerTest {
 
     @Test
-    public void modelName() {
+    void modelName() {
         assertThat(faker.device().modelName()).isNotEmpty();
     }
 
     @Test
-    public void platform() {
+    void platform() {
         assertThat(faker.device().platform()).isNotEmpty();
     }
 
     @Test
-    public void manufacturer() {
+    void manufacturer() {
         assertThat(faker.device().manufacturer()).isNotEmpty();
     }
 
     @Test
-    public void serial() {
+    void serial() {
         assertThat(faker.device().serial()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/DiseaseTest.java
+++ b/src/test/java/net/datafaker/DiseaseTest.java
@@ -5,45 +5,45 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DiseaseTest extends AbstractFakerTest {
+class DiseaseTest extends AbstractFakerTest {
     @Test
-    public void testInternalDisease() {
+    void testInternalDisease() {
         assertThat(faker.disease().internalDisease()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testNeurology() {
+    void testNeurology() {
         assertThat(faker.disease().neurology()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testSurgery() {
+    void testSurgery() {
         assertThat(faker.disease().surgery()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testPaediatrics() {
+    void testPaediatrics() {
         assertThat(faker.disease().paediatrics()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testGynecologyAndObstetrics() {
+    void testGynecologyAndObstetrics() {
         assertThat(faker.disease().gynecologyAndObstetrics()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testOphthalmologyAndOtorhinolaryngology() {
+    void testOphthalmologyAndOtorhinolaryngology() {
         assertThat(faker.disease().ophthalmologyAndOtorhinolaryngology()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    public void testDermatolory() {
+    void testDermatolory() {
         assertThat(faker.disease().dermatolory()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
 
     @Test
-    public void testInternalDiseaseWith10000Times() {
+    void testInternalDiseaseWith10000Times() {
         boolean isExist = false;
         for (int i = 0; i < 10000; i++) {
             String generateString = faker.disease().internalDisease();
@@ -55,32 +55,32 @@ public class DiseaseTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(1000)
-    public void testNeurologyWith1000Times() {
+    void testNeurologyWith1000Times() {
         assertThat(faker.disease().neurology()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    public void testSurgeryWith1000Times() {
+    void testSurgeryWith1000Times() {
         assertThat(faker.disease().surgery()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    public void testPaediatricsWith1000Times() {
+    void testPaediatricsWith1000Times() {
         assertThat(faker.disease().paediatrics()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    public void testGynecologyAndObstetricsWith1000Times() {
+    void testGynecologyAndObstetricsWith1000Times() {
         assertThat(faker.disease().gynecologyAndObstetrics()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    public void testOphthalmologyAndOtorhinolaryngologyWith1000Times() {
+    void testOphthalmologyAndOtorhinolaryngologyWith1000Times() {
         assertThat(faker.disease().ophthalmologyAndOtorhinolaryngology()).isNotEmpty();
     }
 
     @RepeatedTest(10000)
-    public void testDermatoloryWith10000Times() {
+    void testDermatoloryWith10000Times() {
         assertThat(faker.disease().dermatolory()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/DogTest.java
+++ b/src/test/java/net/datafaker/DogTest.java
@@ -4,45 +4,45 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DogTest extends AbstractFakerTest {
+class DogTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.dog().name()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void breed() {
+    void breed() {
         assertThat(faker.dog().breed()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void sound() {
+    void sound() {
         assertThat(faker.dog().sound()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void memePhrase() {
+    void memePhrase() {
         assertThat(faker.dog().memePhrase()).matches("[A-Za-z0-9'/ ]+");
     }
 
     @Test
-    public void age() {
+    void age() {
         assertThat(faker.dog().age()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void gender() {
+    void gender() {
         assertThat(faker.dog().gender()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void coatLength() {
+    void coatLength() {
         assertThat(faker.dog().coatLength()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void size() {
+    void size() {
         assertThat(faker.dog().size()).matches("[A-Za-z ]+");
     }
 }

--- a/src/test/java/net/datafaker/DomainTest.java
+++ b/src/test/java/net/datafaker/DomainTest.java
@@ -3,16 +3,16 @@ package net.datafaker;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-public class DomainTest extends AbstractFakerTest {
+class DomainTest extends AbstractFakerTest {
 
     @Test
-    public void testFirstLevelDomainNotNull() {
+    void testFirstLevelDomainNotNull() {
         String ret = faker.domain().firstLevelDomain("example");
         assert (ret != null);
     }
 
     @Test
-    public void testFirstLevelDomain() {
+    void testFirstLevelDomain() {
         String[] components = faker.domain().firstLevelDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);
@@ -20,13 +20,13 @@ public class DomainTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testSecondLevelDomainNotNull() {
+    void testSecondLevelDomainNotNull() {
         String ret = faker.domain().secondLevelDomain("example");
         assert (ret != null);
     }
 
     @Test
-    public void testSecondLevelDomain() {
+    void testSecondLevelDomain() {
         String[] components = faker.domain().secondLevelDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);
@@ -35,13 +35,13 @@ public class DomainTest extends AbstractFakerTest {
 
 
     @Test
-    public void testFullDomainNotNull() {
+    void testFullDomainNotNull() {
         String ret = faker.domain().fullDomain("example");
         assert (ret != null);
     }
 
     @Test
-    public void testFullDomain() {
+    void testFullDomain() {
         String[] components = faker.domain().fullDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);
@@ -49,13 +49,13 @@ public class DomainTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void testValidDomainNotNull() {
+    void testValidDomainNotNull() {
         String ret = faker.domain().validDomain("example");
         assert (ret != null);
     }
 
     @Test
-    public void testValidDomain() {
+    void testValidDomain() {
         String[] components = faker.domain().validDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);

--- a/src/test/java/net/datafaker/DragonBallTest.java
+++ b/src/test/java/net/datafaker/DragonBallTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DragonBallTest extends AbstractFakerTest {
+class DragonBallTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.dragonBall().character()).matches("^(\\w+\\.?\\s?-?)+$");
     }
 }

--- a/src/test/java/net/datafaker/DuneTest.java
+++ b/src/test/java/net/datafaker/DuneTest.java
@@ -5,41 +5,41 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DuneTest extends AbstractFakerTest {
+class DuneTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.dune().character()).matches("[A-Za-z '\\-\"]+");
     }
 
     @Test
-    public void title() {
+    void title() {
         assertThat(faker.dune().title()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void planet() {
+    void planet() {
         assertThat(faker.dune().planet()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.dune().quote()).matches("\\P{Cc}+");
     }
 
     @RepeatedTest(100)
-    public void randomQuote() {
+    void randomQuote() {
         assertThat(
             faker.dune().quote(faker.options().option(Dune.Quote.class))).matches("\\P{Cc}+");
     }
 
     @Test
-    public void saying() {
+    void saying() {
         assertThat(faker.dune().saying()).matches("\\P{Cc}+");
     }
 
     @RepeatedTest(100)
-    public void randomSaying() {
+    void randomSaying() {
         assertThat(
             faker.dune().saying(faker.options().option(Dune.Saying.class))).matches("\\P{Cc}+");
     }

--- a/src/test/java/net/datafaker/DurationTest.java
+++ b/src/test/java/net/datafaker/DurationTest.java
@@ -6,11 +6,11 @@ import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DurationTest extends AbstractFakerTest {
+class DurationTest extends AbstractFakerTest {
     final int DURATION_IS_EQUAL = 0;
 
     @Test
-    public void testDurationSeconds() {
+    void testDurationSeconds() {
         final long maxSeconds = 55;
         Duration randomDuration = faker.duration().atMostSeconds(maxSeconds);
         Duration lowerBound = Duration.ofSeconds(0);
@@ -21,7 +21,7 @@ public class DurationTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testDurationMinutes() {
+    void testDurationMinutes() {
         final long maxMins = 45;
         Duration randomDuration = faker.duration().atMostMinutes(maxMins);
         Duration lowerBound = Duration.ofMinutes(0);
@@ -32,7 +32,7 @@ public class DurationTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testDurationHours() {
+    void testDurationHours() {
         final long maxHours = 35;
         Duration randomDuration = faker.duration().atMostHours(maxHours);
         Duration lowerBound = Duration.ofHours(0);
@@ -43,7 +43,7 @@ public class DurationTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testDurationDays() {
+    void testDurationDays() {
         final long maxDays = 40;
         Duration randomDuration = faker.duration().atMostDays(maxDays);
         Duration lowerBound = Duration.ofDays(0);

--- a/src/test/java/net/datafaker/EducatorTest.java
+++ b/src/test/java/net/datafaker/EducatorTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EducatorTest extends AbstractFakerTest {
+class EducatorTest extends AbstractFakerTest {
 
     @Test
-    public void testUniversity() {
+    void testUniversity() {
         assertThat(faker.educator().university()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void testCourse() {
+    void testCourse() {
         assertThat(faker.educator().course()).matches("(\\(?\\w+\\)? ?){3,6}");
     }
 
     @Test
-    public void testSecondarySchool() {
+    void testSecondarySchool() {
         assertThat(faker.educator().secondarySchool()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void testCampus() {
+    void testCampus() {
         assertThat(faker.educator().campus()).matches("(\\w+ ?){1,2}");
     }
 }

--- a/src/test/java/net/datafaker/EldenRingTest.java
+++ b/src/test/java/net/datafaker/EldenRingTest.java
@@ -4,29 +4,29 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EldenRingTest extends AbstractFakerTest{
+class EldenRingTest extends AbstractFakerTest{
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.eldenRing().location()).matches("[A-Za-z0-9 .]+");
     }
 
     @Test
-    public void weapon() {
+    void weapon() {
         assertThat(faker.eldenRing().weapon()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void skill() {
+    void skill() {
         assertThat(faker.eldenRing().skill()).matches("[A-Za-z' ]+");
     }
 
     @Test
-    public void spell() {
+    void spell() {
         assertThat(faker.eldenRing().spell()).matches("[A-Za-z' ]+");
     }
 
     @Test
-    public void npc() {
+    void npc() {
         assertThat(faker.eldenRing().npc()).matches("[A-Za-z ]+");
     }
 }

--- a/src/test/java/net/datafaker/ElderScrollsTest.java
+++ b/src/test/java/net/datafaker/ElderScrollsTest.java
@@ -6,45 +6,45 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ElderScrollsTest extends AbstractFakerTest {
+class ElderScrollsTest extends AbstractFakerTest {
 
     @Test
-    public void testCity() {
+    void testCity() {
         assertThat(faker.elderScrolls().city()).isNotEmpty();
     }
 
     @Test
-    public void testCreature() {
+    void testCreature() {
         assertThat(faker.elderScrolls().creature()).isNotEmpty();
     }
 
     @Test
-    public void testDragon() {
+    void testDragon() {
         assertThat(faker.elderScrolls().dragon()).isNotEmpty();
     }
 
     @Test
-    public void testFirstName() {
+    void testFirstName() {
         assertThat(faker.elderScrolls().firstName()).isNotEmpty();
     }
 
     @Test
-    public void testLastName() {
+    void testLastName() {
         assertThat(faker.elderScrolls().lastName()).isNotEmpty();
     }
 
     @Test
-    public void testRace() {
+    void testRace() {
         assertThat(faker.elderScrolls().race()).isNotEmpty();
     }
 
     @Test
-    public void testRegion() {
+    void testRegion() {
         assertThat(faker.elderScrolls().region()).isNotEmpty();
     }
 
     @Test
-    public void testQuote() {
+    void testQuote() {
         assertThat(faker.elderScrolls().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/ElectricalComponentsTest.java
+++ b/src/test/java/net/datafaker/ElectricalComponentsTest.java
@@ -4,22 +4,22 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ElectricalComponentsTest extends AbstractFakerTest{
+class ElectricalComponentsTest extends AbstractFakerTest{
 
     @Test
-    public void testActive() {
+    void testActive() {
         String activeComponent = faker.electricalComponents().active();
         assertThat(activeComponent).isNotEmpty();
     }
 
     @Test
-    public void testPassive() {
+    void testPassive() {
         String passiveComponent = faker.electricalComponents().passive();
         assertThat(passiveComponent).isNotEmpty();
     }
 
     @Test
-    public void testElectromechanical() {
+    void testElectromechanical() {
         String electromechanicalComponent = faker.electricalComponents().electromechanical();
         assertThat(electromechanicalComponent).isNotEmpty();
     }

--- a/src/test/java/net/datafaker/EnglandFootBallTest.java
+++ b/src/test/java/net/datafaker/EnglandFootBallTest.java
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnglandFootBallTest extends AbstractFakerTest {
+class EnglandFootBallTest extends AbstractFakerTest {
 
     @Test
-    public void testLeague() {
+    void testLeague() {
         String league = faker.englandfootball().league();
         assertThat(league).isNotEmpty();
     }
 
     @Test
-    public void testTeam() {
+    void testTeam() {
         String team = faker.englandfootball().team();
         assertThat(team).isNotEmpty();
     }

--- a/src/test/java/net/datafaker/EsportsTest.java
+++ b/src/test/java/net/datafaker/EsportsTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EsportsTest extends AbstractFakerTest {
+class EsportsTest extends AbstractFakerTest {
 
     @Test
-    public void player() {
+    void player() {
         assertThat(faker.esports().player()).matches("(\\w|.)+");
     }
 
     @Test
-    public void team() {
+    void team() {
         assertThat(faker.esports().team()).matches("((\\w|.)+ ?)+");
     }
 
     @Test
-    public void event() {
+    void event() {
         assertThat(faker.esports().event()).matches("(\\w+ ?)+");
     }
 
     @Test
-    public void league() {
+    void league() {
         assertThat(faker.esports().league()).matches("\\w+");
     }
 
     @Test
-    public void game() {
+    void game() {
         assertThat(faker.esports().game()).matches("([\\w:.]+ ?)+");
     }
 }

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -12,9 +12,9 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class FakeCollectionTest extends AbstractFakerTest {
+class FakeCollectionTest extends AbstractFakerTest {
     @Test
-    public void generateCollection() {
+    void generateCollection() {
         List<String> names = faker.<String>collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
             .minLen(3)
@@ -27,7 +27,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void generateNullCollection() {
+    void generateNullCollection() {
         List<String> names = faker.<String>collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
             .nullRate(1d)
@@ -42,7 +42,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @ValueSource(doubles = {Long.MIN_VALUE, Integer.MIN_VALUE, -1, -0.3, 2, 3, Integer.MAX_VALUE, Double.MAX_VALUE})
-    public void illegalNullRate(double nullRate) {
+    void illegalNullRate(double nullRate) {
         assertThatThrownBy(
             () -> faker.collection()
                 .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())
@@ -54,7 +54,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void generateCollectionWithRepeatableFaker() {
+    void generateCollectionWithRepeatableFaker() {
         Faker seededFaker = new Faker(new Random(10L));
 
         List<String> names = faker.<String>collection()
@@ -69,7 +69,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void generateCollectionWithDifferentObjects() {
+    void generateCollectionWithDifferentObjects() {
         List<Object> objects = faker.collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.random().nextInt(100))
             .maxLen(5).build().get();
@@ -80,7 +80,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void checkWrongArguments() {
+    void checkWrongArguments() {
         assertThatThrownBy(() ->
             faker.collection()
                 .suppliers(() -> faker.name().firstName())
@@ -170,7 +170,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void differentNumberOfHeadersAndColumns() {
+    void differentNumberOfHeadersAndColumns() {
         assertThatThrownBy(() -> Format.toCsv(
                 faker.<Name>collection()
                     .suppliers(() -> faker.name())
@@ -183,7 +183,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void toCsv() {
+    void toCsv() {
         String separator = "$$$";
         int limit = 5;
         String csv = Format.toCsv(
@@ -210,7 +210,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void toJson() {
+    void toJson() {
         int limit = 10;
         String json = Format.toJson(
                 faker.<Data>collection().minLen(limit).maxLen(limit)
@@ -234,7 +234,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
-    public void toNestedJson() {
+    void toNestedJson() {
         final int limit = 2;
         final String json =
             Format.toJson(faker.collection()
@@ -272,7 +272,7 @@ public class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void singletonTest() {
+    void singletonTest() {
         int limit = 10;
         assertThat(faker.<Data>collection().minLen(limit).maxLen(limit)
             .suppliers(BloodPressure::new, Glucose::new, Temperature::new)

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -12,65 +12,65 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class FakerTest extends AbstractFakerTest {
+class FakerTest extends AbstractFakerTest {
 
     @Test
-    public void examplifyUppercaseLetters() {
+    void examplifyUppercaseLetters() {
         assertThat(faker.examplify("ABC")).matches("[A-Z]{3}");
     }
 
     @Test
-    public void examplifyLowercaseLetters() {
+    void examplifyLowercaseLetters() {
         assertThat(faker.examplify("abc")).matches("[a-z]{3}");
     }
 
     @Test
-    public void examplifyNumbers() {
+    void examplifyNumbers() {
         assertThat(faker.examplify("489321")).matches("[0-9]{6}");
     }
 
     @Test
-    public void examplifyMixed() {
+    void examplifyMixed() {
         assertThat(faker.examplify("abc123ABC1zzz")).matches("[a-z]{3}[0-9]{3}[A-Z]{3}[0-9][a-z]{3}");
     }
 
     @Test
-    public void examplifyWithSpacesAndSpecialCharacters() {
+    void examplifyWithSpacesAndSpecialCharacters() {
         assertThat(faker.examplify("The number 4!")).matches("[A-Z][a-z]{2} [a-z]{6} [0-9]!");
     }
 
     @Test
-    public void bothifyShouldGenerateLettersAndNumbers() {
+    void bothifyShouldGenerateLettersAndNumbers() {
         assertThat(faker.bothify("????##@gmail.com")).matches("\\w{4}\\d{2}@gmail.com");
     }
 
     @Test
-    public void letterifyShouldGenerateLetters() {
+    void letterifyShouldGenerateLetters() {
         assertThat(faker.bothify("????")).matches("\\w{4}");
     }
 
     @Test
-    public void letterifyShouldGenerateUpperCaseLetters() {
+    void letterifyShouldGenerateUpperCaseLetters() {
         assertThat(faker.bothify("????", true)).matches("[A-Z]{4}");
     }
 
     @Test
-    public void letterifyShouldLeaveNonSpecialCharactersAlone() {
+    void letterifyShouldLeaveNonSpecialCharactersAlone() {
         assertThat(faker.bothify("ABC????DEF")).matches("ABC\\w{4}DEF");
     }
 
     @Test
-    public void numerifyShouldGenerateNumbers() {
+    void numerifyShouldGenerateNumbers() {
         assertThat(faker.numerify("####")).matches("\\d{4}");
     }
 
     @Test
-    public void numerifyShouldLeaveNonSpecialCharactersAlone() {
+    void numerifyShouldLeaveNonSpecialCharactersAlone() {
         assertThat(faker.numerify("####123")).matches("\\d{4}123");
     }
 
     @Test
-    public void templatify() {
+    void templatify() {
         assertThat(faker.templatify("12??34", '?', "тест", "test", "测试测试").length()).isEqualTo(12);
         assertThat(faker.templatify("12??34",
             Collections.singletonMap('1', new String[]{"тест", "test", "测试测试"})).length()).isEqualTo(9);
@@ -79,90 +79,90 @@ public class FakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void regexifyShouldGenerateNumbers() {
+    void regexifyShouldGenerateNumbers() {
         assertThat(faker.regexify("\\d")).matches("\\d");
     }
 
     @Test
-    public void regexifyShouldGenerateLetters() {
+    void regexifyShouldGenerateLetters() {
         assertThat(faker.regexify("\\w")).matches("\\w");
     }
 
     @Test
-    public void regexifyShouldGenerateAlternations() {
+    void regexifyShouldGenerateAlternations() {
         assertThat(faker.regexify("(a|b)")).matches("([ab])");
     }
 
     @Test
-    public void regexifyShouldGenerateBasicCharacterClasses() {
+    void regexifyShouldGenerateBasicCharacterClasses() {
         assertThat(faker.regexify("(aeiou)")).matches("(aeiou)");
     }
 
     @Test
-    public void regexifyShouldGenerateCharacterClassRanges() {
+    void regexifyShouldGenerateCharacterClassRanges() {
         assertThat(faker.regexify("[a-z]")).matches("[a-z]");
     }
 
     @Test
-    public void regexifyShouldGenerateMultipleCharacterClassRanges() {
+    void regexifyShouldGenerateMultipleCharacterClassRanges() {
         assertThat(faker.regexify("[a-z1-9]")).matches("[a-z1-9]");
     }
 
     @Test
-    public void regexifyShouldGenerateSingleCharacterQuantifiers() {
+    void regexifyShouldGenerateSingleCharacterQuantifiers() {
         assertThat(faker.regexify("a*b+c?")).matches("a*b+c?");
     }
 
     @Test
-    public void regexifyShouldGenerateBracketsQuantifiers() {
+    void regexifyShouldGenerateBracketsQuantifiers() {
         assertThat(faker.regexify("a{2}")).matches("a{2}");
     }
 
     @Test
-    public void regexifyShouldGenerateMinMaxQuantifiers() {
+    void regexifyShouldGenerateMinMaxQuantifiers() {
         assertThat(faker.regexify("a{2,3}")).matches("a{2,3}");
     }
 
     @Test
-    public void regexifyShouldGenerateBracketsQuantifiersOnBasicCharacterClasses() {
+    void regexifyShouldGenerateBracketsQuantifiersOnBasicCharacterClasses() {
         assertThat(faker.regexify("[aeiou]{2,3}")).matches("[aeiou]{2,3}");
     }
 
     @Test
-    public void regexifyShouldGenerateBracketsQuantifiersOnCharacterClassRanges() {
+    void regexifyShouldGenerateBracketsQuantifiersOnCharacterClassRanges() {
         assertThat(faker.regexify("[a-z]{2,3}")).matches("[a-z]{2,3}");
     }
 
     @Test
-    public void regexifyShouldGenerateBracketsQuantifiersOnAlternations() {
+    void regexifyShouldGenerateBracketsQuantifiersOnAlternations() {
         assertThat(faker.regexify("(a|b){2,3}")).matches("([ab]){2,3}");
     }
 
     @Test
-    public void regexifyShouldGenerateEscapedCharacters() {
+    void regexifyShouldGenerateEscapedCharacters() {
         assertThat(faker.regexify("\\.\\*\\?\\+")).matches("\\.\\*\\?\\+");
     }
 
     @Test
-    public void badExpressionTooManyArgs() {
+    void badExpressionTooManyArgs() {
         assertThatThrownBy(() -> faker.expression("#{regexify 'a','a'}"))
             .isInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void badExpressionTooFewArgs() {
+    void badExpressionTooFewArgs() {
         assertThatThrownBy(() -> faker.expression("#{regexify}"))
             .isInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void badExpressionCouldntCoerce() {
+    void badExpressionCouldntCoerce() {
         assertThatThrownBy(() -> faker.expression("#{number.number_between 'x','10'}"))
             .isInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void expression() {
+    void expression() {
         assertThat(faker.expression("#{options.option 'a','b','c','d'}")).matches("([abcd])");
         assertThat(faker.expression("#{options.option '12','345','89','54321'}")).matches("(12|345|89|54321)");
         assertThat(faker.expression("#{regexify '(a|b){2,3}'}")).matches("([ab]){2,3}");
@@ -181,12 +181,12 @@ public class FakerTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void numberBetweenRepeated() {
+    void numberBetweenRepeated() {
         assertThat(faker.expression("#{number.number_between '1','10'}")).matches("[1-9]");
     }
 
     @Test
-    public void regexifyShouldGenerateSameValueForFakerWithSameSeed() {
+    void regexifyShouldGenerateSameValueForFakerWithSameSeed() {
         long seed = 1L;
         String regex = "\\d";
 
@@ -197,12 +197,12 @@ public class FakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void resolveShouldReturnValueThatExists() {
+    void resolveShouldReturnValueThatExists() {
         assertThat(faker.resolve("address.city_prefix")).isNotEmpty();
     }
 
     @Test
-    public void resolveShouldThrowExceptionWhenPropertyDoesntExist() {
+    void resolveShouldThrowExceptionWhenPropertyDoesntExist() {
         assertThatThrownBy(() -> faker.resolve("address.nothing"))
             .isInstanceOf(RuntimeException.class);
     }
@@ -212,7 +212,7 @@ public class FakerTest extends AbstractFakerTest {
      */
     @ParameterizedTest
     @ValueSource(strings = {"#{regexify '[a-z]{5}[A-Z]{5}'}", "#{Address.city}"})
-    public void datafaker87(String expression) {
+    void datafaker87(String expression) {
         int n = 10;
         int counter = 0;
         for (int i = 0; i < n; i++) {
@@ -227,7 +227,7 @@ public class FakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void fakerInstanceCanBeAcquiredViaUtilityMethods() {
+    void fakerInstanceCanBeAcquiredViaUtilityMethods() {
         assertThat(Faker.instance()).isInstanceOf(Faker.class);
         assertThat(Faker.instance(Locale.CANADA)).isInstanceOf(Faker.class);
         assertThat(Faker.instance(new Random(1))).isInstanceOf(Faker.class);

--- a/src/test/java/net/datafaker/FileTest.java
+++ b/src/test/java/net/datafaker/FileTest.java
@@ -5,44 +5,44 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FileTest extends AbstractFakerTest {
+class FileTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void testExtension() {
+    void testExtension() {
         assertThat(faker.file().extension())
             .matches("(flac|mp3|wav|bmp|gif|jpeg|jpg|png|tiff|css|csv|html|js|json|txt|mp4|avi|mov|webm|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|pages|numbers|key|pdf)");
     }
 
     @RepeatedTest(10)
-    public void testMimeTypeFormat() {
+    void testMimeTypeFormat() {
         assertThat(faker.file().mimeType()).matches(".+/.+");
     }
 
     @RepeatedTest(10)
-    public void testFileName() {
+    void testFileName() {
         assertThat(faker.file().fileName()).matches("([a-z\\-_]+)([\\\\/])([a-z\\-_]+)\\.([a-z0-9]+)");
     }
 
     @Test
-    public void testFileNameSpecifyExtension() {
+    void testFileNameSpecifyExtension() {
         assertThat(faker.file().fileName(null, null, "txt", null))
             .matches("([a-z\\-_]+)([\\\\/])([a-z\\-_]+)\\.txt");
     }
 
     @Test
-    public void testFileNameSpecifyDir() {
+    void testFileNameSpecifyDir() {
         assertThat(faker.file().fileName("my_dir", null, null, null))
             .matches("my_dir([\\\\/])([a-z\\-_]+)\\.([a-z0-9]+)");
     }
 
     @Test
-    public void testFileNameSpecifySeparator() {
+    void testFileNameSpecifySeparator() {
         assertThat(faker.file().fileName(null, null, null, "\\"))
             .matches("([a-z\\-_]+)\\\\([a-z\\-_]+)\\.([a-z0-9]+)");
     }
 
     @Test
-    public void testFileNameSpecifyName() {
+    void testFileNameSpecifyName() {
         assertThat(faker.file().fileName(null, "da_name", null, null))
             .matches("([a-z\\-_]+)([\\\\/])da_name\\.([a-z0-9]+)");
     }

--- a/src/test/java/net/datafaker/FinanceTest.java
+++ b/src/test/java/net/datafaker/FinanceTest.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FinanceTest extends AbstractFakerTest {
+class FinanceTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
-    public void creditCard() {
+    void creditCard() {
         final String creditCard = faker.finance().creditCard();
         assertCardLuhnDigit(creditCard);
     }
@@ -20,38 +20,38 @@ public class FinanceTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void nasdaqTicker() {
+    void nasdaqTicker() {
         assertThat(faker.finance().nasdaqTicker()).matches("[A-Z.-]+");
     }
 
     @RepeatedTest(10)
-    public void nyseTicker() {
+    void nyseTicker() {
         assertThat(faker.finance().nyseTicker()).matches("[A-Z.-]+");
     }
 
     @Test
-    public void stockMarket() {
+    void stockMarket() {
         assertThat(faker.finance().stockMarket()).matches("[A-Z.-]+");
     }
 
 
     @Test
-    public void bic() {
+    void bic() {
         assertThat(faker.finance().bic()).matches("([A-Z]){4}([A-Z]){2}([0-9A-Z]){2}([0-9A-Z]{3})?");
     }
 
     @RepeatedTest(100)
-    public void iban() {
+    void iban() {
         assertThat(faker.finance().iban()).matches("[A-Z]{2}\\p{Alnum}{13,30}");
     }
 
     @Test
-    public void ibanWithCountryCode() {
+    void ibanWithCountryCode() {
         assertThat(faker.finance().iban("DE")).matches("DE\\d{20}");
     }
 
     @Test
-    public void creditCardWithType() {
+    void creditCardWithType() {
         for (CreditCardType type : CreditCardType.values()) {
             final String creditCard = faker.finance().creditCard(type);
             assertCardLuhnDigit(creditCard);
@@ -59,7 +59,7 @@ public class FinanceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void costaRicaIbanMustBeValid() {
+    void costaRicaIbanMustBeValid() {
         final String givenCountryCode = "CR";
         final Faker faker = new Faker();
         final String ibanFaker = faker.finance().iban(givenCountryCode).toUpperCase(faker.getLocale());

--- a/src/test/java/net/datafaker/FoodTest.java
+++ b/src/test/java/net/datafaker/FoodTest.java
@@ -4,40 +4,40 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FoodTest extends AbstractFakerTest {
+class FoodTest extends AbstractFakerTest {
 
     @Test
-    public void ingredient() {
+    void ingredient() {
         assertThat(faker.food().ingredient()).matches("[A-Za-z- ]+");
     }
 
     @Test
-    public void spice() {
+    void spice() {
         assertThat(faker.food().spice()).matches("[A-Za-z1-9- ]+");
     }
 
     @Test
-    public void dish() {
+    void dish() {
         assertThat(faker.food().dish()).matches("\\P{Cc}+");
     }
 
     @Test
-    public void fruit() {
+    void fruit() {
         assertThat(faker.food().fruit()).matches("[A-Za-z1-9- ]+");
     }
 
     @Test
-    public void vegetable() {
+    void vegetable() {
         assertThat(faker.food().vegetable()).matches("[A-Za-z1-9- ]+");
     }
 
     @Test
-    public void sushi() {
+    void sushi() {
         assertThat(faker.food().sushi()).matches("[A-Za-z1-9- ]+");
     }
 
     @Test
-    public void measurement() {
+    void measurement() {
         assertThat(faker.food().measurement()).matches("([A-Za-z1-9/ ]+){2}");
     }
 }

--- a/src/test/java/net/datafaker/Formula1Test.java
+++ b/src/test/java/net/datafaker/Formula1Test.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Formula1Test extends AbstractFakerTest {
+class Formula1Test extends AbstractFakerTest {
 
     @Test
-    public void driver() {
+    void driver() {
         assertThat(faker.formula1().driver()).matches("[A-Za-zà-úÀ-Ú- ]+");
     }
 
     @Test
-    public void team() {
+    void team() {
         assertThat(faker.formula1().team()).matches("[A-Za-zà-úÀ-Ú- ]+");
     }
 
     @Test
-    public void circuit() {
+    void circuit() {
         assertThat(faker.formula1().circuit()).matches("[A-Za-zà-úÀ-Ú- ]+");
     }
 
     @Test
-    public void grandPrix() {
+    void grandPrix() {
         assertThat(faker.formula1().grandPrix()).matches("[A-Za-zà-úÀ-Ú- ]+");
     }
 }

--- a/src/test/java/net/datafaker/FriendsTest.java
+++ b/src/test/java/net/datafaker/FriendsTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FriendsTest extends AbstractFakerTest {
+class FriendsTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.friends().character()).matches("[A-Za-z .,]+");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.friends().location()).matches("[\\w.', ]+");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.friends().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/FunnyNameTest.java
+++ b/src/test/java/net/datafaker/FunnyNameTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FunnyNameTest extends AbstractFakerTest {
+class FunnyNameTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.funnyName().name()).matches("^(\\w+\\.?\\s?'?-?)+$");
     }
 }

--- a/src/test/java/net/datafaker/GameOfThronesTest.java
+++ b/src/test/java/net/datafaker/GameOfThronesTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GameOfThronesTest extends AbstractFakerTest {
+class GameOfThronesTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.gameOfThrones().character()).matches("[A-Za-z'\\-() ]+");
     }
 
     @Test
-    public void house() {
+    void house() {
         assertThat(faker.gameOfThrones().house()).matches("[A-Za-z' ]+");
     }
 
     @Test
-    public void city() {
+    void city() {
         assertThat(faker.gameOfThrones().city()).matches("[A-Za-z' ]+");
     }
 
     @Test
-    public void dragon() {
+    void dragon() {
         assertThat(faker.gameOfThrones().dragon()).matches("\\w+");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.gameOfThrones().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/GenderTest.java
+++ b/src/test/java/net/datafaker/GenderTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GenderTest extends AbstractFakerTest {
+class GenderTest extends AbstractFakerTest {
 
     @Test
-    public void types() {
+    void types() {
         assertThat(faker.gender().types()).matches("(\\w+ ?){1,2}");
     }
 
     @Test
-    public void binaryTypes() {
+    void binaryTypes() {
         assertThat(faker.gender().binaryTypes()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void shortBinaryTypes() {
+    void shortBinaryTypes() {
         assertThat(faker.gender().shortBinaryTypes()).matches("[fm]");
     }
 

--- a/src/test/java/net/datafaker/GratefulDeadTest.java
+++ b/src/test/java/net/datafaker/GratefulDeadTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GratefulDeadTest extends AbstractFakerTest {
+class GratefulDeadTest extends AbstractFakerTest {
 
     @Test
-    public void players() {
+    void players() {
         assertThat(faker.gratefulDead().players()).isNotEmpty();
     }
 
     @Test
-    public void songs() {
+    void songs() {
         assertThat(faker.gratefulDead().songs()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/HackerTest.java
+++ b/src/test/java/net/datafaker/HackerTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HackerTest extends AbstractFakerTest {
+class HackerTest extends AbstractFakerTest {
 
     @Test
-    public void testAbbreviation() {
+    void testAbbreviation() {
         assertThat(faker.hacker().abbreviation()).matches("[A-Z]{2,4}");
     }
 
     @Test
-    public void testAdjective() {
+    void testAdjective() {
         assertThat(faker.hacker().adjective()).matches("(\\w+[- ]?){1,2}");
     }
 
     @Test
-    public void testNoun() {
+    void testNoun() {
         assertThat(faker.hacker().noun()).matches("\\w+( \\w+)?");
     }
 
     @Test
-    public void testVerb() {
+    void testVerb() {
         assertThat(faker.hacker().verb()).matches("\\w+( \\w+)?");
     }
 
     @Test
-    public void testIngverb() {
+    void testIngverb() {
         assertThat(faker.hacker().ingverb()).matches("\\w+ing( \\w+)?");
     }
 }

--- a/src/test/java/net/datafaker/HarryPotterTest.java
+++ b/src/test/java/net/datafaker/HarryPotterTest.java
@@ -5,35 +5,35 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Strings.isNullOrEmpty;
 
-public class HarryPotterTest extends AbstractFakerTest {
+class HarryPotterTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.harryPotter().character()).matches("[A-Za-z,\\-.() ]+");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.harryPotter().location()).matches("[A-Za-z0-9'. &,/]+");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(isNullOrEmpty(faker.harryPotter().quote())).isFalse();
     }
 
     @Test
-    public void book() {
+    void book() {
         assertThat(faker.harryPotter().book()).matches("Harry Potter and the ([A-Za-z'\\-]+ ?)+");
     }
 
     @Test
-    public void house() {
+    void house() {
         assertThat(faker.harryPotter().house()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void spell() {
+    void spell() {
         assertThat(faker.harryPotter().spell()).matches("[A-Za-z ]+");
     }
 }

--- a/src/test/java/net/datafaker/HashingTest.java
+++ b/src/test/java/net/datafaker/HashingTest.java
@@ -4,35 +4,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HashingTest extends AbstractFakerTest {
+class HashingTest extends AbstractFakerTest {
 
     @Test
-    public void testMd2() {
+    void testMd2() {
         assertThat(faker.hashing().md2()).matches("[a-z\\d]+");
     }
 
     @Test
-    public void testMd5() {
+    void testMd5() {
         assertThat(faker.hashing().md5()).matches("[a-z\\d]+");
     }
 
     @Test
-    public void testSha1() {
+    void testSha1() {
         assertThat(faker.hashing().sha1()).matches("[a-z\\d]+");
     }
 
     @Test
-    public void testSha256() {
+    void testSha256() {
         assertThat(faker.hashing().sha256()).matches("[a-z\\d]+");
     }
 
     @Test
-    public void testSha384() {
+    void testSha384() {
         assertThat(faker.hashing().sha384()).matches("[a-z\\d]+");
     }
 
     @Test
-    public void testSha512() {
+    void testSha512() {
         assertThat(faker.hashing().sha512()).matches("[a-z\\d]+");
     }
 }

--- a/src/test/java/net/datafaker/HearthstoneTest.java
+++ b/src/test/java/net/datafaker/HearthstoneTest.java
@@ -4,41 +4,41 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HearthstoneTest extends AbstractFakerTest {
+class HearthstoneTest extends AbstractFakerTest {
 
     @Test
-    public void mainProfessionTest() {
+    void mainProfessionTest() {
         String profession = faker.hearthstone().mainProfession();
         assertThat(profession).matches("[ A-Za-z]+");
     }
 
     @Test
-    public void mainCharacterTest() {
+    void mainCharacterTest() {
         String character = faker.hearthstone().mainCharacter();
         assertThat(character).matches("[ A-Za-z']+");
     }
 
     @Test
-    public void mainPatternTest() {
+    void mainPatternTest() {
         String pattern = faker.hearthstone().mainPattern();
         assertThat(pattern).matches("[ A-Za-z]+");
     }
 
     @Test
-    public void battlegroundsScoreTest() {
+    void battlegroundsScoreTest() {
         int score = faker.hearthstone().battlegroundsScore();
         assertThat(score).isLessThanOrEqualTo(16000);
         assertThat(score).isGreaterThanOrEqualTo(0);
     }
 
     @Test
-    public void standardRankTest() {
+    void standardRankTest() {
         String rank = faker.hearthstone().standardRank();
         assertThat(rank).matches("[ A-Za-z0-9]+");
     }
 
     @Test
-    public void wildRankTest() {
+    void wildRankTest() {
         String rank = faker.hearthstone().wildRank();
         assertThat(rank).matches("[ A-Za-z0-9]+");
     }

--- a/src/test/java/net/datafaker/HeyArnoldTest.java
+++ b/src/test/java/net/datafaker/HeyArnoldTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HeyArnoldTest extends AbstractFakerTest {
+class HeyArnoldTest extends AbstractFakerTest {
 
     @Test
-    public void characters() {
+    void characters() {
         assertThat(faker.heyArnold().characters()).isNotEmpty();
     }
 
     @Test
-    public void locations() {
+    void locations() {
         assertThat(faker.heyArnold().locations()).isNotEmpty();
     }
 
     @Test
-    public void quotes() {
+    void quotes() {
         assertThat(faker.heyArnold().quotes()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/HipsterTest.java
+++ b/src/test/java/net/datafaker/HipsterTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HipsterTest extends AbstractFakerTest {
+class HipsterTest extends AbstractFakerTest {
 
     @Test
-    public void word() {
+    void word() {
         assertThat(faker.hipster().word()).matches("^([\\w-+&']+ ?)+$");
     }
 }

--- a/src/test/java/net/datafaker/HitchhikersGuideToTheGalaxyTest.java
+++ b/src/test/java/net/datafaker/HitchhikersGuideToTheGalaxyTest.java
@@ -4,35 +4,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HitchhikersGuideToTheGalaxyTest extends AbstractFakerTest {
+class HitchhikersGuideToTheGalaxyTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.hitchhikersGuideToTheGalaxy().character()).matches("^(\\w+(\\.?\\s?'?))+$");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.hitchhikersGuideToTheGalaxy().location()).matches("^(\\w+\\S?\\.?\\s?'?-?)+$");
     }
 
     @Test
-    public void marvinQuote() {
+    void marvinQuote() {
         assertThat(faker.hitchhikersGuideToTheGalaxy().marvinQuote()).isNotEmpty();
     }
 
     @Test
-    public void planet() {
+    void planet() {
         assertThat(faker.hitchhikersGuideToTheGalaxy().planet()).matches("^(\\w+-?\\s?)+$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.hitchhikersGuideToTheGalaxy().quote()).isNotEmpty();
     }
 
     @Test
-    public void species() {
+    void species() {
         assertThat(faker.hitchhikersGuideToTheGalaxy().species()).matches("^(\\w+'?\\s?)+$");
     }
 }

--- a/src/test/java/net/datafaker/HobbitTest.java
+++ b/src/test/java/net/datafaker/HobbitTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HobbitTest extends AbstractFakerTest {
+class HobbitTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.hobbit().character()).matches("^(\\(?\\w+\\.?\\s?\\)?)+$");
     }
 
     @Test
-    public void thorinsCompany() {
+    void thorinsCompany() {
         assertThat(faker.hobbit().thorinsCompany()).matches("^(\\w+\\s?)+$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.hobbit().quote()).isNotEmpty();
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.hobbit().location()).matches("^(\\w+'?-?\\s?)+$");
     }
 }

--- a/src/test/java/net/datafaker/HobbyTest.java
+++ b/src/test/java/net/datafaker/HobbyTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HobbyTest extends AbstractFakerTest {
+class HobbyTest extends AbstractFakerTest {
 
     @Test
-    public void activity() {
+    void activity() {
         assertThat(faker.hobby().activity()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/HorseTest.java
+++ b/src/test/java/net/datafaker/HorseTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HorseTest extends AbstractFakerTest {
+class HorseTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.horse().name()).isNotEmpty();
     }
 
     @Test
-    public void breed() {
+    void breed() {
         assertThat(faker.horse().breed()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/HowIMetYourMotherTest.java
+++ b/src/test/java/net/datafaker/HowIMetYourMotherTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HowIMetYourMotherTest extends AbstractFakerTest {
+class HowIMetYourMotherTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.howIMetYourMother().character()).matches("^(\\w+\\.?\\s?)+$");
     }
 
     @Test
-    public void catchPhrase() {
+    void catchPhrase() {
         assertThat(faker.howIMetYourMother().catchPhrase()).isNotEmpty();
     }
 
     @Test
-    public void highFive() {
+    void highFive() {
         assertThat(faker.howIMetYourMother().highFive()).matches("^(\\w+-?\\s?)+$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.howIMetYourMother().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/IdNumberTest.java
+++ b/src/test/java/net/datafaker/IdNumberTest.java
@@ -7,69 +7,69 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class IdNumberTest extends AbstractFakerTest {
+class IdNumberTest extends AbstractFakerTest {
 
     @Test
-    public void testValid() {
+    void testValid() {
         assertThat(faker.idNumber().valid()).matches("[0-8]\\d{2}-\\d{2}-\\d{4}");
     }
 
     @Test
-    public void testInvalid() {
+    void testInvalid() {
         assertThat(faker.idNumber().invalid()).matches("[0-9]\\d{2}-\\d{2}-\\d{4}");
     }
 
     @RepeatedTest(100)
-    public void testSsnValid() {
+    void testSsnValid() {
         assertThat(faker.idNumber().ssnValid()).matches("[0-8]\\d{2}-\\d{2}-\\d{4}");
     }
 
     @RepeatedTest(100)
-    public void testValidSwedishSsn() {
+    void testValidSwedishSsn() {
         final Faker f = new Faker(new Locale("sv_SE"));
         assertThat(f.idNumber().validSvSeSsn()).matches("\\d{6}[-+]\\d{4}");
     }
 
     @RepeatedTest(100)
-    public void testInvalidSwedishSsn() {
+    void testInvalidSwedishSsn() {
         final Faker f = new Faker(new Locale("sv_SE"));
         assertThat(f.idNumber().invalidSvSeSsn()).matches("\\d{6}[-+]\\d{4}");
     }
 
     @RepeatedTest(100)
-    public void testValidEnZaSsn() {
+    void testValidEnZaSsn() {
         final Faker f = new Faker(new Locale("en_ZA"));
         assertThat(f.idNumber().validEnZaSsn()).matches("[0-9]{10}([01])8[0-9]");
     }
 
     @RepeatedTest(100)
-    public void testInvalidEnZaSsn() {
+    void testInvalidEnZaSsn() {
         final Faker f = new Faker(new Locale("en_ZA"));
         assertThat(f.idNumber().inValidEnZaSsn()).matches("[0-9]{10}([01])8[0-9]");
     }
 
     @RepeatedTest(100)
-    public void testSingaporeanFin() {
+    void testSingaporeanFin() {
         assertThat(faker.idNumber().singaporeanFin()).matches("G[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    public void testSingaporeanFinBefore2000() {
+    void testSingaporeanFinBefore2000() {
         assertThat(faker.idNumber().singaporeanFinBefore2000()).matches("F[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    public void testSingaporeanUin() {
+    void testSingaporeanUin() {
         assertThat(faker.idNumber().singaporeanUin()).matches("T[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    public void testSingaporeanUinBefore2000() {
+    void testSingaporeanUinBefore2000() {
         assertThat(faker.idNumber().singaporeanUinBefore2000()).matches("S[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    public void testPeselNumber() {
+    void testPeselNumber() {
         assertThat(faker.idNumber().peselNumber()).matches("[0-9]{11}");
     }
 }

--- a/src/test/java/net/datafaker/InternetPasswordTest.java
+++ b/src/test/java/net/datafaker/InternetPasswordTest.java
@@ -7,9 +7,9 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class InternetPasswordTest extends AbstractFakerTest {
+class InternetPasswordTest extends AbstractFakerTest {
     @Test
-    public void testPassword1000() {
+    void testPassword1000() {
         final Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
         final Pattern digitPattern = Pattern.compile("[0-9]");
         for (int i = 0; i < 1000; i++) {
@@ -26,7 +26,7 @@ public class InternetPasswordTest extends AbstractFakerTest {
     }
 
     @Test
-    public void passwordSpecial() {
+    void passwordSpecial() {
         boolean check = true;
         for (int i = 0; i < 10; i++) {
             String password = faker.internet().password(8, 16, true, true, true);
@@ -42,7 +42,7 @@ public class InternetPasswordTest extends AbstractFakerTest {
     }
 
     @Test
-    public void passwordMix() {
+    void passwordMix() {
         boolean check = true;
         for (int i = 0; i < 10; i++) {
             String password = faker.internet().password(8, 16, true, true, true);

--- a/src/test/java/net/datafaker/InternetTest.java
+++ b/src/test/java/net/datafaker/InternetTest.java
@@ -17,23 +17,23 @@ import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.fail;
 
-public class InternetTest extends AbstractFakerTest {
+class InternetTest extends AbstractFakerTest {
 
     @Test
-    public void testEmailAddress() {
+    void testEmailAddress() {
         String emailAddress = faker.internet().emailAddress();
         assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
     }
 
     @Test
-    public void testEmailAddressWithLocalPartParameter() {
+    void testEmailAddressWithLocalPartParameter() {
         String emailAddress = faker.internet().emailAddress("john");
         assertThat(emailAddress).startsWith("john@");
         assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
     }
 
     @Test
-    public void testSafeEmailAddress() {
+    void testSafeEmailAddress() {
         List<String> emails = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             String emailAddress = faker.internet().safeEmailAddress();
@@ -47,7 +47,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testSafeEmailAddressWithLocalPartParameter() {
+    void testSafeEmailAddressWithLocalPartParameter() {
         List<String> emails = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             String emailAddress = faker.internet().safeEmailAddress("john");
@@ -62,91 +62,91 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
+    void testEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
         String emailAddress = faker.internet().emailAddress("áéíóú");
         assertThat(emailAddress).startsWith("aeiou@");
     }
 
     @Test
-    public void testSafeEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
+    void testSafeEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
         String emailAddress = faker.internet().safeEmailAddress("áéíóú");
         assertThat(emailAddress).startsWith("aeiou@");
     }
 
     @Test
-    public void testUrl() {
+    void testUrl() {
         assertThat(faker.internet().url()).matches("www\\.(\\w|-)+\\.\\w+");
     }
 
     @Test
-    public void testAvatar() {
+    void testAvatar() {
         assertThat(faker.internet().avatar()).matches("http.*/[^/]+/128.jpg$");
     }
 
     @Test
-    public void testImage() {
+    void testImage() {
         String imageUrl = faker.internet().image();
         assertThat(imageUrl).matches("^https://lorempixel\\.com(/g)?/\\d{1,4}/\\d{1,4}/\\w+/$");
     }
 
     @Test
-    public void testDomainName() {
+    void testDomainName() {
         assertThat(faker.internet().domainName()).matches("[a-z]+\\.\\w{2,4}");
     }
 
     @Test
-    public void testDomainWord() {
+    void testDomainWord() {
         assertThat(faker.internet().domainWord()).matches("[a-z]+");
     }
 
     @Test
-    public void testDomainSuffix() {
+    void testDomainSuffix() {
         assertThat(faker.internet().domainSuffix()).matches("\\w{2,4}");
     }
 
     @Test
-    public void testImageWithExplicitParams() {
+    void testImageWithExplicitParams() {
         String imageUrl = faker.internet().image(800, 600, false, "bugs");
         assertThat(imageUrl).matches("^https://lorempixel\\.com/800/600/\\w+/bugs$");
     }
 
     @Test
-    public void testPassword() {
+    void testPassword() {
         assertThat(faker.internet().password()).matches("[a-z\\d]{8,16}");
     }
 
     @Test
-    public void testPasswordWithFixedLength() {
+    void testPasswordWithFixedLength() {
         String password = Faker.instance().internet().password(32, 32, true, true, true);
         assertThat(password).hasSize(32);
     }
 
     @Test
-    public void testPasswordIncludeDigit() {
+    void testPasswordIncludeDigit() {
         assertThat(faker.internet().password()).matches("[a-z\\d]{8,16}");
         assertThat(faker.internet().password(false)).matches("[a-z]{8,16}");
     }
 
     @Test
-    public void testPasswordMinLengthMaxLength() {
+    void testPasswordMinLengthMaxLength() {
         assertThat(faker.internet().password(10, 25)).matches("[a-z\\d]{10,25}");
     }
 
     @Test
-    public void testPasswordMinLengthMaxLengthIncludeUpperCase() {
+    void testPasswordMinLengthMaxLengthIncludeUpperCase() {
         assertThat(faker.internet().password(1, 2, false)).matches("[a-z\\d]{1,2}");
         assertThat(faker.internet().password(10, 25, true)).matches("[a-zA-Z\\d]{10,25}");
     }
 
     @Test
-    public void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecial() {
+    void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecial() {
         assertThat(faker.internet().password(10, 25, false, false)).matches("[a-z\\d]{10,25}");
         assertThat(faker.internet().password(10, 25, false, true)).matches("[a-z\\d!@#$%^&*]{10,25}");
         assertThat(faker.internet().password(10, 25, true, true)).matches("[a-zA-Z\\d!@#$%^&*]{10,25}");
     }
 
     @Test
-    public void shouldGenerateAPasswordWithMinAndMaxLength() {
+    void shouldGenerateAPasswordWithMinAndMaxLength() {
         List<String> results = new ArrayList<>();
         for (int i = 0; i < 300; i++) {
             results.add(faker.internet().password(1, 10));
@@ -160,7 +160,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecialIncludeDigit() {
+    void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecialIncludeDigit() {
         assertThat(faker.internet().password(10, 25, false, false, false)).matches("[a-z]{10,25}");
         assertThat(faker.internet().password(10, 25, false, true, true)).matches("[a-z\\d!@#$%^&*]{10,25}");
         assertThat(faker.internet().password(10, 25, true, true, false)).matches("[a-zA-Z!@#$%^&*]{10,25}");
@@ -186,7 +186,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testMacAddress() {
+    void testMacAddress() {
         Condition<String> colon = getCharacterCondition(':', 5);
         assertThat(faker.internet().macAddress()).is(colon);
         assertThat(faker.internet().macAddress("")).is(colon);
@@ -206,7 +206,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testIpV4Address() {
+    void testIpV4Address() {
         Condition<String> colon = getCharacterCondition('.', 3);
         assertThat(faker.internet().ipV4Address()).is(colon);
         for (int i = 0; i < 100; i++) {
@@ -223,7 +223,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testIpV4Cidr() {
+    void testIpV4Cidr() {
         assertThat(faker.internet().ipV4Cidr())
             .is(getCharacterCondition('.', 3))
             .is(getCharacterCondition('/', 1));
@@ -235,7 +235,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPrivateIpV4Address() {
+    void testPrivateIpV4Address() {
         String tenDot = "^10\\..+";
         String oneTwoSeven = "^127\\..+";
         String oneSixNine = "^169\\.254\\..+";
@@ -260,7 +260,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPublicIpV4Address() {
+    void testPublicIpV4Address() {
         String tenDot = "^10\\.";
         String oneTwoSeven = "^127\\.";
         String oneSixNine = "^169\\.254";
@@ -281,7 +281,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testIpV6() {
+    void testIpV6() {
         assertThat(faker.internet().ipV6Address()).is(getCharacterCondition(':', 7));
 
         for (int i = 0; i < 1000; i++) {
@@ -295,7 +295,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testIpV6Cidr() {
+    void testIpV6Cidr() {
         assertThat(faker.internet().ipV6Cidr())
             .is(getCharacterCondition(':', 7))
             .is(getCharacterCondition('/', 1));
@@ -307,22 +307,22 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void testSlugWithParams() {
+    void testSlugWithParams() {
         assertThat(faker.internet().slug(Arrays.asList("a", "b"), "-")).matches("[a-zA-Z]+-[a-zA-Z]+");
     }
 
     @RepeatedTest(10)
-    public void testSlug() {
+    void testSlug() {
         assertThat(faker.internet().slug()).matches("[a-zA-Z]+_[a-zA-Z]+");
     }
 
     @RepeatedTest(10)
-    public void testUuid() {
+    void testUuid() {
         assertThat(faker.internet().uuid()).matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
     }
 
     @RepeatedTest(100)
-    public void testFarsiIDNs() {
+    void testFarsiIDNs() {
         // in this case, we're just making sure Farsi doesn't blow up.
         // there have been issues with Farsi not being produced.
         final Faker f = new Faker(new Locale("fa"));
@@ -333,7 +333,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testUserAgent() {
+    void testUserAgent() {
         Internet.UserAgent[] agents = Internet.UserAgent.values();
         for (Internet.UserAgent agent : agents) {
             assertThat(faker.internet().userAgent(agent)).isNotEmpty();
@@ -344,7 +344,7 @@ public class InternetTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testSlugWithNull() {
+    void testSlugWithNull() {
         assertThat(faker.internet().slug(null, "_")).isNotNull();
     }
 }

--- a/src/test/java/net/datafaker/JobTest.java
+++ b/src/test/java/net/datafaker/JobTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JobTest extends AbstractFakerTest {
+class JobTest extends AbstractFakerTest {
 
     @Test
-    public void field() {
+    void field() {
         assertThat(faker.job().field()).matches("^[A-Z][A-Za-z-]+$");
     }
 
     @Test
-    public void seniority() {
+    void seniority() {
         assertThat(faker.job().seniority()).matches("^[A-Z][a-z]+$");
     }
 
     @Test
-    public void position() {
+    void position() {
         assertThat(faker.job().position()).matches("^[A-Z][a-z]+$");
     }
 
     @Test
-    public void keySkills() {
+    void keySkills() {
         assertThat(faker.job().keySkills()).matches("([A-Za-z-]+ ?){1,3}");
     }
 
     @Test
-    public void title() {
+    void title() {
         assertThat(faker.job().title()).matches("([A-Za-z-]+ ?){2,3}");
     }
 }

--- a/src/test/java/net/datafaker/KaamelottTest.java
+++ b/src/test/java/net/datafaker/KaamelottTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KaamelottTest extends AbstractFakerTest {
+class KaamelottTest extends AbstractFakerTest {
 
     @Test
-    public void testCharacter() {
+    void testCharacter() {
         assertThat(faker.kaamelott().character()).matches("[A-Za-z' -ÇÉàçêèéïîüùú]+");
     }
 
     @Test
-    public void testQuote() {
+    void testQuote() {
         assertThat(faker.kaamelott().quote()).matches("[-A-Za-z0-9 —ÇÉàçêèéïîüùú;:…?!.’‘'”“,\\[\\]]+");
     }
 }

--- a/src/test/java/net/datafaker/KpopTest.java
+++ b/src/test/java/net/datafaker/KpopTest.java
@@ -5,35 +5,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KpopTest extends AbstractFakerTest {
+class KpopTest extends AbstractFakerTest {
 
     @Test
-    public void iGroups() {
+    void iGroups() {
         assertThat(faker.kpop().iGroups()).isNotEmpty();
     }
 
     @Test
-    public void iiGroups() {
+    void iiGroups() {
         assertThat(faker.kpop().iiGroups()).isNotEmpty();
     }
 
     @Test
-    public void iiiGroups() {
+    void iiiGroups() {
         assertThat(faker.kpop().iiiGroups()).isNotEmpty();
     }
 
     @Test
-    public void girlGroups() {
+    void girlGroups() {
         assertThat(faker.kpop().girlGroups()).isNotEmpty();
     }
 
     @Test
-    public void boyBands() {
+    void boyBands() {
         assertThat(faker.kpop().boyBands()).isNotEmpty();
     }
 
     @Test
-    public void solo() {
+    void solo() {
         assertThat(faker.kpop().solo()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/LeagueOfLegendsTest.java
+++ b/src/test/java/net/datafaker/LeagueOfLegendsTest.java
@@ -4,35 +4,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LeagueOfLegendsTest extends AbstractFakerTest {
+class LeagueOfLegendsTest extends AbstractFakerTest {
 
     @Test
-    public void champion() {
+    void champion() {
         assertThat(faker.leagueOfLegends().champion()).matches("^(\\w+\\.?-?'?\\s?&?\\s?)+$");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.leagueOfLegends().location()).matches("^(\\w+\\s?)+$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.leagueOfLegends().quote()).isNotEmpty();
     }
 
     @Test
-    public void summonerSpell() {
+    void summonerSpell() {
         assertThat(faker.leagueOfLegends().summonerSpell()).matches("^(\\w+\\s?!?)+$");
     }
 
     @Test
-    public void masteries() {
+    void masteries() {
         assertThat(faker.leagueOfLegends().masteries()).matches("^(\\w+\\s?'?)+$");
     }
 
     @Test
-    public void rank() {
+    void rank() {
         assertThat(faker.leagueOfLegends().rank()).matches("^\\w+(\\s[IV]+)?$");
     }
 }

--- a/src/test/java/net/datafaker/LebowskiTest.java
+++ b/src/test/java/net/datafaker/LebowskiTest.java
@@ -4,19 +4,19 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LebowskiTest extends AbstractFakerTest {
+class LebowskiTest extends AbstractFakerTest {
     @Test
-    public void actor() {
+    void actor() {
         assertThat(faker.lebowski().actor()).matches("^([\\w]+ ?){1,3}$");
     }
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.lebowski().character()).matches("^([\\w]+ ?){1,3}$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.lebowski().quote()).matches("^([\\w.,!?'-]+ ?)+$");
     }
 }

--- a/src/test/java/net/datafaker/LocalePickerExample.java
+++ b/src/test/java/net/datafaker/LocalePickerExample.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-public class LocalePickerExample {
+class LocalePickerExample {
 
     /**
      * Example to illustrate use of LocalePicker to randomly select

--- a/src/test/java/net/datafaker/LordOfTheRingsTest.java
+++ b/src/test/java/net/datafaker/LordOfTheRingsTest.java
@@ -7,15 +7,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Luka Obradovic (luka@vast.com)
  */
-public class LordOfTheRingsTest extends AbstractFakerTest {
+class LordOfTheRingsTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.lordOfTheRings().character()).matches("(?U)([\\w ]+ ?)+");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.lordOfTheRings().location()).matches("(?U)([\\w'\\- ]+ ?)+");
     }
 }

--- a/src/test/java/net/datafaker/LoremTest.java
+++ b/src/test/java/net/datafaker/LoremTest.java
@@ -11,10 +11,10 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LoremTest extends AbstractFakerTest {
+class LoremTest extends AbstractFakerTest {
 
     @Test
-    public void shouldCreateFixedLengthString() {
+    void shouldCreateFixedLengthString() {
         assertThat(faker.lorem().fixedString(10)).hasSize(10);
         assertThat(faker.lorem().fixedString(50)).hasSize(50);
         assertThat(faker.lorem().fixedString(0)).isEmpty();
@@ -22,23 +22,23 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
-    public void wordShouldNotBeNullOrEmpty() {
+    void wordShouldNotBeNullOrEmpty() {
         assertThat(faker.lorem().word()).isNotEmpty();
     }
 
     @Test
-    public void testCharacter() {
+    void testCharacter() {
         assertThat(String.valueOf(faker.lorem().character())).matches("[a-z\\d]{1}");
     }
 
     @Test
-    public void testCharacterIncludeUpperCase() {
+    void testCharacterIncludeUpperCase() {
         assertThat(String.valueOf(faker.lorem().character(false))).matches("[a-z\\d]{1}");
         assertThat(String.valueOf(faker.lorem().character(true))).matches("[a-zA-Z\\d]{1}");
     }
 
     @Test
-    public void testCharactersShouldIncludeMinAndMaxLenght() {
+    void testCharactersShouldIncludeMinAndMaxLenght() {
         List<String> results = new ArrayList<>();
         for (int i = 0; i < 300; i++) {
             results.add(faker.lorem().characters(1, 10));
@@ -52,18 +52,18 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testCharacters() {
+    void testCharacters() {
         assertThat(faker.lorem().characters()).matches("[a-z\\d]{255}");
     }
 
     @Test
-    public void testCharactersIncludeUpperCase() {
+    void testCharactersIncludeUpperCase() {
         assertThat(faker.lorem().characters(false)).matches("[a-z\\d]{255}");
         assertThat(faker.lorem().characters(true)).matches("[a-zA-Z\\d]{255}");
     }
 
     @Test
-    public void testCharactersWithLength() {
+    void testCharactersWithLength() {
         assertThat(faker.lorem().characters(2)).matches("[a-z\\d]{2}");
         assertThat(faker.lorem().characters(500)).matches("[a-z\\d]{500}");
         assertThat(faker.lorem().characters(0)).isEmpty();
@@ -71,7 +71,7 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testCharactersWithLengthIncludeUppercase() {
+    void testCharactersWithLengthIncludeUppercase() {
         assertThat(faker.lorem().characters(2, false)).matches("[a-z\\d]{2}");
         assertThat(faker.lorem().characters(500, false)).matches("[a-z\\d]{500}");
         assertThat(faker.lorem().characters(2, true)).matches("[a-zA-Z\\d]{2}");
@@ -81,22 +81,22 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testCharactersMinimumMaximumLength() {
+    void testCharactersMinimumMaximumLength() {
         assertThat(faker.lorem().characters(1, 10)).matches("[a-z\\d]{1,10}");
     }
 
     @RepeatedTest(10)
-    public void testCharactersMinimumMaximumLengthEquals() {
+    void testCharactersMinimumMaximumLengthEquals() {
         assertThat(faker.lorem().characters(5, 5)).matches("[a-z\\d]{5}");
     }
 
     @RepeatedTest(10)
-    public void testCharactersMinimumMaximumLengthEqualsIncludingUppercaseAndIncludingDigit() {
+    void testCharactersMinimumMaximumLengthEqualsIncludingUppercaseAndIncludingDigit() {
         assertThat(faker.lorem().characters(8, 8, true, true)).matches("[a-zA-Z\\d]{8}");
     }
 
     @Test
-    public void testFixedNumberOfCharactersEmpty() {
+    void testFixedNumberOfCharactersEmpty() {
         assertThat(faker.lorem().characters(-1)).isEmpty();
         assertThat(faker.lorem().characters(0)).isEmpty();
 
@@ -106,18 +106,18 @@ public class LoremTest extends AbstractFakerTest {
 
 
     @Test
-    public void testCharactersMinimumMaximumLengthIncludeUppercase() {
+    void testCharactersMinimumMaximumLengthIncludeUppercase() {
         assertThat(faker.lorem().characters(1, 10, true)).matches("[a-zA-Z\\d]{1,10}");
     }
 
     @Test
-    public void testCharactersMinimumMaximumLengthIncludeUppercaseIncludeDigit() {
+    void testCharactersMinimumMaximumLengthIncludeUppercaseIncludeDigit() {
         assertThat(faker.lorem().characters(1, 10, false, false)).matches("[a-zA-Z]{1,10}");
         assertThat(faker.lorem().characters(1, 10, true, true)).matches("[a-zA-Z\\d]{1,10}");
     }
 
     @Test
-    public void testSentence() {
+    void testSentence() {
         String sentence = faker.lorem().sentence();
         String[] words = sentence.split(" ");
 
@@ -126,7 +126,7 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testSentenceWithWordCount() {
+    void testSentenceWithWordCount() {
         String sentence = faker.lorem().sentence(10);
         String[] words = sentence.split(" ");
 
@@ -135,22 +135,22 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void testSentenceWithWordCountAndRandomWordsToAdd() {
+    void testSentenceWithWordCountAndRandomWordsToAdd() {
         assertThat(faker.lorem().sentence(10, 10)).matches("(\\w+\\s?){10,20}\\.");
     }
 
     @RepeatedTest(10)
-    public void testSentenceFixedNumberOfWords() {
+    void testSentenceFixedNumberOfWords() {
         assertThat(faker.lorem().sentence(10, 0)).matches("(\\w+\\s?){10}\\.");
     }
 
     @Test
-    public void testWords() {
+    void testWords() {
         assertThat(faker.lorem().words().size()).isGreaterThanOrEqualTo(1);
     }
 
     @RepeatedTest(10)
-    public void testMaxLengthSentence() {
+    void testMaxLengthSentence() {
         Random rand = new Random();
         // Test different lengths over 10 runs
         int length = Math.abs(rand.nextInt(10000));
@@ -159,26 +159,26 @@ public class LoremTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testMaxLengthWithEmptySentence() {
+    void testMaxLengthWithEmptySentence() {
         String s = faker.lorem().maxLengthSentence(0);
         assertThat(s).isEmpty();
     }
 
     @Test
-    public void testMaxLengthWithNegativeLengthSentence() {
+    void testMaxLengthWithNegativeLengthSentence() {
         String s = faker.lorem().maxLengthSentence(-1);
         assertThat(s).isEmpty();
     }
 
     @RepeatedTest(10)
-    public void testSentences() {
+    void testSentences() {
         String paragraph = faker.lorem().paragraph();
         int matches = StringUtils.countMatches(paragraph, ".");
         assertThat(matches).isBetween(3, 6);
     }
 
     @RepeatedTest(10)
-    public void testSentencesWithCount() {
+    void testSentencesWithCount() {
         String paragraph = faker.lorem().paragraph(1);
         int matches = StringUtils.countMatches(paragraph, ".");
         assertThat(matches).isBetween(1, 3);

--- a/src/test/java/net/datafaker/MarketingTest.java
+++ b/src/test/java/net/datafaker/MarketingTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MarketingTest extends AbstractFakerTest {
+class MarketingTest extends AbstractFakerTest {
 
     @Test
-    public void buzzwords() {
+    void buzzwords() {
         assertThat(faker.marketing().buzzwords()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/MatzTest.java
+++ b/src/test/java/net/datafaker/MatzTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MatzTest extends AbstractFakerTest {
+class MatzTest extends AbstractFakerTest {
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.matz().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/MedicalTest.java
+++ b/src/test/java/net/datafaker/MedicalTest.java
@@ -7,30 +7,30 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MedicalTest extends AbstractFakerTest {
+class MedicalTest extends AbstractFakerTest {
 
     @Test
-    public void testMedicineName() {
+    void testMedicineName() {
         assertThat(faker.medical().medicineName()).isNotEmpty();
     }
 
     @Test
-    public void testDiseaseName() {
+    void testDiseaseName() {
         assertThat(faker.medical().diseaseName()).isNotEmpty();
     }
 
     @Test
-    public void testHospitalName() {
+    void testHospitalName() {
         assertThat(faker.medical().hospitalName()).isNotEmpty();
     }
 
     @Test
-    public void testSymptom() {
+    void testSymptom() {
         assertThat(faker.medical().symptoms()).isNotEmpty();
     }
 
     @Test
-    public void testDiagnosisCodeUS() {
+    void testDiagnosisCodeUS() {
         // will use icd-10-cm - https://www.johndcook.com/blog/2019/05/05/regex_icd_codes/
         Faker faker = new Faker(Locale.US);
 
@@ -41,7 +41,7 @@ public class MedicalTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testDiagnosisCodeAU() {
+    void testDiagnosisCodeAU() {
         // will use icd-10-am - https://ace.ihpa.gov.au/Downloads/Current/ICD-10-AM-ACHI-ACS%2011th%20Edition/Education/11th%20Edition%20PDF%20files/Coding-Exercise-Workbook-Eleventh-Edition%20V2-15%20Jun%202019.pdf
         Faker faker = new Faker(new Locale("en", "au"));
 
@@ -50,7 +50,7 @@ public class MedicalTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testDiagnosisCodeNotAustraliaNorUS() {
+    void testDiagnosisCodeNotAustraliaNorUS() {
         // will use icd-10 - variation of https://regexlib.com/REDetails.aspx?regexp_id=2276&AspxAutoDetectCookieSupport=1
         Faker faker = new Faker(Locale.FRANCE);
 
@@ -59,7 +59,7 @@ public class MedicalTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testProcedureCodes() {
+    void testProcedureCodes() {
         // will use icd-10-pcs - https://regex101.com/library/nJ1wC4
         String procedureCode = faker.medical().procedureCode();
         assertThat(procedureCode).matches("^[a-hj-np-zA-HJ-NP-Z0-9]{7}$");

--- a/src/test/java/net/datafaker/MilitaryTest.java
+++ b/src/test/java/net/datafaker/MilitaryTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MilitaryTest extends AbstractFakerTest {
+class MilitaryTest extends AbstractFakerTest {
 
     @Test
-    public void armyRank() {
+    void armyRank() {
         assertThat(faker.military().armyRank()).isNotEmpty();
     }
 
     @Test
-    public void marinesRank() {
+    void marinesRank() {
         assertThat(faker.military().marinesRank()).isNotEmpty();
     }
 
     @Test
-    public void navyRank() {
+    void navyRank() {
         assertThat(faker.military().navyRank()).isNotEmpty();
     }
 
     @Test
-    public void airForceRank() {
+    void airForceRank() {
         assertThat(faker.military().airForceRank()).isNotEmpty();
     }
 
     @Test
-    public void dodPaygrade() {
+    void dodPaygrade() {
         assertThat(faker.military().dodPaygrade()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/MinecraftTest.java
+++ b/src/test/java/net/datafaker/MinecraftTest.java
@@ -4,35 +4,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MinecraftTest extends AbstractFakerTest {
+class MinecraftTest extends AbstractFakerTest {
 
     @Test
-    public void testItemName() {
+    void testItemName() {
         assertThat(faker.minecraft().itemName()).matches("([\\w'()]+\\.?( )?){2,4}");
     }
 
     @Test
-    public void testTileName() {
+    void testTileName() {
         assertThat(faker.minecraft().tileName()).matches("([\\w'()]+\\.?( )?){2,5}");
     }
 
     @Test
-    public void testEntityName() {
+    void testEntityName() {
         assertThat(faker.minecraft().entityName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    public void testMonsterName() {
+    void testMonsterName() {
         assertThat(faker.minecraft().monsterName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    public void testAnimalName() {
+    void testAnimalName() {
         assertThat(faker.minecraft().animalName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    public void testTileItemName() {
+    void testTileItemName() {
         assertThat(faker.minecraft().tileItemName()).matches("([\\w()']+\\.?( )?){2,5}");
     }
 

--- a/src/test/java/net/datafaker/MoodTest.java
+++ b/src/test/java/net/datafaker/MoodTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MoodTest extends AbstractFakerTest {
+class MoodTest extends AbstractFakerTest {
 
     @Test
-    public void feeling() {
+    void feeling() {
         assertThat(faker.mood().feeling()).matches("[a-zA-Z]+");
     }
 
     @Test
-    public void emotion() {
+    void emotion() {
         assertThat(faker.mood().emotion()).matches("[a-zA-Z]+");
     }
 
     @Test
-    public void tone() {
+    void tone() {
         assertThat(faker.mood().tone()).matches("[a-zA-Z]+");
     }
 

--- a/src/test/java/net/datafaker/MountainTest.java
+++ b/src/test/java/net/datafaker/MountainTest.java
@@ -4,16 +4,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MountainTest extends AbstractFakerTest {
+class MountainTest extends AbstractFakerTest {
 
     @Test
-    public void testMountainName() {
+    void testMountainName() {
         String mountainName = faker.mountain().name();
         assertThat(mountainName).isNotEmpty();
     }
 
     @Test
-    public void testMountainLeague() {
+    void testMountainLeague() {
         String mountainLeague = faker.mountain().range();
         assertThat(mountainLeague).isNotEmpty();
     }

--- a/src/test/java/net/datafaker/MountaineeringTest.java
+++ b/src/test/java/net/datafaker/MountaineeringTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MountaineeringTest extends AbstractFakerTest {
+class MountaineeringTest extends AbstractFakerTest {
 
     @Test
-    public void mountaineer() {
+    void mountaineer() {
         assertThat(faker.mountaineering().mountaineer()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/MusicTest.java
+++ b/src/test/java/net/datafaker/MusicTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MusicTest extends AbstractFakerTest {
+class MusicTest extends AbstractFakerTest {
 
     @Test
-    public void instrument() {
+    void instrument() {
         assertThat(faker.music().instrument()).matches("\\w+ ?\\w+");
     }
 
     @Test
-    public void key() {
+    void key() {
         assertThat(faker.music().key()).matches("([A-Z])+([b#])?");
     }
 
     @Test
-    public void chord() {
+    void chord() {
         assertThat(faker.music().chord()).matches("([A-Z])+([b#])?+(-?[a-zA-Z0-9]{0,4})");
     }
 
     @Test
-    public void genre() {
+    void genre() {
         assertThat(faker.music().genre()).matches("[[ -]?\\w+]+");
     }
 }

--- a/src/test/java/net/datafaker/NameTest.java
+++ b/src/test/java/net/datafaker/NameTest.java
@@ -10,23 +10,23 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 
-public class NameTest extends AbstractFakerTest {
+class NameTest extends AbstractFakerTest {
 
     @Spy
     private Faker mockedFaker;
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.name().name()).matches("([\\w']+\\.?( )?){2,3}");
     }
 
     @Test
-    public void testNameWithMiddle() {
+    void testNameWithMiddle() {
         assertThat(faker.name().nameWithMiddle()).matches("([\\w']+\\.?( )?){3,4}");
     }
 
     @Test
-    public void testNameWithMiddleDoesNotHaveRepeatedName() {
+    void testNameWithMiddleDoesNotHaveRepeatedName() {
         int theSameNameCnt = 0;
         int total = 100;
         for (int i = 0; i < total; i++) {
@@ -40,12 +40,12 @@ public class NameTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testFullName() {
+    void testFullName() {
         assertThat(faker.name().fullName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    public void testFullNameArabic() {
+    void testFullNameArabic() {
         Faker localFaker = new Faker(new Locale("ar"));
 
         for (int i = 0; i < 25; i++) {
@@ -54,37 +54,37 @@ public class NameTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testFirstName() {
+    void testFirstName() {
         assertThat(faker.name().firstName()).matches("\\w+");
     }
 
     @Test
-    public void testLastName() {
+    void testLastName() {
         assertThat(faker.name().lastName()).matches("[A-Za-z']+");
     }
 
     @Test
-    public void testPrefix() {
+    void testPrefix() {
         assertThat(faker.name().prefix()).matches("\\w+\\.?");
     }
 
     @Test
-    public void testSuffix() {
+    void testSuffix() {
         assertThat(faker.name().suffix()).matches("\\w+\\.?");
     }
 
     @Test
-    public void testTitle() {
+    void testTitle() {
         assertThat(faker.name().title()).matches("(\\w+\\.?( )?){3}");
     }
 
     @RepeatedTest(100)
-    public void testUsername() {
+    void testUsername() {
         assertThat(faker.name().username()).matches("^(\\w+)\\.(\\w+)$");
     }
 
     @Test
-    public void testUsernameWithSpaces() {
+    void testUsernameWithSpaces() {
         final Name name = Mockito.spy(new Name(mockedFaker));
         doReturn("Compound Name").when(name).firstName();
         doReturn(name).when(mockedFaker).name();
@@ -92,7 +92,7 @@ public class NameTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testBloodGroup() {
+    void testBloodGroup() {
         assertThat(faker.name().bloodGroup()).matches("(A|B|AB|O)[+-]");
     }
 

--- a/src/test/java/net/datafaker/NationTest.java
+++ b/src/test/java/net/datafaker/NationTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NationTest extends AbstractFakerTest {
+class NationTest extends AbstractFakerTest {
 
     @Test
-    public void nationality() {
+    void nationality() {
         assertThat(faker.nation().nationality()).matches("\\P{Cc}+");
     }
 
     @Test
-    public void language() {
+    void language() {
         assertThat(faker.nation().language()).matches("[A-Za-z ]+");
     }
 
     @Test
-    public void capitalCity() {
+    void capitalCity() {
         assertThat(faker.nation().capitalCity()).matches("[A-Za-z .'()-]+");
     }
 
     @Test
-    public void flag() {
+    void flag() {
         String flag = faker.nation().flag();
 
         // all utf8 emoji flags are at least 4 characters long and start with the same char
@@ -31,12 +31,12 @@ public class NationTest extends AbstractFakerTest {
     }
 
     @Test
-    public void isoLanguage() {
+    void isoLanguage() {
         assertThat(faker.nation().isoLanguage()).matches("[a-z]{2}");
     }
 
     @Test
-    public void isoCountry() {
+    void isoCountry() {
         assertThat(faker.nation().isoCountry()).matches("[A-Z]{2}");
     }
 }

--- a/src/test/java/net/datafaker/NatoPhoneticAlphabetTest.java
+++ b/src/test/java/net/datafaker/NatoPhoneticAlphabetTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NatoPhoneticAlphabetTest extends AbstractFakerTest {
+class NatoPhoneticAlphabetTest extends AbstractFakerTest {
 
     @Test
-    public void codeWord() {
+    void codeWord() {
         assertThat(faker.natoPhoneticAlphabet().codeWord()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/NigeriaTest.java
+++ b/src/test/java/net/datafaker/NigeriaTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NigeriaTest extends AbstractFakerTest {
 
     @Test
-    public void places() {
+    void places() {
         assertThat(faker.nigeria().places()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/NumberTest.java
+++ b/src/test/java/net/datafaker/NumberTest.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NumberTest extends AbstractFakerTest {
+class NumberTest extends AbstractFakerTest {
 
     public static final int RANDOMIZATION_QUALITY_RANGE_END = 1000;
     public static final int RANDOMIZATION_QUALITY_RANGE_STEP = 25;
@@ -29,7 +29,7 @@ public class NumberTest extends AbstractFakerTest {
     final double percentRunsGtUniquePercentage = 0.90;
 
     @Test
-    public void testRandomDigit() {
+    void testRandomDigit() {
         Set<Integer> nums = new HashSet<>();
         for (int i = 0; i < 1000; ++i) {
             int value = faker.number().randomDigit();
@@ -41,7 +41,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testRandomDigitNotZero() {
+    void testRandomDigitNotZero() {
         Set<Integer> nums = new HashSet<>();
         for (int i = 0; i < 1000; ++i) {
             int value = faker.number().randomDigitNotZero();
@@ -53,13 +53,13 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testRandomNumber() {
+    void testRandomNumber() {
         long value = faker.number().randomNumber();
         assertThat(value).isLessThan(Long.MAX_VALUE);
     }
 
     @Test
-    public void testRandomNumberWithSingleDigitStrict() {
+    void testRandomNumberWithSingleDigitStrict() {
         for (int i = 0; i < 100; ++i) {
             long value = faker.number().randomNumber(1, true);
             assertThat(value).isLessThan(10L);
@@ -68,7 +68,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testRandomNumberWithZeroDigitsStrict() {
+    void testRandomNumberWithZeroDigitsStrict() {
         for (int i = 0; i < 100; ++i) {
             long value = faker.number().randomNumber(0, true);
             assertThat(value).isEqualTo(0L);
@@ -76,7 +76,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testRandomNumberWithGivenDigitsStrict() {
+    void testRandomNumberWithGivenDigitsStrict() {
         for (int i = 1; i < 9; ++i) {
             for (int x = 0; x < 100; ++x) {
                 long value = faker.number().randomNumber(i, true);
@@ -87,7 +87,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testRandomDouble() {
+    void testRandomDouble() {
         for (int i = 1; i < 5; ++i) {
             for (int x = 0; x < 100; ++x) {
                 double value = faker.number().randomDouble(i, 1, 1000);
@@ -101,7 +101,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNumberBetween() {
+    void testNumberBetween() {
         for (int i = 1; i < 100; ++i) {
             int v = faker.number().numberBetween(0, i);
             assertThat(v).isLessThanOrEqualTo(i);
@@ -121,7 +121,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testLongNumberBetweenRepeated() {
+    void testLongNumberBetweenRepeated() {
         long low = 1;
         long high = 10;
         long v = faker.number().numberBetween(low, high);
@@ -130,7 +130,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testIntNumberBetweenRepeated() {
+    void testIntNumberBetweenRepeated() {
         int low = 1;
         int high = 10;
         int v = faker.number().numberBetween(low, high);
@@ -139,7 +139,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNumberBetweenOneAndThree() {
+    void testNumberBetweenOneAndThree() {
         Set<Integer> nums = new HashSet<>();
         final int lowerLimit = 0;
         final int upperLimit = 3;
@@ -153,7 +153,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testLongBetweenOneAndThree() {
+    void testLongBetweenOneAndThree() {
         Set<Long> nums = new HashSet<>();
         final long lowerLimit = 0;
         final long upperLimit = 3;
@@ -167,7 +167,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void numberBetweenIntIntZeroMinMax() {
+    void numberBetweenIntIntZeroMinMax() {
         assertThat(faker.number().numberBetween(0, 0))
             .as("Calling numberBetween with min==max yields min, with 0")
             .isEqualTo(0);
@@ -177,7 +177,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void numberBetweenLongLongZeroMinMax() {
+    void numberBetweenLongLongZeroMinMax() {
         assertThat(faker.number().numberBetween(0L, 0L))
             .as("Calling numberBetween with min==max yields min, with 0")
             .isEqualTo(0);
@@ -196,7 +196,7 @@ public class NumberTest extends AbstractFakerTest {
      * This isn't perfect but it ensures a pretty good degree of uniqueness in the random number generation.
      */
     @Test
-    public void randomDoubleRandomizationQuality() {
+    void randomDoubleRandomizationQuality() {
         Function<Pair<Long, Long>, Double> minMaxRangeToUniquePercentageFunction = minMax -> {
             final int min = minMax.getLeft().intValue(), max = minMax.getRight().intValue();
             long numbersToGet = calculateNumbersToGet(min, max);
@@ -223,7 +223,7 @@ public class NumberTest extends AbstractFakerTest {
      * This isn't perfect but it ensures a pretty good degree of uniqueness in the random number generation.
      */
     @Test
-    public void numberBetweenIntIntRandomizationQuality() {
+    void numberBetweenIntIntRandomizationQuality() {
         Function<Pair<Long, Long>, Double> minMaxRangeToUniquePercentageFunction = minMax -> {
             final int min = minMax.getLeft().intValue();
             final int max = minMax.getRight().intValue();
@@ -251,7 +251,7 @@ public class NumberTest extends AbstractFakerTest {
      * This isn't perfect but it ensures a pretty good degree of uniqueness in the random number generation.
      */
     @Test
-    public void numberBetweenLongLongRandomizationQuality() {
+    void numberBetweenLongLongRandomizationQuality() {
         Function<Pair<Long, Long>, Double> minMaxRangeToUniquePercentageFunction = minMax -> {
             final long min = minMax.getLeft(), max = minMax.getRight();
             long numbersToGet = calculateNumbersToGet(min, max);
@@ -269,7 +269,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testRandomDoubleMaxEqualsMin() {
+    void testRandomDoubleMaxEqualsMin() {
         double actual = faker.number().randomDouble(1, 42, 42);
 
         double expected = BigDecimal.valueOf(42).doubleValue();
@@ -278,14 +278,14 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testDigit() {
+    void testDigit() {
         String digit = faker.number().digit();
 
         assertThat(digit).matches("[0-9]");
     }
 
     @Test
-    public void testDigits() {
+    void testDigits() {
         String digits = faker.number().digits(5);
 
         assertThat(digits).matches("[0-9]{5}");
@@ -346,7 +346,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testIntNumberBetweenQuality() {
+    void testIntNumberBetweenQuality() {
         //test whether the fake number made by numberBetween(int min, int max)
         // is not randomly and evenly distributed
         // (The difference between the average is less than 10%)
@@ -369,7 +369,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testLongNumberBetweenQuality() {
+    void testLongNumberBetweenQuality() {
         //test whether the fake number made by numberBetween(long min, long max)
         // is not randomly and evenly distributed
         // (The difference between the average is less than 10%)
@@ -393,7 +393,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNumberBetweenContain() {
+    void testNumberBetweenContain() {
 
         Set<Integer> ints = new HashSet<>();
         Set<Long> longs = new HashSet<>();
@@ -428,7 +428,7 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNumberBetweenBorder() {
+    void testNumberBetweenBorder() {
 
         Random random = new Random();
 
@@ -452,12 +452,12 @@ public class NumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void testPositive() {
+    void testPositive() {
         assertThat(faker.number().positive()).isGreaterThan(0);
     }
 
     @RepeatedTest(10)
-    public void testNegative() {
+    void testNegative() {
         assertThat(faker.number().negative()).isLessThan(0);
 
     }

--- a/src/test/java/net/datafaker/OscarMovieTest.java
+++ b/src/test/java/net/datafaker/OscarMovieTest.java
@@ -6,32 +6,32 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Strings.isNullOrEmpty;
 
-public class OscarMovieTest extends AbstractFakerTest {
+class OscarMovieTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
-    public void actor() {
+    void actor() {
         assertThat(faker.oscarMovie().actor())
             .is(CONDITION_FUNCTION.apply(c -> Character.isLetter(c) || c == ' ' || c == '.' || c == '-' || c == '(' || c == ')' || c == '\''));
     }
 
     @Test
-    public void movieName() {
+    void movieName() {
         assertThat(isNullOrEmpty(faker.oscarMovie().movieName())).isFalse();
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(isNullOrEmpty(faker.oscarMovie().quote())).isFalse();
     }
 
     @RepeatedTest(100)
-    public void character() {
+    void character() {
         assertThat(faker.oscarMovie().character())
             .is(CONDITION_FUNCTION.apply(c -> Character.isLetter(c) || c == ' ' || c == '.' || c == '-' || c == '\''));
     }
 
     @RepeatedTest(100)
-    public void releaseDate() {
+    void releaseDate() {
         assertThat(faker.oscarMovie().releaseDate()).matches("[A-Za-z,0-9 ]+");
     }
 }

--- a/src/test/java/net/datafaker/OverwatchTest.java
+++ b/src/test/java/net/datafaker/OverwatchTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OverwatchTest extends AbstractFakerTest {
+class OverwatchTest extends AbstractFakerTest {
 
     @Test
-    public void hero() {
+    void hero() {
         assertThat(faker.overwatch().hero()).matches("^(\\w+\\.?\\s?)+$");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.overwatch().location()).matches("^(.+'?:?\\s?)+$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.overwatch().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/PassportTest.java
+++ b/src/test/java/net/datafaker/PassportTest.java
@@ -8,10 +8,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author CharlotteE67
  */
-public class PassportTest extends AbstractFakerTest {
+class PassportTest extends AbstractFakerTest {
 
     @Test
-    public void testChValid() {
+    void testChValid() {
         String passport = faker.passport().chValid();
         assertThat(passport.charAt(0) == 'E' || passport.charAt(0) == 'G').isTrue();
         if (passport.charAt(0) == 'G') {
@@ -28,48 +28,48 @@ public class PassportTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testChValidLength() {
+    void testChValidLength() {
         assertThat(faker.passport().chValid()).hasSize(9);
     }
 
     @Test
-    public void testChInValid() {
+    void testChInValid() {
         assertThat(faker.passport().chInvalid().matches("E[0-9A-HJ-NP-Z][0-9]{7}")
             && faker.passport().chInvalid().matches("G[0-9]{8}")).isFalse();
     }
 
     @Test
-    public void testChInValidNotNull() {
+    void testChInValidNotNull() {
         assertThat(faker.passport().chInvalid()).isNotNull();
     }
 
     @Test
-    public void testAmValid() {
+    void testAmValid() {
         assertThat(faker.passport().amValid().matches("[0-9]{8}")).isTrue();
     }
 
     @Test
-    public void testAmValidLength() {
+    void testAmValidLength() {
         assertThat(faker.passport().amValid()).hasSize(8);
     }
 
     @Test
-    public void testAmInValid() {
+    void testAmInValid() {
         assertThat(faker.passport().amInvalid().matches("[0-9]{8}")).isFalse();
     }
 
     @Test
-    public void testAmInValidNotNull() {
+    void testAmInValidNotNull() {
         assertThat(faker.passport().amInvalid()).isNotNull();
     }
 
     @RepeatedTest(100)
-    public void testChValidFrequently() {
+    void testChValidFrequently() {
         testChValid();
     }
 
     @RepeatedTest(100)
-    public void testChInValidFrequently() {
+    void testChInValidFrequently() {
         testChInValid();
     }
 }

--- a/src/test/java/net/datafaker/PhoneNumberTest.java
+++ b/src/test/java/net/datafaker/PhoneNumberTest.java
@@ -10,7 +10,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PhoneNumberTest extends AbstractFakerTest {
+class PhoneNumberTest extends AbstractFakerTest {
     private static final Faker US_FAKER = new Faker(new Locale("en_US"));
     private static final Faker SE_FAKER = new Faker(new Locale("sv_SE"));
     private static final Faker CZ_FAKER = new Faker(new Locale("cs_CZ"));
@@ -21,7 +21,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
     private final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
 
     @Test
-    public void testCellPhone_enUS() {
+    void testCellPhone_enUS() {
         final Faker f = new Faker(Locale.US);
         String cellPhone = f.phoneNumber().cellPhone();
         assertThat(cellPhone).matches("\\(?\\d+\\)?([- .]\\d+){1,3}");
@@ -29,7 +29,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
 
 
     @RepeatedTest(100)
-    public void testAllCellPhone_enUS() throws NumberParseException {
+    void testAllCellPhone_enUS() throws NumberParseException {
         String phoneNumber = US_FAKER.phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "US");
         assertThat(util.isValidNumberForRegion(proto, "US")).as(phoneNumber).isTrue();
@@ -37,7 +37,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
 
 
     @RepeatedTest(100)
-    public void testAllCellPhone_svSE() throws NumberParseException {
+    void testAllCellPhone_svSE() throws NumberParseException {
         String phoneNumber = SE_FAKER.phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "SE");
         assertThat(util.isValidNumberForRegion(proto, "SE")).as(phoneNumber).isTrue();
@@ -45,7 +45,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
 
 
     @RepeatedTest(100)
-    public void testAllCellPhone_csCZ() throws NumberParseException {
+    void testAllCellPhone_csCZ() throws NumberParseException {
         String phoneNumber = CZ_FAKER.phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "CZ");
         assertThat(util.isValidNumberForRegion(proto, "CZ")).as(phoneNumber).isTrue();
@@ -53,7 +53,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
 
 
     @Test
-    public void testAllCellPhone_enGB() throws NumberParseException {
+    void testAllCellPhone_enGB() throws NumberParseException {
 
         int errorCount = 0;
         for (int i = 0; i < 100; i++) {
@@ -70,7 +70,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
 
 
     @Test
-    public void testAllCellPhone_nbNO() throws NumberParseException {
+    void testAllCellPhone_nbNO() throws NumberParseException {
         int errorCount = 0;
 
         for (int i = 0; i < 1000; i++) {
@@ -88,14 +88,14 @@ public class PhoneNumberTest extends AbstractFakerTest {
 
 
     @RepeatedTest(100)
-    public void testAllCellPhone_nl() throws NumberParseException {
+    void testAllCellPhone_nl() throws NumberParseException {
         String phoneNumber = NL_FAKER.phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "NL");
         assertThat(util.isValidNumberForRegion(proto, "NL")).as(phoneNumber).isTrue();
     }
 
     @Test
-    public void testPhone_esMx() {
+    void testPhone_esMx() {
         final Faker f = new Faker(new Locale("es_MX"));
         for (int i = 0; i < 100; i++) {
             assertThat(f.phoneNumber().cellPhone()).matches("(044 )?\\(?\\d+\\)?([- .]\\d+){1,3}");
@@ -104,7 +104,7 @@ public class PhoneNumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testPhone_CA() {
+    void testPhone_CA() {
         final Locale[] locales = new Locale[]{Locale.CANADA, new Locale("ca")};
         for (Locale locale : locales) {
             final Faker f = new Faker(locale);
@@ -120,27 +120,27 @@ public class PhoneNumberTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testCellPhone() {
+    void testCellPhone() {
         assertThat(faker.phoneNumber().cellPhone()).matches("\\(?\\d+\\)?([- .]\\d+){1,3}");
     }
 
     @Test
-    public void testPhoneNumber() {
+    void testPhoneNumber() {
         assertThat(faker.phoneNumber().phoneNumber()).matches("\\(?\\d+\\)?([- .]x?\\d+){1,5}");
     }
 
     @Test
-    public void testExtension() {
+    void testExtension() {
         assertThat(faker.phoneNumber().extension()).matches("\\d{4}");
     }
 
     @Test
-    public void testSubscriberNumber() {
+    void testSubscriberNumber() {
         assertThat(faker.phoneNumber().subscriberNumber()).matches("\\d{4}");
     }
 
     @Test
-    public void testSubscriberNumberWithLength() {
+    void testSubscriberNumberWithLength() {
         assertThat(faker.phoneNumber().subscriberNumber(10)).matches("\\d{10}");
     }
 }

--- a/src/test/java/net/datafaker/PhoneNumberValidityFinderTest.java
+++ b/src/test/java/net/datafaker/PhoneNumberValidityFinderTest.java
@@ -14,10 +14,10 @@ import java.util.Map;
 /**
  * These tests use System.out.printlns because the error rate is quite high.
  */
-public class PhoneNumberValidityFinderTest {
+class PhoneNumberValidityFinderTest {
 
     @Test
-    public void testAllCellPhoneForLocale() throws NumberParseException {
+    void testAllCellPhoneForLocale() throws NumberParseException {
         String language = "en";
         String region = "GB";
         Faker localFaker = new Faker(new Locale(language, region));
@@ -40,7 +40,7 @@ public class PhoneNumberValidityFinderTest {
     }
 
     @Test
-    public void testValidNumber() throws NumberParseException {
+    void testValidNumber() throws NumberParseException {
         String phoneNumber = "0140 123456";
         String region = "SE";
 
@@ -50,7 +50,7 @@ public class PhoneNumberValidityFinderTest {
     }
 
     @Test
-    public void testAllPhoneNumbers() {
+    void testAllPhoneNumbers() {
         List<String> allSupportedLocales = new LocalePicker().getAllSupportedLocales();
         Map<Locale, Integer> errorCounts = new HashMap<>();
 

--- a/src/test/java/net/datafaker/PhotographyTest.java
+++ b/src/test/java/net/datafaker/PhotographyTest.java
@@ -5,58 +5,58 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PhotographyTest extends AbstractFakerTest {
+class PhotographyTest extends AbstractFakerTest {
 
     @Test
-    public void testAperture() {
+    void testAperture() {
         final String value = faker.photography().aperture();
         assertThat(value).startsWith("f");
     }
 
     @Test
-    public void testTerm() {
+    void testTerm() {
         final String value = faker.photography().term();
         assertNonNullOrEmpty(value);
     }
 
     @Test
-    public void brand() {
+    void brand() {
         final String value = faker.photography().brand();
         assertNonNullOrEmpty(value);
     }
 
     @Test
-    public void camera() {
+    void camera() {
         final String value = faker.photography().camera();
         assertNonNullOrEmpty(value);
     }
 
     @Test
-    public void lens() {
+    void lens() {
         final String value = faker.photography().lens();
         assertNonNullOrEmpty(value);
     }
 
     @Test
-    public void genre() {
+    void genre() {
         final String value = faker.photography().genre();
         assertNonNullOrEmpty(value);
     }
 
     @Test
-    public void imageTag() {
+    void imageTag() {
         final String value = faker.photography().imageTag();
         assertNonNullOrEmpty(value);
     }
 
     @RepeatedTest(7)
-    public void shutter() {
+    void shutter() {
         final String value = faker.photography().shutter();
         assertThat(value).matches("\\d+/?\\d*");
     }
 
     @RepeatedTest(7)
-    public void iso() {
+    void iso() {
         final String value = faker.photography().iso();
         assertThat(value).matches("\\d+");
     }

--- a/src/test/java/net/datafaker/PokemonTest.java
+++ b/src/test/java/net/datafaker/PokemonTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PokemonTest extends AbstractFakerTest {
+class PokemonTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.pokemon().name()).matches("[\\w']+.?( \\w+)?");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.pokemon().location()).matches("\\w+( \\w+)?( \\w+)?");
     }
 }

--- a/src/test/java/net/datafaker/PrincessBrideTest.java
+++ b/src/test/java/net/datafaker/PrincessBrideTest.java
@@ -4,14 +4,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PrincessBrideTest extends AbstractFakerTest {
+class PrincessBrideTest extends AbstractFakerTest {
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.princessBride().character()).matches("[A-Za-z .-]+");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.princessBride().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/ProgrammingLanguageTest.java
+++ b/src/test/java/net/datafaker/ProgrammingLanguageTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProgrammingLanguageTest extends AbstractFakerTest {
+class ProgrammingLanguageTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.programmingLanguage().name()).matches("[A-Za-z0-9 :,.+*()#/–\\-@πéöü'′!]+");
     }
 
     @Test
-    public void creator() {
+    void creator() {
         assertThat(faker.programmingLanguage().creator()).matches("[A-Za-z .,\\-]+");
     }
 }

--- a/src/test/java/net/datafaker/RandomFakerTest.java
+++ b/src/test/java/net/datafaker/RandomFakerTest.java
@@ -7,7 +7,7 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RandomFakerTest extends AbstractFakerTest {
+class RandomFakerTest extends AbstractFakerTest {
 
     private static final int CONSTANT_SEED_VALUE = 10;
     private Faker faker;
@@ -21,7 +21,7 @@ public class RandomFakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNumerifyRandomnessCanBeControlled() {
+    void testNumerifyRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.numerify("###");
 
@@ -31,7 +31,7 @@ public class RandomFakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testLetterifyRandomnessCanBeControlled() {
+    void testLetterifyRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.letterify("???");
 
@@ -41,7 +41,7 @@ public class RandomFakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testNameRandomnessCanBeControlled() {
+    void testNameRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.name().name();
 
@@ -51,7 +51,7 @@ public class RandomFakerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testEmailRandomnessCanBeControlled() {
+    void testEmailRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.internet().emailAddress();
 

--- a/src/test/java/net/datafaker/RelationshipTest.java
+++ b/src/test/java/net/datafaker/RelationshipTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-public class RelationshipTest extends AbstractFakerTest {
+class RelationshipTest extends AbstractFakerTest {
 
     private Faker mockFaker;
 
@@ -22,56 +22,56 @@ public class RelationshipTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void anyTest() {
+    void anyTest() {
         assertThat(faker.relationships().any()).isNotEmpty();
     }
 
     @Test
-    public void directTest() {
+    void directTest() {
         assertThat(faker.relationships().direct()).isNotEmpty();
     }
 
     @Test
-    public void extendedTest() {
+    void extendedTest() {
         assertThat(faker.relationships().extended()).isNotEmpty();
     }
 
     @Test
-    public void inLawTest() {
+    void inLawTest() {
         assertThat(faker.relationships().inLaw()).isNotEmpty();
     }
 
     @Test
-    public void spouseTest() {
+    void spouseTest() {
         assertThat(faker.relationships().spouse()).isNotEmpty();
     }
 
     @Test
-    public void parentTest() {
+    void parentTest() {
         assertThat(faker.relationships().parent()).isNotEmpty();
     }
 
     @Test
-    public void siblingTest() {
+    void siblingTest() {
         assertThat(faker.relationships().sibling()).isNotEmpty();
     }
 
     @Test
-    public void anyWithIllegalArgumentExceptionThrown() {
+    void anyWithIllegalArgumentExceptionThrown() {
         when(mockFaker.random()).thenThrow(new IllegalArgumentException());
         assertThatThrownBy(() -> new Relationship(mockFaker).any())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void anyWithSecurityExceptionThrown() {
+    void anyWithSecurityExceptionThrown() {
         when(mockFaker.random()).thenThrow(new SecurityException());
         assertThatThrownBy(() -> new Relationship(mockFaker).any())
             .isInstanceOf(SecurityException.class);
     }
 
     @Test
-    public void anyWithIllegalAccessExceptionThrown() {
+    void anyWithIllegalAccessExceptionThrown() {
         when(mockFaker.random()).then(invocationOnMock -> {
             throw new IllegalAccessException();
         });
@@ -81,7 +81,7 @@ public class RelationshipTest extends AbstractFakerTest {
     }
 
     @Test
-    public void anyWithInvocationTargetExceptionThrown() {
+    void anyWithInvocationTargetExceptionThrown() {
         when(mockFaker.random()).then(invocationOnMock -> {
             throw new InvocationTargetException(new Exception());
         });

--- a/src/test/java/net/datafaker/ResidentEvilTest.java
+++ b/src/test/java/net/datafaker/ResidentEvilTest.java
@@ -4,40 +4,40 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ResidentEvilTest extends AbstractFakerTest {
+class ResidentEvilTest extends AbstractFakerTest {
 
     static private final String WORDS_WITH_SPECIAL_CHAR_REGEX = "^(?! )[A-Za-z0-9αγβ'.()\\- ]*(?<! )$";
 
     @Test
-    public void testCharacter() {
+    void testCharacter() {
         String character = faker.residentEvil().character();
         assertThat(character).isNotEmpty();
         assertThat(character).matches(WORDS_WITH_SPECIAL_CHAR_REGEX);
     }
 
     @Test
-    public void testBiologicalAgent() {
+    void testBiologicalAgent() {
         String biologicalAgent = faker.residentEvil().biologicalAgent();
         assertThat(biologicalAgent).isNotEmpty();
         assertThat(biologicalAgent).matches(WORDS_WITH_SPECIAL_CHAR_REGEX);
     }
 
     @Test
-    public void testEquipment() {
+    void testEquipment() {
         String equipment = faker.residentEvil().equipment();
         assertThat(equipment).isNotEmpty();
         assertThat(equipment).matches(WORDS_WITH_SPECIAL_CHAR_REGEX);
     }
 
     @Test
-    public void testLocation() {
+    void testLocation() {
         String location = faker.residentEvil().location();
         assertThat(location).isNotEmpty();
         assertThat(location).matches(WORDS_WITH_SPECIAL_CHAR_REGEX);
     }
 
     @Test
-    public void testCreature() {
+    void testCreature() {
         String creature = faker.residentEvil().creature();
         assertThat(creature).isNotEmpty();
         assertThat(creature).matches(WORDS_WITH_SPECIAL_CHAR_REGEX);

--- a/src/test/java/net/datafaker/RestaurantTest.java
+++ b/src/test/java/net/datafaker/RestaurantTest.java
@@ -4,35 +4,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RestaurantTest extends AbstractFakerTest {
+class RestaurantTest extends AbstractFakerTest {
 
     @Test
-    public void namePrefix() {
+    void namePrefix() {
         assertThat(faker.restaurant().namePrefix()).isNotEmpty();
     }
 
     @Test
-    public void nameSuffix() {
+    void nameSuffix() {
         assertThat(faker.restaurant().nameSuffix()).isNotEmpty();
     }
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.restaurant().name()).isNotEmpty();
     }
 
     @Test
-    public void type() {
+    void type() {
         assertThat(faker.restaurant().type()).isNotEmpty();
     }
 
     @Test
-    public void description() {
+    void description() {
         assertThat(faker.restaurant().description()).isNotEmpty();
     }
 
     @Test
-    public void review() {
+    void review() {
         assertThat(faker.restaurant().review()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/RickAndMortyTest.java
+++ b/src/test/java/net/datafaker/RickAndMortyTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RickAndMortyTest extends AbstractFakerTest {
+class RickAndMortyTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.rickAndMorty().character()).matches("^([\\w'-.]+ ?){2,}$");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.rickAndMorty().location()).matches("^([\\w-.]+ ?){2,}$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.rickAndMorty().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/RobinTest.java
+++ b/src/test/java/net/datafaker/RobinTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RobinTest extends AbstractFakerTest {
+class RobinTest extends AbstractFakerTest {
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.robin().quote()).matches("^(\\w+\\.?-?'?\\s?)+(\\(?)?(\\w+\\s?\\.?)+(\\))?$");
     }
 }

--- a/src/test/java/net/datafaker/RockBandTest.java
+++ b/src/test/java/net/datafaker/RockBandTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RockBandTest extends AbstractFakerTest {
+class RockBandTest extends AbstractFakerTest {
 
     @Test
-    public void name() {
+    void name() {
         assertThat(faker.rockBand().name()).matches("([\\w'/.,&]+ ?)+");
     }
 }

--- a/src/test/java/net/datafaker/RuPaulDragRaceTest.java
+++ b/src/test/java/net/datafaker/RuPaulDragRaceTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RuPaulDragRaceTest extends AbstractFakerTest {
+class RuPaulDragRaceTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
-    public void queens() {
+    void queens() {
         assertThat(faker.ruPaulDragRace().queen()).matches("([\\w'/.,&]+ ?)+");
     }
 
     @RepeatedTest(100)
-    public void quotes() {
+    void quotes() {
         assertThat(faker.ruPaulDragRace().quote()).matches("([\\w'/.,\\-!&?\"]+ ?)+");
     }
 }

--- a/src/test/java/net/datafaker/ScienceTest.java
+++ b/src/test/java/net/datafaker/ScienceTest.java
@@ -4,40 +4,40 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ScienceTest extends AbstractFakerTest {
+class ScienceTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void element() {
+    void element() {
         assertThat(faker.science().element()).matches("[A-Za-z ]+");
     }
 
     @RepeatedTest(10)
-    public void elementSymbol() {
+    void elementSymbol() {
         assertThat(faker.science().elementSymbol()).matches("[A-Za-z]{1,2}");
     }
 
     @RepeatedTest(10)
-    public void scientist() {
+    void scientist() {
         assertThat(faker.science().scientist()).matches("[A-Za-z. -]+");
     }
 
     @RepeatedTest(10)
-    public void tool() {
+    void tool() {
         assertThat(faker.science().tool()).matches("[0-9A-Za-z. -]+");
     }
 
     @RepeatedTest(10)
-    public void quark() {
+    void quark() {
         assertThat(faker.science().quark()).matches("[A-Za-z]+");
     }
 
     @RepeatedTest(10)
-    public void leptons() {
+    void leptons() {
         assertThat(faker.science().leptons()).matches("[A-Za-z ]+");
     }
 
     @RepeatedTest(10)
-    public void bosons() {
+    void bosons() {
         assertThat(faker.science().bosons()).matches("[A-Za-z ]+");
     }
 }

--- a/src/test/java/net/datafaker/SeinfeldTest.java
+++ b/src/test/java/net/datafaker/SeinfeldTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class SeinfeldTest extends AbstractFakerTest {
+class SeinfeldTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.seinfeld().character()).isNotEmpty();
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.seinfeld().quote()).isNotEmpty();
     }
 
     @Test
-    public void business() {
+    void business() {
         assertThat(faker.seinfeld().business()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/ShakespeareTest.java
+++ b/src/test/java/net/datafaker/ShakespeareTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ShakespeareTest extends AbstractFakerTest {
+class ShakespeareTest extends AbstractFakerTest {
 
     @Test
-    public void testHamletQuote() {
+    void testHamletQuote() {
         assertThat(faker.shakespeare().hamletQuote()).isNotEmpty();
     }
 
     @Test
-    public void testAsYouLikeItQuote() {
+    void testAsYouLikeItQuote() {
         assertThat(faker.shakespeare().asYouLikeItQuote()).isNotEmpty();
     }
 
     @Test
-    public void testKingRichardIIIQuote() {
+    void testKingRichardIIIQuote() {
         assertThat(faker.shakespeare().kingRichardIIIQuote()).isNotEmpty();
     }
 
     @Test
-    public void testRomeoAndJulietQuote() {
+    void testRomeoAndJulietQuote() {
         assertThat(faker.shakespeare().romeoAndJulietQuote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/SipTest.java
+++ b/src/test/java/net/datafaker/SipTest.java
@@ -4,92 +4,92 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SipTest extends AbstractFakerTest {
+class SipTest extends AbstractFakerTest {
 
     @Test
-    public void method_returnUpperCaseWithMinimum3Chars() {
+    void method_returnUpperCaseWithMinimum3Chars() {
         assertThat(faker.sip().method()).matches("^[A-Z]{3,}$");
     }
 
     @Test
-    public void contentType_returnLowerCaseTwoWordsSepereatedBySlashMinimum3And4Chars() {
+    void contentType_returnLowerCaseTwoWordsSepereatedBySlashMinimum3And4Chars() {
         assertThat(faker.sip().contentType()).matches("^[a-z]{4,}[/]{1,}[a-z0-9-]{3,}$");
     }
 
     @Test
-    public void messagingPort_return4DigitIntBetween1000And9999() {
+    void messagingPort_return4DigitIntBetween1000And9999() {
         assertThat(faker.sip().messagingPort()).isBetween(1000, 10000);
     }
 
     @Test
-    public void rtpPort_returnPositiveEvenInt() {
+    void rtpPort_returnPositiveEvenInt() {
         int sut = faker.sip().rtpPort();
         assertThat(sut).isGreaterThanOrEqualTo(2);
         assertThat(sut % 2).isEqualTo(0);
     }
 
     @Test
-    public void provisionalResponseCode_return3DigitIntBetween100And199() {
+    void provisionalResponseCode_return3DigitIntBetween100And199() {
         assertThat(faker.sip().provisionalResponseCode()).isBetween(100, 200);
     }
 
     @Test
-    public void successResponse_Codereturn3DigitIntBetween200And299() {
+    void successResponse_Codereturn3DigitIntBetween200And299() {
         assertThat(faker.sip().successResponseCode()).isBetween(200, 300);
     }
 
     @Test
-    public void redirectResponseCode_Codereturn3DigitIntBetween300And399() {
+    void redirectResponseCode_Codereturn3DigitIntBetween300And399() {
         assertThat(faker.sip().redirectResponseCode()).isBetween(300, 400);
     }
 
     @Test
-    public void clientErrorResponseCode_Codereturn3DigitIntBetween400And499() {
+    void clientErrorResponseCode_Codereturn3DigitIntBetween400And499() {
         assertThat(faker.sip().clientErrorResponseCode()).isBetween(400, 500);
     }
 
     @Test
-    public void serverErrorResponseCode_Codereturn3DigitIntBetween500And599() {
+    void serverErrorResponseCode_Codereturn3DigitIntBetween500And599() {
         assertThat(faker.sip().serverErrorResponseCode()).isBetween(500, 600);
     }
 
     @Test
-    public void globalErrorResponseCode_Codereturn3DigitIntBetween600And699() {
+    void globalErrorResponseCode_Codereturn3DigitIntBetween600And699() {
         assertThat(faker.sip().globalErrorResponseCode()).isBetween(600, 700);
     }
 
     @Test
-    public void provisionalResponsePhrase_returnAnyNonDigitString() {
+    void provisionalResponsePhrase_returnAnyNonDigitString() {
         assertThat(faker.sip().provisionalResponsePhrase()).matches("\\D+");
     }
 
     @Test
-    public void successResponsePhrase_returnAnyNonDigitString() {
+    void successResponsePhrase_returnAnyNonDigitString() {
         assertThat(faker.sip().successResponsePhrase()).matches("\\D+");
     }
 
     @Test
-    public void redirectResponsePhrase_returnAnyNonDigitString() {
+    void redirectResponsePhrase_returnAnyNonDigitString() {
         assertThat(faker.sip().redirectResponsePhrase()).matches("\\D+");
     }
 
     @Test
-    public void clientErrorResponsePhrase_returnAnyNonDigitString() {
+    void clientErrorResponsePhrase_returnAnyNonDigitString() {
         assertThat(faker.sip().clientErrorResponsePhrase()).matches("\\D+");
     }
 
     @Test
-    public void serverErrorResponsePhrase_returnAnyNonDigitString() {
+    void serverErrorResponsePhrase_returnAnyNonDigitString() {
         assertThat(faker.sip().serverErrorResponsePhrase()).matches("\\D+");
     }
 
     @Test
-    public void globalErrorResponsePhrase_returnAnyNonDigitString() {
+    void globalErrorResponsePhrase_returnAnyNonDigitString() {
         assertThat(faker.sip().globalErrorResponsePhrase()).matches("\\D+");
     }
 
     @Test
-    public void bodyString_returnAValidSdpBodyString() {
+    void bodyString_returnAValidSdpBodyString() {
         String[] sut = faker.sip().bodyString().split("\n");
 
         assertThat(sut.length).isEqualTo(7);
@@ -118,14 +118,14 @@ public class SipTest extends AbstractFakerTest {
     }
 
     @Test
-    public void bodyBytes_isNotNull() {
+    void bodyBytes_isNotNull() {
         byte[] sut = faker.sip().bodyBytes();
 
         assertThat(sut.length).isNotNull();
     }
 
     @Test
-    public void nameAddress_returnValidNameAddressString() {
+    void nameAddress_returnValidNameAddressString() {
         String[] sut = faker.sip().nameAddress().split("@");
 
         assertThat(sut[0].split(":")[1]).matches("\\w+");

--- a/src/test/java/net/datafaker/SizeTest.java
+++ b/src/test/java/net/datafaker/SizeTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SizeTest extends AbstractFakerTest {
+class SizeTest extends AbstractFakerTest {
 
     @Test
-    public void adjective() {
+    void adjective() {
         assertThat(faker.size().adjective()).matches("[a-zA-Z]+(-[a-zA-Z]+)?");
     }
 }

--- a/src/test/java/net/datafaker/SlackEmojiTest.java
+++ b/src/test/java/net/datafaker/SlackEmojiTest.java
@@ -4,52 +4,52 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SlackEmojiTest extends AbstractFakerTest {
+class SlackEmojiTest extends AbstractFakerTest {
 
     private static final String EMOTICON_REGEX = ":([\\w-]+):";
 
     @Test
-    public void people() {
+    void people() {
         assertThat(faker.slackEmoji().people()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void nature() {
+    void nature() {
         assertThat(faker.slackEmoji().nature()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void food_and_drink() {
+    void food_and_drink() {
         assertThat(faker.slackEmoji().foodAndDrink()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void celebration() {
+    void celebration() {
         assertThat(faker.slackEmoji().celebration()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void activity() {
+    void activity() {
         assertThat(faker.slackEmoji().activity()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void travel_and_places() {
+    void travel_and_places() {
         assertThat(faker.slackEmoji().travelAndPlaces()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void objects_and_symbols() {
+    void objects_and_symbols() {
         assertThat(faker.slackEmoji().objectsAndSymbols()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void custom() {
+    void custom() {
         assertThat(faker.slackEmoji().custom()).matches(EMOTICON_REGEX);
     }
 
     @Test
-    public void emoji() {
+    void emoji() {
         assertThat(faker.slackEmoji().emoji()).matches(EMOTICON_REGEX);
     }
 }

--- a/src/test/java/net/datafaker/SpaceTest.java
+++ b/src/test/java/net/datafaker/SpaceTest.java
@@ -4,70 +4,70 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SpaceTest extends AbstractFakerTest {
+class SpaceTest extends AbstractFakerTest {
 
     @Test
-    public void planet() {
+    void planet() {
         assertThat(faker.space().planet()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void moon() {
+    void moon() {
         assertThat(faker.space().moon()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void galaxy() {
+    void galaxy() {
         assertThat(faker.space().galaxy()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void nebula() {
+    void nebula() {
         assertThat(faker.space().nebula()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void starCluster() {
+    void starCluster() {
         assertThat(faker.space().starCluster()).matches("(\\w+[ -]?){1,3}");
     }
 
     @Test
-    public void constellation() {
+    void constellation() {
         assertThat(faker.space().constellation()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void star() {
+    void star() {
         assertThat(faker.space().star()).matches("(\\w+[ -]?){2,3}");
     }
 
     @Test
-    public void agency() {
+    void agency() {
         assertThat(faker.space().agency()).matches("(\\w+ ?){2,5}");
     }
 
     @Test
-    public void agencyAbbreviation() {
+    void agencyAbbreviation() {
         assertThat(faker.space().agencyAbbreviation()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void nasaSpaceCraft() {
+    void nasaSpaceCraft() {
         assertThat(faker.space().nasaSpaceCraft()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void company() {
+    void company() {
         assertThat(faker.space().company()).matches("((\\w|')+ ?){2,4}");
     }
 
     @Test
-    public void distanceMeasurement() {
+    void distanceMeasurement() {
         assertThat(faker.space().distanceMeasurement()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    public void meteorite() {
+    void meteorite() {
         assertThat(faker.space().meteorite()).matches("(?U)([\\w()]+[ -–]?){1,4}");
     }
 }

--- a/src/test/java/net/datafaker/StarCraftTest.java
+++ b/src/test/java/net/datafaker/StarCraftTest.java
@@ -5,18 +5,18 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StarCraftTest extends AbstractFakerTest {
+class StarCraftTest extends AbstractFakerTest {
     private final String noLeadingTrailingWhitespaceRegex = "^(?! )[-A-Za-z0-9' ]*(?<! )$";
 
     @Test
-    public void testUnit() {
+    void testUnit() {
         String unit = faker.starCraft().unit();
         assertThat(unit).isNotEmpty();
         assertThat(unit).matches(noLeadingTrailingWhitespaceRegex);
     }
 
     @RepeatedTest(1000)
-    public void testUnitOneThousand() {
+    void testUnitOneThousand() {
         String unit = faker.starCraft().unit();
         // System.out.println(unit);
         assertThat(unit).isNotEmpty();
@@ -24,28 +24,28 @@ public class StarCraftTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testBuilding() {
+    void testBuilding() {
         String building = faker.starCraft().building();
         assertThat(building).isNotEmpty();
         assertThat(building).matches(noLeadingTrailingWhitespaceRegex);
     }
 
     @Test
-    public void testCharacter() {
+    void testCharacter() {
         String character = faker.starCraft().character();
         assertThat(character).isNotEmpty();
         assertThat(character).matches(noLeadingTrailingWhitespaceRegex);
     }
 
     @Test
-    public void testPlanet() {
+    void testPlanet() {
         String planet = faker.starCraft().planet();
         assertThat(planet).isNotEmpty();
         assertThat(planet).matches(noLeadingTrailingWhitespaceRegex);
     }
 
     @RepeatedTest(1000)
-    public void testPlanetOneThousand() {
+    void testPlanetOneThousand() {
         String planet = faker.starCraft().planet();
         // System.out.println(planet);
         assertThat(planet).isNotEmpty();

--- a/src/test/java/net/datafaker/StarTrekTest.java
+++ b/src/test/java/net/datafaker/StarTrekTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StarTrekTest extends AbstractFakerTest {
+class StarTrekTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.starTrek().character()).matches("^(\\w+-?'?\\.?\\s?)+$");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.starTrek().location()).matches("^(\\w+'?\\s?)+$");
     }
 
     @Test
-    public void species() {
+    void species() {
         assertThat(faker.starTrek().species()).matches("^(\\w+-?'?\\s?)+$");
     }
 
     @Test
-    public void villain() {
+    void villain() {
         assertThat(faker.starTrek().villain()).matches("^(\\w+'?\\.?\\s?)+$");
     }
 
     @Test
-    public void klingon() {
+    void klingon() {
         assertThat(faker.starTrek().klingon()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/StockTest.java
+++ b/src/test/java/net/datafaker/StockTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StockTest extends AbstractFakerTest {
+class StockTest extends AbstractFakerTest {
 
     @Test
-    public void testNasdaq() {
+    void testNasdaq() {
         assertThat(faker.stock().nsdqSymbol()).isNotEmpty();
     }
 
     @Test
-    public void testNYSE() {
+    void testNYSE() {
         assertThat(faker.stock().nyseSymbol()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/SubscriptionTest.java
+++ b/src/test/java/net/datafaker/SubscriptionTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SubscriptionTest extends AbstractFakerTest {
+class SubscriptionTest extends AbstractFakerTest {
 
     @Test
-    public void plans() {
+    void plans() {
         assertThat(faker.subscription().plans()).isNotEmpty();
     }
 
     @Test
-    public void statuses() {
+    void statuses() {
         assertThat(faker.subscription().statuses()).isNotEmpty();
     }
 
     @Test
-    public void paymentMethods() {
+    void paymentMethods() {
         assertThat(faker.subscription().paymentMethods()).isNotEmpty();
     }
 
     @Test
-    public void subscriptionTerms() {
+    void subscriptionTerms() {
         assertThat(faker.subscription().subscriptionTerms()).isNotEmpty();
     }
 
     @Test
-    public void paymentTerms() {
+    void paymentTerms() {
         assertThat(faker.subscription().paymentTerms()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/SuperMarioTest.java
+++ b/src/test/java/net/datafaker/SuperMarioTest.java
@@ -4,19 +4,19 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SuperMarioTest extends AbstractFakerTest {
+class SuperMarioTest extends AbstractFakerTest {
 
     @Test
-    public void characters() {
+    void characters() {
         assertThat(faker.superMario().characters()).isNotEmpty();
     }
 
     @Test
-    public void games() {
+    void games() {
         assertThat(faker.superMario().games()).isNotEmpty();
     }
     @Test
-    public void locations() {
+    void locations() {
         assertThat(faker.superMario().locations()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/SuperheroTest.java
+++ b/src/test/java/net/datafaker/SuperheroTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SuperheroTest extends AbstractFakerTest {
+class SuperheroTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.superhero().name()).matches("[A-Za-z' -/]+");
     }
 
     @Test
-    public void testPrefix() {
+    void testPrefix() {
         assertThat(faker.superhero().prefix()).matches("[A-Za-z -]+");
     }
 
     @Test
-    public void testSuffix() {
+    void testSuffix() {
         assertThat(faker.superhero().suffix()).matches("[A-Za-z -]+");
     }
 
     @Test
-    public void testPower() {
+    void testPower() {
         assertThat(faker.superhero().power()).matches("[A-Za-z/ -]+");
     }
 
     @Test
-    public void testDescriptor() {
+    void testDescriptor() {
         assertThat(faker.superhero().descriptor()).matches("[A-Za-z' -]+");
     }
 }

--- a/src/test/java/net/datafaker/TeamTest.java
+++ b/src/test/java/net/datafaker/TeamTest.java
@@ -6,32 +6,32 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TeamTest extends AbstractFakerTest {
+class TeamTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.team().name()).matches("(\\w+( )?){2,4}");
     }
 
     @Test
-    public void testCreature() {
+    void testCreature() {
         assertThat(faker.team().creature()).matches("\\w+( \\w+)?");
     }
 
     @Test
-    public void testState() {
+    void testState() {
         assertThat(faker.team().state()).matches("(\\w+( )?){1,2}");
     }
 
 
     @Test
-    public void testStateWithZaLocale() {
+    void testStateWithZaLocale() {
         Faker zaFaker = new Faker(new Locale("en-ZA"));
         assertThat(zaFaker.team().state()).isNotEmpty();
     }
 
     @Test
-    public void testSport() {
+    void testSport() {
         assertThat(faker.team().sport()).matches("(\\p{L}|\\s)+");
     }
 }

--- a/src/test/java/net/datafaker/TheItCrowdTest.java
+++ b/src/test/java/net/datafaker/TheItCrowdTest.java
@@ -4,25 +4,25 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TheItCrowdTest extends AbstractFakerTest {
+class TheItCrowdTest extends AbstractFakerTest {
 
     @Test
-    public void actors() {
+    void actors() {
         assertThat(faker.theItCrowd().actors()).isNotEmpty();
     }
 
     @Test
-    public void characters() {
+    void characters() {
         assertThat(faker.theItCrowd().characters()).isNotEmpty();
     }
 
     @Test
-    public void emails() {
+    void emails() {
         assertThat(faker.theItCrowd().emails()).isNotEmpty();
     }
 
     @Test
-    public void quotes() {
+    void quotes() {
         assertThat(faker.theItCrowd().quotes()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/TouhouTest.java
+++ b/src/test/java/net/datafaker/TouhouTest.java
@@ -5,30 +5,30 @@ import org.junit.jupiter.api.RepeatedTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class TouhouTest extends AbstractFakerTest {
+class TouhouTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
-    public void testCharacterName() {
+    void testCharacterName() {
         assertThat(faker.touhou().characterName()).matches("[a-zA-Z0-9 \\-']+");
     }
 
     @RepeatedTest(100)
-    public void testCharacterFirstName() {
+    void testCharacterFirstName() {
         assertThat(faker.touhou().characterFirstName()).matches("[a-zA-Z0-9 \\-']+");
     }
 
     @RepeatedTest(100)
-    public void testCharacterLastName() {
+    void testCharacterLastName() {
         assertThat(faker.touhou().characterLastName()).matches("[a-zA-Z0-9 \\-']+");
     }
 
     @RepeatedTest(100)
-    public void testTrackName() {
+    void testTrackName() {
         assertThat(faker.touhou().trackName()).matches(".+");
     }
 
     @RepeatedTest(100)
-    public void testGameName() {
+    void testGameName() {
         String s = faker.touhou().gameName();
         assertThat(s).matches("[a-zA-Z0-9 \\-'\\.]+");
     }

--- a/src/test/java/net/datafaker/TronTest.java
+++ b/src/test/java/net/datafaker/TronTest.java
@@ -4,55 +4,55 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class TronTest extends AbstractFakerTest {
+class TronTest extends AbstractFakerTest {
 
     @Test
-    public void characters() {
+    void characters() {
         assertThat(faker.tron().character()).isNotEmpty();
     }
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.tron().character(Tron.Character.USER)).isNotEmpty();
     }
 
     @Test
-    public void games() {
+    void games() {
         assertThat(faker.tron().game()).isNotEmpty();
     }
 
     @Test
-    public void locations() {
+    void locations() {
         assertThat(faker.tron().location()).isNotEmpty();
     }
 
     @Test
-    public void quotes() {
+    void quotes() {
         assertThat(faker.tron().quote()).isNotNull();
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.tron().quote(Tron.Quote.DR_WALTER_GIBBS)).isNotNull();
     }
 
     @Test
-    public void taglines() {
+    void taglines() {
         assertThat(faker.tron().tagline()).isNotEmpty();
     }
 
     @Test
-    public void vehicles() {
+    void vehicles() {
         assertThat(faker.tron().vehicle()).isNotEmpty();
     }
 
     @Test
-    public void alternateCharacterSpellings() {
+    void alternateCharacterSpellings() {
         assertThat(faker.tron().alternateCharacterSpelling()).isNotEmpty();
     }
 
     @Test
-    public void alternateCharacterSpelling() {
+    void alternateCharacterSpelling() {
         assertThat(faker.tron().alternateCharacterSpelling(Tron.AlternateCharacterSpelling.DR_LORA_BAINES)).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/TwinPeaksTest.java
+++ b/src/test/java/net/datafaker/TwinPeaksTest.java
@@ -5,20 +5,20 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class TwinPeaksTest extends AbstractFakerTest {
+class TwinPeaksTest extends AbstractFakerTest {
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.twinPeaks().character()).matches("^([\\w']+ ?){2,}$");
     }
 
     @Test
-    public void location() {
+    void location() {
         assertThat(faker.twinPeaks().location()).matches("^[A-Za-z0-9'&,\\- ]+$");
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.twinPeaks().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/TwitterTest.java
+++ b/src/test/java/net/datafaker/TwitterTest.java
@@ -7,10 +7,10 @@ import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TwitterTest extends AbstractFakerTest {
+class TwitterTest extends AbstractFakerTest {
 
     @Test
-    public void testCreatedDateForward() {
+    void testCreatedDateForward() {
         Date testDate = new Date();
         Date constrainDate = new Date(testDate.getTime() + 3000000);
         Date generated = faker.twitter().createdTime(true, testDate, constrainDate);
@@ -19,7 +19,7 @@ public class TwitterTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testCreatedDateBackward() {
+    void testCreatedDateBackward() {
         Date testDate = new Date();
         Date constrainDate = new Date(testDate.getTime() - 3000000);
         Date generated = faker.twitter().createdTime(false, testDate, constrainDate);
@@ -28,28 +28,28 @@ public class TwitterTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testShortTwitterIdLength() {
+    void testShortTwitterIdLength() {
         int expectedLength = 6;
         String generatedID = faker.twitter().twitterId(expectedLength);
         assertThat(generatedID).hasSize(expectedLength);
     }
 
     @RepeatedTest(100)
-    public void testLongTwitterIdLength() {
+    void testLongTwitterIdLength() {
         int expectedLength = 25;
         String generatedID = faker.twitter().twitterId(expectedLength);
         assertThat(generatedID).hasSize(expectedLength);
     }
 
     @Test
-    public void testTwitterIdLength() {
+    void testTwitterIdLength() {
         int expectedLength = 15;
         String generatedID = faker.twitter().twitterId(expectedLength);
         assertThat(generatedID).hasSize(expectedLength);
     }
 
     @Test
-    public void testTwitterIdUnique() {
+    void testTwitterIdUnique() {
         int expectedLength = 15;
         String generatedIDOne = faker.twitter().twitterId(expectedLength);
         String generatedIDTwo = faker.twitter().twitterId(expectedLength);
@@ -57,7 +57,7 @@ public class TwitterTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testTextLength() {
+    void testTextLength() {
         int sentenceMaxLength = 15;
         int wordMaxLength = 5;
         String text = faker.twitter().text(null, sentenceMaxLength, wordMaxLength);
@@ -66,7 +66,7 @@ public class TwitterTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testTextKeyWords() {
+    void testTextKeyWords() {
         int sentenceMaxLength = 15;
         int wordMaxLength = 5;
         String[] keywords = new String[]{"buy", "see"};
@@ -90,28 +90,28 @@ public class TwitterTest extends AbstractFakerTest {
     }
 
     @Test
-    public void username() {
+    void username() {
         for (int i = 0; i < 10; i++) {
             assertThat(faker.twitter().userName()).matches("[a-zA-Z0-9_\\-\u4e00-\u9fa5]+");
         }
     }
 
     @Test
-    public void userId() {
+    void userId() {
         for (int i = 0; i < 10; i++) {
             assertThat(faker.twitter().userId()).matches("[0-9]+");
         }
     }
 
     @Test
-    public void linkTestRules() {
+    void linkTestRules() {
         for (int i = 0; i < 10; i++) {
             assertThat(faker.twitter().getLink("John", 6)).matches("[A-Za-z0-9.:/]+");
         }
     }
 
     @Test
-    public void linkTestKeyWords() {
+    void linkTestKeyWords() {
         for (int i = 0; i < 10; i++) {
             assertThat(faker.twitter().getLink("John", 6)).contains("John");
         }

--- a/src/test/java/net/datafaker/UniversityTest.java
+++ b/src/test/java/net/datafaker/UniversityTest.java
@@ -4,20 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UniversityTest extends AbstractFakerTest {
+class UniversityTest extends AbstractFakerTest {
 
     @Test
-    public void testName() {
+    void testName() {
         assertThat(faker.university().name()).matches("[A-Za-z'() ]+");
     }
 
     @Test
-    public void testPrefix() {
+    void testPrefix() {
         assertThat(faker.university().prefix()).matches("\\w+");
     }
 
     @Test
-    public void testSuffix() {
+    void testSuffix() {
         assertThat(faker.university().suffix()).matches("\\w+");
     }
 }

--- a/src/test/java/net/datafaker/VehicleTest.java
+++ b/src/test/java/net/datafaker/VehicleTest.java
@@ -8,86 +8,86 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class VehicleTest extends AbstractFakerTest {
+class VehicleTest extends AbstractFakerTest {
 
     private static final String WORD_MATCH = "\\w+\\.?";
     private static final String WORDS_MATCH = "^[a-zA-Z0-9_/ -]*$";
     private static final String INTERNATIONAL_WORDS_MATCH = "\\P{Cc}+";
 
     @RepeatedTest(10)
-    public void testVin() {
+    void testVin() {
         assertThat(faker.vehicle().vin()).matches(Vehicle.VIN_REGEX);
     }
 
     @Test
-    public void testManufacturer() {
+    void testManufacturer() {
         assertThat(faker.vehicle().manufacturer()).matches(INTERNATIONAL_WORDS_MATCH);
     }
 
     @Test
-    public void testMake() {
+    void testMake() {
         assertThat(faker.vehicle().make()).matches(WORD_MATCH);
     }
 
     @Test
-    public void testModel() {
+    void testModel() {
         assertThat(faker.vehicle().model()).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testModelWithParams() {
+    void testModelWithParams() {
         assertThat(faker.vehicle().model("Toyota")).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testMakeAndModel() {
+    void testMakeAndModel() {
         assertThat(faker.vehicle().makeAndModel()).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testStyle() {
+    void testStyle() {
         assertThat(faker.vehicle().style()).matches(WORD_MATCH);
     }
 
     @Test
-    public void testColor() {
+    void testColor() {
         assertThat(faker.vehicle().color()).matches(WORD_MATCH);
     }
 
     @Test
-    public void testTransmission() {
+    void testTransmission() {
         assertThat(faker.vehicle().transmission()).matches(WORD_MATCH);
     }
 
     @Test
-    public void testDriveType() {
+    void testDriveType() {
         assertThat(faker.vehicle().driveType()).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testFuelType() {
+    void testFuelType() {
         assertThat(faker.vehicle().fuelType()).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testCarType() {
+    void testCarType() {
         assertThat(faker.vehicle().carType()).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testEngine() {
+    void testEngine() {
         assertThat(faker.vehicle().engine()).matches("\\d Cylinder Engine");
     }
 
     @Test
-    public void testCarOptions() {
+    void testCarOptions() {
         List<String> carOptions = faker.vehicle().carOptions();
         assertThat(carOptions.size()).isGreaterThanOrEqualTo(5);
         assertThat(carOptions.size()).isLessThanOrEqualTo(10);
     }
 
     @Test
-    public void testCarOptionsMinMax() {
+    void testCarOptionsMinMax() {
         List<String> carOptions = faker.vehicle().carOptions(11, 12);
         assertThat(carOptions.size()).isGreaterThanOrEqualTo(11);
         assertThat(carOptions.size()).isLessThanOrEqualTo(12);
@@ -95,38 +95,38 @@ public class VehicleTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testStandardSpecsMinMax() {
+    void testStandardSpecsMinMax() {
         List<String> standardSpecs = faker.vehicle().standardSpecs(13, 14);
         assertThat(standardSpecs.size()).isGreaterThanOrEqualTo(13);
         assertThat(standardSpecs.size()).isLessThanOrEqualTo(14);
     }
 
     @Test
-    public void testStandardSpecs() {
+    void testStandardSpecs() {
         List<String> standardSpecs = faker.vehicle().standardSpecs();
         assertThat(standardSpecs.size()).isGreaterThanOrEqualTo(5);
         assertThat(standardSpecs.size()).isLessThanOrEqualTo(10);
     }
 
     @Test
-    public void testDoor() {
+    void testDoor() {
         assertThat(faker.vehicle().doors()).matches("\\d");
     }
 
 
     @Test
-    public void testLicensePlate() {
+    void testLicensePlate() {
         assertThat(faker.vehicle().licensePlate()).matches(WORDS_MATCH);
     }
 
     @Test
-    public void testLicensePlateWithParam() {
+    void testLicensePlateWithParam() {
         assertThat(faker.vehicle().licensePlate("GA")).matches(WORDS_MATCH);
         assertThat(faker.vehicle().licensePlate("AL")).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(100)
-    public void testLicensePlateWithParam_Canada() {
+    void testLicensePlateWithParam_Canada() {
         Faker test = new Faker(Locale.CANADA);
         assertThat(test.vehicle().licensePlate("MB")).matches(WORDS_MATCH);
         assertThat(test.vehicle().licensePlate("ON")).matches(WORDS_MATCH);

--- a/src/test/java/net/datafaker/VolleyballTest.java
+++ b/src/test/java/net/datafaker/VolleyballTest.java
@@ -4,30 +4,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class VolleyballTest extends AbstractFakerTest {
+class VolleyballTest extends AbstractFakerTest {
 
     @Test
-    public void team() {
+    void team() {
         assertThat(faker.volleyball().team()).isNotEmpty();
     }
 
     @Test
-    public void player() {
+    void player() {
         assertThat(faker.volleyball().player()).isNotEmpty();
     }
 
     @Test
-    public void coach() {
+    void coach() {
         assertThat(faker.volleyball().coach()).isNotEmpty();
     }
 
     @Test
-    public void position() {
+    void position() {
         assertThat(faker.volleyball().position()).isNotEmpty();
     }
 
     @Test
-    public void formation() {
+    void formation() {
         assertThat(faker.volleyball().formation()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/WeatherTest.java
+++ b/src/test/java/net/datafaker/WeatherTest.java
@@ -4,32 +4,32 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WeatherTest extends AbstractFakerTest {
+class WeatherTest extends AbstractFakerTest {
 
     @Test
-    public void description() {
+    void description() {
         assertThat(faker.weather().description()).isNotEmpty();
     }
 
     @Test
-    public void temperatureCelsius() {
+    void temperatureCelsius() {
         assertThat(faker.weather().temperatureCelsius()).matches("[-]?\\d+°C");
     }
 
     @Test
-    public void temperatureFahrenheit() {
+    void temperatureFahrenheit() {
         assertThat(faker.weather().temperatureFahrenheit()).matches("[-]?\\d+°F");
     }
 
     @Test
-    public void temperatureCelsiusInRange() {
+    void temperatureCelsiusInRange() {
         for (int i = 1; i < 100; i++) {
             assertThat(faker.weather().temperatureCelsius(-5, 5)).matches("[-]?[0-5]°C");
         }
     }
 
     @Test
-    public void temperatureFahrenheitInRange() {
+    void temperatureFahrenheitInRange() {
         for (int i = 1; i < 100; i++) {
             assertThat(faker.weather().temperatureFahrenheit(-5, 5)).matches("[-]?[0-5]°F");
         }

--- a/src/test/java/net/datafaker/WitcherTest.java
+++ b/src/test/java/net/datafaker/WitcherTest.java
@@ -4,50 +4,50 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WitcherTest extends AbstractFakerTest {
+class WitcherTest extends AbstractFakerTest {
 
     @Test
-    public void testCharacter() {
+    void testCharacter() {
         assertThat(faker.witcher().character()).matches("[A-Za-z' -éúï]+");
     }
 
     @Test
-    public void testWitcher() {
+    void testWitcher() {
         assertThat(faker.witcher().witcher()).matches("[A-Za-z -ëúï]+");
     }
 
     @Test
-    public void testSchool() {
+    void testSchool() {
         assertThat(faker.witcher().school()).matches("[A-Za-z]+");
     }
 
     @Test
-    public void testLocation() {
+    void testLocation() {
         assertThat(faker.witcher().location()).matches("[A-Za-z -áâé]+");
     }
 
     @Test
-    public void testQuote() {
+    void testQuote() {
         assertThat(faker.witcher().quote()).matches("[-A-Za-z0-9 —;…?!.’‘'”“,\\[\\]]+");
     }
 
     @Test
-    public void testMonster() {
+    void testMonster() {
         assertThat(faker.witcher().monster()).matches("[A-Za-z -]+");
     }
 
     @Test
-    public void testSign() {
+    void testSign() {
         assertThat(faker.witcher().sign()).matches("[A-Za-z -]+");
     }
 
     @Test
-    public void testPotion() {
+    void testPotion() {
         assertThat(faker.witcher().potion()).matches("[A-Za-z '-]+");
     }
 
     @Test
-    public void testBook() {
+    void testBook() {
         assertThat(faker.witcher().book()).matches("[A-Za-z -]+");
     }
 }

--- a/src/test/java/net/datafaker/YodaTest.java
+++ b/src/test/java/net/datafaker/YodaTest.java
@@ -7,10 +7,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Luka Obradovic (luka@vast.com)
  */
-public class YodaTest extends AbstractFakerTest {
+class YodaTest extends AbstractFakerTest {
 
     @Test
-    public void quote() {
+    void quote() {
         assertThat(faker.yoda().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/ZeldaTest.java
+++ b/src/test/java/net/datafaker/ZeldaTest.java
@@ -4,15 +4,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZeldaTest extends AbstractFakerTest {
+class ZeldaTest extends AbstractFakerTest {
 
     @Test
-    public void game() {
+    void game() {
         assertThat(faker.zelda().game()).matches("[A-Za-z'\\- :]+");
     }
 
     @Test
-    public void character() {
+    void character() {
         assertThat(faker.zelda().character()).matches("(?U)([\\w'\\-.()]+ ?)+");
     }
 }

--- a/src/test/java/net/datafaker/fileformats/CsvTest.java
+++ b/src/test/java/net/datafaker/fileformats/CsvTest.java
@@ -11,10 +11,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CsvTest extends AbstractFakerTest {
+class CsvTest extends AbstractFakerTest {
 
     @Test
-    public void csvTest() {
+    void csvTest() {
         String separator = "@@@";
         int limit = 20;
         String csv = Format.toCsv(Csv.Column.of("first_name", () -> faker.name().firstName()),
@@ -38,7 +38,7 @@ public class CsvTest extends AbstractFakerTest {
     }
 
     @Test
-    public void csvTestWithQuotes() {
+    void csvTestWithQuotes() {
         String separator = "$$$";
         int limit = 20;
         List<Csv.Column> columns = new ArrayList<>();
@@ -64,7 +64,7 @@ public class CsvTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testCsvWithComma() {
+    void testCsvWithComma() {
         String csv = Format.toCsv(
                 Csv.Column.of("values", () -> "1,2,3"),
                 Csv.Column.of("title", () -> "The \"fabulous\" artist"))
@@ -80,7 +80,7 @@ public class CsvTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-    public void testLimitForCsv(int limit) {
+    void testLimitForCsv(int limit) {
         String csv = Format.toCsv(
                 faker.<Name>collection()
                     .suppliers(() -> faker.name())
@@ -105,7 +105,7 @@ public class CsvTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-    public void testLimitForCollection(int limit) {
+    void testLimitForCollection(int limit) {
         String csv = Format.toCsv(
                 faker.<Name>collection()
                     .suppliers(() -> faker.name())

--- a/src/test/java/net/datafaker/fileformats/JsonTest.java
+++ b/src/test/java/net/datafaker/fileformats/JsonTest.java
@@ -15,10 +15,10 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.fail;
 
-public class JsonTest {
+class JsonTest {
     @ParameterizedTest
     @MethodSource("generateTestJson")
-    public void simpleJsonTest(Map<Object, Supplier<Object>> input, String expected) {
+    void simpleJsonTest(Map<Object, Supplier<Object>> input, String expected) {
         Json.JsonBuilder builder = new Json.JsonBuilder();
         for (Map.Entry<Object, Supplier<Object>> entry: input.entrySet()) {
             if (entry.getKey() instanceof String) {

--- a/src/test/java/net/datafaker/fileformats/XmlTest.java
+++ b/src/test/java/net/datafaker/fileformats/XmlTest.java
@@ -12,10 +12,10 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class XmlTest {
+class XmlTest {
     @ParameterizedTest
     @MethodSource("generateTestXmlPretty")
-    public void xmlPrettyTest(Xml.XmlNode xmlNode, String expected) {
+    void xmlPrettyTest(Xml.XmlNode xmlNode, String expected) {
         Xml xml = new Xml(xmlNode);
         assertThat(xml.generate(true)).isEqualTo(expected);
     }
@@ -37,7 +37,7 @@ public class XmlTest {
 
     @ParameterizedTest
     @MethodSource("generateTestXml")
-    public void xmlTest(Xml.XmlNode xmlNode, String expected) {
+    void xmlTest(Xml.XmlNode xmlNode, String expected) {
         Xml xml = new Xml(xmlNode);
         assertThat(xml.generate()).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/fileformats/YamlTest.java
+++ b/src/test/java/net/datafaker/fileformats/YamlTest.java
@@ -14,10 +14,10 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class YamlTest {
+class YamlTest {
     @ParameterizedTest
     @MethodSource("generateTestYaml")
-    public void simpleYamlTest(Map<Supplier<String>, Supplier<Object>> input, String expected) {
+    void simpleYamlTest(Map<Supplier<String>, Supplier<Object>> input, String expected) {
         Yaml yaml = new Yaml(input);
         assertThat(yaml.generate()).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/foods/HebrewFoodTest.java
+++ b/src/test/java/net/datafaker/foods/HebrewFoodTest.java
@@ -8,37 +8,37 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HebrewFoodTest {
+class HebrewFoodTest {
     public final String matchHebrewFood = "[\\u0590-\\u05FF ']+";
     public static Faker food;
 
     @BeforeEach
-    public void before() {
+    void before() {
         food = new Faker(new Locale("he"));
     }
 
     @Test
-    public void hebrewIngredient() {
+    void hebrewIngredient() {
         assertThat(food.food().ingredient()).matches(matchHebrewFood);
     }
 
     @Test
-    public void hebrewFruit() {
+    void hebrewFruit() {
         assertThat(food.food().fruit()).matches(matchHebrewFood);
     }
 
     @Test
-    public void hebrewVegetable() {
+    void hebrewVegetable() {
         assertThat(food.food().vegetable()).matches(matchHebrewFood);
     }
 
     @Test
-    public void hebrewSpice() {
+    void hebrewSpice() {
         assertThat(food.food().spice()).matches(matchHebrewFood);
     }
 
     @Test
-    public void hebrewSushi() {
+    void hebrewSushi() {
         assertThat(food.food().sushi()).matches(matchHebrewFood);
     }
 }

--- a/src/test/java/net/datafaker/idnumbers/EnZAIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/EnZAIdNumberTest.java
@@ -11,10 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /*
  * This file was used to test the issue #566 by SE_CHWJ
  */
-public class EnZAIdNumberTest {
+class EnZAIdNumberTest {
 
     @Test
-    public void testExistSsn() {
+    void testExistSsn() {
         EnZAIdNumber idNumber = new EnZAIdNumber();
 
         assertThat(idNumber.validSsn("9202204720085")).isFalse();
@@ -26,7 +26,7 @@ public class EnZAIdNumberTest {
     }
 
     @RepeatedTest(100)
-    public void testFakerSsn() {
+    void testFakerSsn() {
         EnZAIdNumber idNumber = new EnZAIdNumber();
         final Faker f = new Faker(new Locale("en-ZA"));
 
@@ -35,7 +35,7 @@ public class EnZAIdNumberTest {
     }
 
     @RepeatedTest(100)
-    public void testSsnFormat() {
+    void testSsnFormat() {
         final Faker f = new Faker(new Locale("en-ZA"));
         assertThat(f.idNumber().valid()).matches("\\d{10}[01][8]\\d");
         assertThat(f.idNumber().invalid()).matches("\\d{10}[01][8]\\d");

--- a/src/test/java/net/datafaker/idnumbers/EsMXIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/EsMXIdNumberTest.java
@@ -7,10 +7,10 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EsMXIdNumberTest {
+class EsMXIdNumberTest {
 
     @RepeatedTest(100)
-    public void testValidMXSsn() {
+    void testValidMXSsn() {
         final Faker f = new Faker(new Locale("es-MX"));
         assertThat(f.idNumber().valid()).matches("[A-Z][A-Z][A-Z][A-Z]\\d{6}[HM]" +
             "[A-Z][A-Z][A-Z][A-Z][A-Z][A-Z,0-9]\\d");
@@ -19,7 +19,7 @@ public class EsMXIdNumberTest {
     }
 
     @RepeatedTest(100)
-    public void testInvalidMXSsn() {
+    void testInvalidMXSsn() {
         final Faker f = new Faker(new Locale("es-MX"));
         assertThat(f.idNumber().validEsMXSsn()).matches("[A-Z][A-Z][A-Z][A-Z]\\d{6}[HM]" +
             "[A-Z][A-Z][A-Z][A-Z][A-Z][A-Z,0-9]\\d");

--- a/src/test/java/net/datafaker/idnumbers/PtNifIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/PtNifIdNumberTest.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PtNifIdNumberTest extends AbstractFakerTest {
+class PtNifIdNumberTest extends AbstractFakerTest {
 
     private Faker ptFaker;
 
@@ -19,19 +19,19 @@ public class PtNifIdNumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testInValid() {
+    void testInValid() {
         PtNifIdNumber idNumber = new PtNifIdNumber();
         assertThat(idNumber.getInvalid(ptFaker)).matches("[0-9]{9,10}");
     }
 
     @RepeatedTest(100)
-    public void testValid() {
+    void testValid() {
         PtNifIdNumber idNumber = new PtNifIdNumber();
         assertThat(idNumber.getValid(ptFaker)).matches("[0-9]{9,10}");
     }
 
     @RepeatedTest(100)
-    public void testValidWithFaker() {
+    void testValidWithFaker() {
         assertThat(ptFaker.idNumber().valid()).matches("[0-9]{9,10}");
     }
 

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -4,17 +4,17 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SwedishIdNumberTest {
+class SwedishIdNumberTest {
 
     @Test
-    public void valid() {
+    void valid() {
         SvSEIdNumber idNumber = new SvSEIdNumber();
         assertThat(idNumber.validSwedishSsn("670919-9530")).isTrue();
         assertThat(idNumber.validSwedishSsn("811228-9874")).isTrue();
     }
 
     @Test
-    public void invalid() {
+    void invalid() {
         SvSEIdNumber idNumber = new SvSEIdNumber();
         assertThat(idNumber.validSwedishSsn("8112289873")).isFalse();
         assertThat(idNumber.validSwedishSsn("foo228-9873")).isFalse();

--- a/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
@@ -8,10 +8,10 @@ import java.util.Locale;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class ZhCNIdNumberTest extends AbstractFakerTest {
+class ZhCNIdNumberTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    public void testValidChineseIdNumber() {
+    void testValidChineseIdNumber() {
         Faker faker = new Faker(new Locale("zh_CN"));
         String idNumber = faker.idNumber().valid();
         boolean isSatisfied = idNumber.length() == 18;
@@ -33,7 +33,7 @@ public class ZhCNIdNumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    public void testChecksumOfChineseIdNumber() {
+    void testChecksumOfChineseIdNumber() {
         Faker faker = new Faker(new Locale("zh_CN"));
         String s = faker.idNumber().valid();
         boolean isSatisfied = true;
@@ -63,7 +63,7 @@ public class ZhCNIdNumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    public void testValidZhCnIdNumber() {
+    void testValidZhCnIdNumber() {
         ZhCnIdNumber id = new ZhCnIdNumber();
         String idNumber = id.getValidSsn(faker);
         boolean isSatisfied = idNumber.length() == 18;

--- a/src/test/java/net/datafaker/integration/FakerIT.java
+++ b/src/test/java/net/datafaker/integration/FakerIT.java
@@ -32,7 +32,7 @@ import static org.reflections.ReflectionUtils.withReturnType;
  * are correct. These tests just ensure that the methods can be invoked.
  */
 @SuppressWarnings("NewClassNamingConvention")
-public class FakerIT {
+class FakerIT {
     private Faker faker;
     private Locale locale;
 
@@ -73,7 +73,7 @@ public class FakerIT {
 
     @ParameterizedTest
     @MethodSource("dataParameters")
-    public void testAllFakerMethodsThatReturnStrings(Locale locale, Random random) throws Exception {
+    void testAllFakerMethodsThatReturnStrings(Locale locale, Random random) throws Exception {
         init(locale, random);
         testAllMethodsThatReturnStringsActuallyReturnStrings(faker);
         testAllMethodsThatReturnStringsActuallyReturnStrings(faker.address());
@@ -216,7 +216,7 @@ public class FakerIT {
 
     @ParameterizedTest
     @MethodSource("dataParameters")
-    public void testExceptionsNotCoveredInAboveTest(Locale locale, Random random) {
+    void testExceptionsNotCoveredInAboveTest(Locale locale, Random random) {
         init(locale, random);
         assertThat(faker.bothify("####???")).isNotNull();
         assertThat(faker.letterify("????")).isNotNull();

--- a/src/test/java/net/datafaker/integration/Issue194SlashFormatRegexIT.java
+++ b/src/test/java/net/datafaker/integration/Issue194SlashFormatRegexIT.java
@@ -7,10 +7,10 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Issue194SlashFormatRegexIT {
+class Issue194SlashFormatRegexIT {
 
     @Test
-    public void enGBZipCodeReturnsProperRegexifiedValue() {
+    void enGBZipCodeReturnsProperRegexifiedValue() {
         final Locale uk = new Locale("en-GB");
 
         final String postalCode = new Faker(uk).address().zipCode();
@@ -19,7 +19,7 @@ public class Issue194SlashFormatRegexIT {
     }
 
     @Test
-    public void enCAZipCodeReturnsProperRegexifiedValue() {
+    void enCAZipCodeReturnsProperRegexifiedValue() {
         final Locale uk = new Locale("en-CA");
 
         final String postalCode = new Faker(uk).address().zipCode();
@@ -28,7 +28,7 @@ public class Issue194SlashFormatRegexIT {
     }
 
     @Test
-    public void viZipCodeReturnsProperRegexifiedValue() {
+    void viZipCodeReturnsProperRegexifiedValue() {
         final Locale uk = new Locale("vi");
 
         final String postalCode = new Faker(uk).address().zipCode();

--- a/src/test/java/net/datafaker/integration/MostSpecificLocaleIT.java
+++ b/src/test/java/net/datafaker/integration/MostSpecificLocaleIT.java
@@ -14,20 +14,20 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and that methods return values. The unit tests should ensure what the values returned
  * are correct. These tests just ensure that the methods can be invoked.
  */
-public class MostSpecificLocaleIT {
+class MostSpecificLocaleIT {
 
     private FakeValuesService en;
     private FakeValuesService en_US;
 
     @BeforeEach
-    public void setupFakers() {
+    void setupFakers() {
         en = new FakeValuesService(new Locale("en"), null);
         en_US = new FakeValuesService(new Locale("en", "US"), null);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void resolvesTheMostSpecificLocale() {
+    void resolvesTheMostSpecificLocale() {
         final List<String> enDefaultCountries = (List<String>) en.fetchObject("address.default_country");
         final List<String> enUsDefaultCountries = (List<String>) en_US.fetchObject("address.default_country");
 

--- a/src/test/java/net/datafaker/integration/UkLocalDirectivesTest.java
+++ b/src/test/java/net/datafaker/integration/UkLocalDirectivesTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and that methods return values. The unit tests should ensure what the values returned
  * are correct. These tests just ensure that the methods can be invoked.
  */
-public class UkLocalDirectivesTest {
+class UkLocalDirectivesTest {
 
     /**
      * uk is interesting in that it has feminine and masculine prefixes for street names.  the feminine
@@ -23,7 +23,7 @@ public class UkLocalDirectivesTest {
      * child objects.
      */
     @Test
-    public void resolvesDirectivesOnlyInYmlFile() {
+    void resolvesDirectivesOnlyInYmlFile() {
         final Locale uk = new Locale("uk");
 
         final String streetName = new Faker(uk).address().streetName();

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ProviderGenerator {
+class ProviderGenerator {
 
     public static void main(String[] args) throws FileNotFoundException {
         new ProviderGenerator().generateProvider();
@@ -62,7 +62,7 @@ public class ProviderGenerator {
         System.out.println("/**");
         System.out.println(" * @since 1.4.0");
         System.out.println(" */");
-        System.out.println("public class " + className + " {");
+        System.out.println("class " + className + " {");
         System.out.println();
         System.out.println("    private final Faker faker;");
         System.out.println();
@@ -94,7 +94,7 @@ public class ProviderGenerator {
         System.out.println("import static org.assertj.core.api.AssertionsForClassTypes.assertThat;");
 
         System.out.println();
-        System.out.println("public class " + className + "Test extends AbstractFakerTest {");
+        System.out.println("class " + className + "Test extends AbstractFakerTest {");
         System.out.println();
 
         for (String string : strings) {

--- a/src/test/java/net/datafaker/service/FakeValuesGroupingTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesGroupingTest.java
@@ -7,26 +7,26 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FakeValuesGroupingTest {
+class FakeValuesGroupingTest {
 
     private FakeValuesGrouping fakeValuesGrouping;
     private FakeValues addressValues;
 
     @BeforeEach
-    public void before() {
+    void before() {
         fakeValuesGrouping = new FakeValuesGrouping();
         addressValues = new FakeValues(Locale.ENGLISH, "address.yml", "address");
         fakeValuesGrouping.add(addressValues);
     }
 
     @Test
-    public void handlesOneFakeValue() {
+    void handlesOneFakeValue() {
         assertThat(fakeValuesGrouping.get("address")).isEqualTo(addressValues.get("address"));
         assertThat(fakeValuesGrouping.get("address")).isNotNull();
     }
 
     @Test
-    public void handlesMultipleFakeValues() {
+    void handlesMultipleFakeValues() {
         FakeValues catValues = new FakeValues(Locale.ENGLISH, "cat.yml", "creature");
         fakeValuesGrouping.add(catValues);
 

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class FakeValuesServiceTest extends AbstractFakerTest {
+class FakeValuesServiceTest extends AbstractFakerTest {
 
     private static final Long MILLIS_IN_AN_HOUR = 1000 * 60 * 60L;
     private static final Long MILLIS_IN_A_DAY = MILLIS_IN_AN_HOUR * 24;
@@ -58,38 +58,38 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void fetchStringShouldReturnValue() {
+    void fetchStringShouldReturnValue() {
         assertThat(fakeValuesService.fetchString("property.dummy")).isEqualTo("x");
     }
 
     @Test
-    public void fetchShouldReturnValue() {
+    void fetchShouldReturnValue() {
         assertThat(fakeValuesService.fetch("property.dummy")).isEqualTo("x");
     }
 
     @Test
-    public void fetchObjectShouldReturnValue() {
+    void fetchObjectShouldReturnValue() {
         assertThat((Iterable<?>) fakeValuesService.fetchObject("property.dummy")).isEqualTo(Arrays.asList("x", "y", "z"));
     }
 
     @Test
-    public void safeFetchShouldReturnValueInList() {
+    void safeFetchShouldReturnValueInList() {
         doReturn(0).when(randomService).nextInt(Mockito.anyInt());
         assertThat(fakeValuesService.safeFetch("property.dummy", null)).isEqualTo("x");
     }
 
     @Test
-    public void safeFetchShouldReturnSimpleList() {
+    void safeFetchShouldReturnSimpleList() {
         assertThat(fakeValuesService.safeFetch("property.simple", null)).isEqualTo("hello");
     }
 
     @Test
-    public void safeFetchShouldReturnEmptyStringWhenPropertyDoesntExist() {
+    void safeFetchShouldReturnEmptyStringWhenPropertyDoesntExist() {
         assertThat(fakeValuesService.safeFetch("property.dummy2", "")).isEmpty();
     }
 
     @Test
-    public void bothify2Args() {
+    void bothify2Args() {
         final DummyService dummy = mock(DummyService.class);
 
         Faker f = new Faker();
@@ -99,7 +99,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void regexifyDirective() {
+    void regexifyDirective() {
         final DummyService dummy = mock(DummyService.class);
 
         String value = fakeValuesService.resolve("property.regexify1", dummy, mockedFaker);
@@ -108,7 +108,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void regexifySlashFormatDirective() {
+    void regexifySlashFormatDirective() {
         final DummyService dummy = mock(DummyService.class);
 
         String value = fakeValuesService.resolve("property.regexify_slash_format", dummy, mockedFaker);
@@ -117,7 +117,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void regexifyDirective2() {
+    void regexifyDirective2() {
         final DummyService dummy = mock(DummyService.class);
 
         String value = fakeValuesService.resolve("property.regexify_cell", dummy, mockedFaker);
@@ -126,7 +126,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void resolveKeyToPropertyWithAPropertyWithoutAnObject() {
+    void resolveKeyToPropertyWithAPropertyWithoutAnObject() {
         // #{hello} -> DummyService.hello
 
         // given
@@ -143,7 +143,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void resolveKeyToPropertyWithAPropertyWithAnObject() {
+    void resolveKeyToPropertyWithAPropertyWithAnObject() {
         // given
         final Superhero person = mock(Superhero.class);
         final DummyService dummy = mock(DummyService.class);
@@ -160,7 +160,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void resolveKeyToPropertyWithAList() {
+    void resolveKeyToPropertyWithAList() {
         // property.resolutionWithList -> #{hello}
         // #{hello} -> DummyService.hello
 
@@ -178,7 +178,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void resolveKeyWithMultiplePropertiesShouldJoinResults() {
+    void resolveKeyWithMultiplePropertiesShouldJoinResults() {
         // given
         final Superhero person = mock(Superhero.class);
         final DummyService dummy = mock(DummyService.class);
@@ -199,35 +199,35 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testLocaleChain() {
+    void testLocaleChain() {
         final List<Locale> chain = fakeValuesService.localeChain(Locale.SIMPLIFIED_CHINESE);
 
         assertThat(chain).contains(Locale.SIMPLIFIED_CHINESE, Locale.CHINESE, Locale.ENGLISH);
     }
 
     @Test
-    public void testLocaleChainEnglish() {
+    void testLocaleChainEnglish() {
         final List<Locale> chain = fakeValuesService.localeChain(Locale.ENGLISH);
 
         assertThat(chain).contains(Locale.ENGLISH);
     }
 
     @Test
-    public void testLocaleChainLanguageOnly() {
+    void testLocaleChainLanguageOnly() {
         final List<Locale> chain = fakeValuesService.localeChain(Locale.CHINESE);
 
         assertThat(chain).contains(Locale.CHINESE, Locale.ENGLISH);
     }
 
     @Test
-    public void testLocalesChainGetter() {
+    void testLocalesChainGetter() {
         final List<Locale> chain = fakeValuesService.getLocalesChain();
 
         assertThat(chain).contains(new Locale("test"), Locale.ENGLISH);
     }
 
     @Test
-    public void testLocalesChainGetterRu() {
+    void testLocalesChainGetterRu() {
         final FakeValuesService FVS = new FakeValuesService(new Locale("ru"), randomService);
         final List<Locale> processedChain = FVS.localeChain(new Locale("ru"));
         final List<Locale> chain = FVS.getLocalesChain();
@@ -236,13 +236,13 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void expressionWithInvalidFakerObject() {
+    void expressionWithInvalidFakerObject() {
         expressionShouldFailWith("#{ObjectNotOnFaker.methodName}",
             "Unable to resolve #{ObjectNotOnFaker.methodName} directive.");
     }
 
     @Test
-    public void expressionWithValidFakerObjectButInvalidMethod() {
+    void expressionWithValidFakerObjectButInvalidMethod() {
         expressionShouldFailWith("#{Name.nonExistentMethod}",
             "Unable to resolve #{Name.nonExistentMethod} directive.");
     }
@@ -256,13 +256,13 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
      * the two conditions above are still true.
      */
     @Test
-    public void expressionWithValidFakerObjectValidMethodInvalidArgs() {
+    void expressionWithValidFakerObjectValidMethodInvalidArgs() {
         expressionShouldFailWith("#{Number.number_between 'x','y'}",
             "Unable to resolve #{Number.number_between 'x','y'} directive.");
     }
 
     @Test
-    public void futureDateExpression() throws ParseException {
+    void futureDateExpression() throws ParseException {
         SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH);
 
         Date now = new Date();
@@ -275,7 +275,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void pastDateExpression() throws ParseException {
+    void pastDateExpression() throws ParseException {
         SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH);
 
         Date now = new Date();
@@ -288,20 +288,20 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void expressionWithFourArguments() {
+    void expressionWithFourArguments() {
 
         assertThat(fakeValuesService.expression("#{Internet.password '5','8','true','true'}", faker)).matches("[\\w\\d!%#$@_^&*]{5,8}");
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"src/test/test.txt_null", "qwerty", "src"})
-    public void fileExpressionTestFailure(String filename) {
+    void fileExpressionTestFailure(String filename) {
         assertThatThrownBy(() -> fakeValuesService.fileExpression(Paths.get(filename), faker))
             .isInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void fileNoExpressionTest() {
+    void fileNoExpressionTest() {
         try {
             Path tmpPath = Files.createTempFile("tmp", "file");
             assertThat(String.join("", Files.readAllLines(tmpPath))).isEqualTo(fakeValuesService.fileExpression(tmpPath, faker));
@@ -311,7 +311,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void fileExpressionTest() {
+    void fileExpressionTest() {
         try {
             Path path = Paths.get("src/test/test.txt");
             assertThat(String.join(System.lineSeparator(), Files.readAllLines(path)))
@@ -330,7 +330,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
      * the two conditions above are still true.
      */
     @Test
-    public void expressionCompletelyUnresolvable() {
+    void expressionCompletelyUnresolvable() {
         expressionShouldFailWith("#{x}", "Unable to resolve #{x} directive.");
     }
 
@@ -341,7 +341,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void resolveUsingTheSameKeyTwice() {
+    void resolveUsingTheSameKeyTwice() {
         // #{hello} -> DummyService.hello
 
         // given
@@ -357,7 +357,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void FakeValuesServiceWithNullLocaleTest() {
+    void FakeValuesServiceWithNullLocaleTest() {
         RandomService r = new RandomService();
         assertThatThrownBy(() -> new FakeValuesService(null, new RandomService()))
             .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/net/datafaker/service/FakeValuesTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesTest.java
@@ -1,6 +1,5 @@
 package net.datafaker.service;
 
-import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,50 +15,50 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 
-public class FakeValuesTest {
+class FakeValuesTest {
 
     private static final String PATH = "address";
     private FakeValues fakeValues;
 
     @BeforeEach
-    public void before() {
+    void before() {
         fakeValues = new FakeValues(Locale.ENGLISH, "address.yml", PATH);
     }
 
     @Test
-    public void supportsPathIsTrueWithTheSameValueAsThePath() {
+    void supportsPathIsTrueWithTheSameValueAsThePath() {
         assertThat(fakeValues.supportsPath(PATH)).isTrue();
     }
 
     @Test
-    public void supportsPathIsFalseWhenValueIsNotTheSame() {
+    void supportsPathIsFalseWhenValueIsNotTheSame() {
         assertThat(fakeValues.supportsPath("dog")).isFalse();
     }
 
     @Test
-    public void getAValueReturnsAValue() {
+    void getAValueReturnsAValue() {
         assertThat(fakeValues.get(PATH)).isNotNull();
     }
 
     @Test
-    public void getAValueDoesNotReturnAValue() {
+    void getAValueDoesNotReturnAValue() {
         assertThat(fakeValues.get("dog")).isNull();
     }
 
     @Test
-    public void getAValueWithANonEnglishFile() {
+    void getAValueWithANonEnglishFile() {
         FakeValues frenchFakeValues = new FakeValues(Locale.FRENCH);
         assertThat(frenchFakeValues.get(PATH)).isNotNull();
     }
 
     @Test
-    public void getAValueForHebrewLocale() {
+    void getAValueForHebrewLocale() {
         FakeValues hebrew = new FakeValues(new Locale("iw"));
         assertThat(hebrew.get(PATH)).isNotNull();
     }
 
     @Test
-    public void getAValueFromALocaleThatCantBeLoaded() {
+    void getAValueFromALocaleThatCantBeLoaded() {
         FakeValues fakeValues = new FakeValues(new Locale("nothing"));
         assertThat(fakeValues.get(PATH)).isNull();
     }

--- a/src/test/java/net/datafaker/service/FakerIDNTest.java
+++ b/src/test/java/net/datafaker/service/FakerIDNTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FakerIDNTest {
+class FakerIDNTest {
 
     @Test
-    public void toASCIINoError() {
+    void toASCIINoError() {
         assertThat(FakerIDN.toASCII("hello")).isEqualTo("hello");
     }
 }

--- a/src/test/java/net/datafaker/service/LocalePickerTest.java
+++ b/src/test/java/net/datafaker/service/LocalePickerTest.java
@@ -14,7 +14,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalePickerTest extends AbstractFakerTest {
+class LocalePickerTest extends AbstractFakerTest {
 
     private LocalePicker localePicker;
     private List<String> allLocales;
@@ -23,7 +23,7 @@ public class LocalePickerTest extends AbstractFakerTest {
      * Initialize tests by instantiating a LocalePicker object and list of all supported locales
      */
     @BeforeEach
-    public void init() {
+    void init() {
         localePicker = new LocalePicker();
         allLocales = localePicker.getAllSupportedLocales();
     }
@@ -32,7 +32,7 @@ public class LocalePickerTest extends AbstractFakerTest {
      * Test to check that list of all locales support is loaded
      */
     @Test
-    public void testGetAllSuppportedLocales() {
+    void testGetAllSuppportedLocales() {
         // Check that directory of locale resources exists
         File resourceDirectory = new File("./src/main/resources");
         assertThat(resourceDirectory).exists();
@@ -47,7 +47,7 @@ public class LocalePickerTest extends AbstractFakerTest {
      * should have deterministic results.
      */
     @Test
-    public void testGetLocaleStringRandom() {
+    void testGetLocaleStringRandom() {
         // Check that we get the same locale when using pseudorandom number generator with a fixed seed
         final long fixedSeed = 5;
 
@@ -65,7 +65,7 @@ public class LocalePickerTest extends AbstractFakerTest {
      * locale is within the set of all supported locales
      */
     @RepeatedTest(100)
-    public void testGetLocaleString() {
+    void testGetLocaleString() {
         Random random = new Random();
         String randomLocale = localePicker.getLocaleString(random);
         assertThat(allLocales).contains(randomLocale);
@@ -77,7 +77,7 @@ public class LocalePickerTest extends AbstractFakerTest {
      * It ensures that all the locales supported are represented once.
      */
     @Test
-    public void testGetLocaleStringWithoutReplacement() {
+    void testGetLocaleStringWithoutReplacement() {
         Random random = new Random();
 
         // loop through all supported locales
@@ -93,12 +93,12 @@ public class LocalePickerTest extends AbstractFakerTest {
     }
 
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         assertThat(localePicker.getLocale()).isNotNull();
     }
 
     @Test
-    public void testGetLocaleWithoutReplacement() {
+    void testGetLocaleWithoutReplacement() {
         assertThat(localePicker.getLocaleWithoutReplacement()).isNotNull();
     }
 }

--- a/src/test/java/net/datafaker/service/RandomServiceTest.java
+++ b/src/test/java/net/datafaker/service/RandomServiceTest.java
@@ -17,18 +17,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * @author pmiklos
  */
-public class RandomServiceTest extends AbstractFakerTest {
+class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testPositiveBoundariesOnly(RandomService randomService) {
+    void testPositiveBoundariesOnly(RandomService randomService) {
         assertThatThrownBy( () -> randomService.nextLong(0L))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testLongWithinBoundary(RandomService randomService) {
+    void testLongWithinBoundary(RandomService randomService) {
         assertThat(randomService.nextLong(1)).isEqualTo(0L);
 
         for (int i = 1; i < 10; i++) {
@@ -38,14 +38,14 @@ public class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testLongMaxBoundary(RandomService randomService) {
+    void testLongMaxBoundary(RandomService randomService) {
         assertThat(randomService.nextLong(Long.MAX_VALUE)).isGreaterThan(0L);
         assertThat(randomService.nextLong(Long.MAX_VALUE)).isLessThan(Long.MAX_VALUE);
     }
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testIntInRange(RandomService randomService) {
+    void testIntInRange(RandomService randomService) {
         final Condition<Integer> lessThanOrEqual = new Condition<>(t -> t <= 5, "should be less than or equal 5");
         final Condition<Integer> greaterThanOrEqual = new Condition<>(t -> t >= -5, "should be greater than or equal -5");
         for (int i = 1; i < 100; i++) {
@@ -55,7 +55,7 @@ public class RandomServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    public void predictableRandomRange() {
+    void predictableRandomRange() {
         RandomService randomService = new RandomService(new Random(10));
 
         int i1 = randomService.nextInt();
@@ -85,7 +85,7 @@ public class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testDoubleInRange(RandomService randomService) {
+    void testDoubleInRange(RandomService randomService) {
         final Condition<Double> lessThanOrEqual = new Condition<>(t -> t <= 5d, "should be less than or equal 5");
         final Condition<Double> greaterThanOrEqual = new Condition<>(t -> t >= -5d, "should be greater than or equal -5");
         for (int i = 1; i < 100; i++) {
@@ -95,7 +95,7 @@ public class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testLongInRange(RandomService randomService) {
+    void testLongInRange(RandomService randomService) {
         final Condition<Long> lessThanOrEqual = new Condition<>(t -> t <= 5_000_000_000L, "should be less than or equal 5_000_000_000L");
         final Condition<Long> greaterThanOrEqual = new Condition<>(t -> t >= -5_000_000_000L, "should be greater than or equal -5_000_000_000L");
         for (int i = 1; i < 1_000; i++) {
@@ -105,13 +105,13 @@ public class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testHex(RandomService randomService) {
+    void testHex(RandomService randomService) {
         assertThat(randomService.hex(8)).matches("^[0-9A-F]{8}$");
     }
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    public void testDefaultHex(RandomService randomService) {
+    void testDefaultHex(RandomService randomService) {
         assertThat(randomService.hex()).matches("^[0-9A-F]{8}$");
     }
 


### PR DESCRIPTION
Since junit5 can run tests for classes with package level modifier and methods this PR hardens  the access modifiers for tests