### PR TITLE
Use valid void class for PRIMITIVE_WRAPPER_MAP

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -912,7 +912,7 @@ public class FakeValuesService {
         PRIMITIVE_WRAPPER_MAP.put(Long.TYPE, Long.class);
         PRIMITIVE_WRAPPER_MAP.put(Double.TYPE, Double.class);
         PRIMITIVE_WRAPPER_MAP.put(Float.TYPE, Float.class);
-        PRIMITIVE_WRAPPER_MAP.put(Void.TYPE, Void.TYPE);
+        PRIMITIVE_WRAPPER_MAP.put(Void.TYPE, Void.class);
     }
 
     public static Class<?> primitiveToWrapper(final Class<?> cls) {


### PR DESCRIPTION
It looks like for the `void` type it is used a valid type. This PR fixes this