### PR TITLE
Add caching for fetching object by keys

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -51,6 +51,8 @@ public class FakeValuesService {
     private final Map<String, String[]> args2splittedArgs = new WeakHashMap<>();
     private final Map<String, String[]> key2splittedKey = new WeakHashMap<>();
 
+    private final Map<String, Object> key2fetchedObject = new WeakHashMap<>();
+
     /**
      * Resolves YAML file using the most specific path first based on language and country code.
      * 'en_US' would resolve in the following order:
@@ -212,9 +214,12 @@ public class FakeValuesService {
      *            dot. E.g. name.first_name
      */
     public Object fetchObject(String key) {
-        String[] path = split(key);
+        Object result = key2fetchedObject.get(key);
+        if (result != null) {
+            return result;
+        }
 
-        Object result = null;
+        String[] path = split(key);
         for (Locale locale : localesChain) {
             Object currentValue = fakeValuesInterfaceMap.get(locale);
             for (int p = 0; currentValue != null && p < path.length; p++) {
@@ -230,6 +235,7 @@ public class FakeValuesService {
                 break;
             }
         }
+        key2fetchedObject.put(key, result);
         return result;
     }
 


### PR DESCRIPTION
The PR adds caching for fetching objects

It allows to speed up expressions where more than one method should be called 
Before
```
Benchmark                                       Mode  Cnt     Score    Error   Units
DatafakerBenchmark.address                     thrpt    5   109.668 ±  1.462  ops/ms
DatafakerBenchmark.oneMethodCallExpression     thrpt    5  1087.463 ± 24.951  ops/ms
DatafakerBenchmark.threeMethodsCallExpression  thrpt    5   281.641 ±  7.682  ops/ms
```

After
```
Benchmark                                       Mode  Cnt     Score    Error   Units
DatafakerBenchmark.address                     thrpt    5   119.390 ±  1.479  ops/ms
DatafakerBenchmark.oneMethodCallExpression     thrpt    5  1088.493 ± 19.085  ops/ms
DatafakerBenchmark.threeMethodsCallExpression  thrpt    5   328.149 ±  7.412  ops/ms
```
For one method it brings nothing however for cases where more than one method should be called (under fullAddress there are several methods should be called) it brings about 10% speed up