### PR TITLE
Add missing symbols in regex for SoulKnightTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Providers
 * Shakespeare
 * Sip
 * SlackEmoji
+* SoulKnight
 * Space
 * StarCraft
 * StarTrek

--- a/src/test/java/net/datafaker/SoulKnightTest.java
+++ b/src/test/java/net/datafaker/SoulKnightTest.java
@@ -1,40 +1,41 @@
 package net.datafaker;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SoulKnightTest extends AbstractFakerTest{
+public class SoulKnightTest extends AbstractFakerTest {
 
-    public static final String SOUL_KNIGHT_VALUE_REGEX = "[a-zA-Z\\d\\-. /():']+";
+    public static final String SOUL_KNIGHT_VALUE_REGEX = "[a-zA-Z\\d\\-. /():+'’]+";
 
     @Test
-    public void charactersTest(){
+    public void charactersTest() {
         assertThat(faker.soulKnight().characters()).matches(SOUL_KNIGHT_VALUE_REGEX);
     }
 
     @Test
-    public void buffsTest(){
+    public void buffsTest() {
         assertThat(faker.soulKnight().buffs()).matches(SOUL_KNIGHT_VALUE_REGEX);
     }
 
     @Test
-    public void statuesTest(){
+    public void statuesTest() {
         assertThat(faker.soulKnight().statues()).matches(SOUL_KNIGHT_VALUE_REGEX);
     }
 
-    @Test
-    public void weaponsTest(){
+    @RepeatedTest(100)
+    public void weaponsTest() {
         assertThat(faker.soulKnight().weapons()).matches(SOUL_KNIGHT_VALUE_REGEX);
     }
 
     @Test
-    public void bossesTest(){
+    public void bossesTest() {
         assertThat(faker.soulKnight().bosses()).matches(SOUL_KNIGHT_VALUE_REGEX);
     }
 
     @Test
-    public void enemiesTest(){
+    public void enemiesTest() {
         assertThat(faker.soulKnight().enemies()).matches(SOUL_KNIGHT_VALUE_REGEX);
     }
 }


### PR DESCRIPTION
The PR fixes missing symbols in regex for SoulKnightTest to fix ci failing like https://github.com/datafaker-net/datafaker/runs/6622190178?check_suite_focus=true