### PR TITLE
Use primitive int, long to generate numbers if possible

### DIFF
--- a/src/main/java/net/datafaker/Number.java
+++ b/src/main/java/net/datafaker/Number.java
@@ -17,25 +17,25 @@ public class Number {
      * Returns a random number from 0-9 (both inclusive)
      */
     public int randomDigit() {
-        return decimalBetween(0, 10).intValue();
+        return faker.random().nextInt(0, 9);
     }
 
     /**
      * Returns a random number from 1-9 (both inclusive)
      */
     public int randomDigitNotZero() {
-        return decimalBetween(1, 10).intValue();
+        return faker.random().nextInt(1, 9);
     }
 
     /**
      * Returns a positive number
      */
-    public int positive() { return decimalBetween(1, Integer.MAX_VALUE).intValue(); }
+    public int positive() { return numberBetween(1, Integer.MAX_VALUE); }
 
     /**
      * Returns a negative number
      */
-    public int negative() { return decimalBetween(0, Integer.MIN_VALUE).intValue(); }
+    public int negative() { return numberBetween(0, Integer.MIN_VALUE); }
 
     /**
      * @param min the lower bound (include min)
@@ -45,7 +45,12 @@ public class Number {
      */
     public int numberBetween(int min, int max) {
         if (min == max) return min;
-        return decimalBetween(min, max).intValue();
+        final int realMin = Math.min(min, max);
+        final int realMax = Math.max(min, max);
+        if (realMax - realMin >= realMin && (realMin >= 0 || realMax - realMin >= realMax)) {
+            return faker.random().nextInt(realMax - realMin) + realMin;
+        }
+        return decimalBetween(realMin, realMax).intValue();
     }
 
     /**
@@ -56,7 +61,12 @@ public class Number {
      */
     public long numberBetween(long min, long max) {
         if (min == max) return min;
-        return decimalBetween(min, max).longValue();
+        final long realMin = Math.min(min, max);
+        final long realMax = Math.max(min, max);
+        if (realMax - realMin >= realMin && (realMin >= 0 || realMax - realMin >= realMax)) {
+            return faker.random().nextLong(realMax - realMin) + realMin;
+        }
+        return decimalBetween(realMin, realMax).longValue();
     }
 
     /**
@@ -77,7 +87,7 @@ public class Number {
      * Returns a random number
      */
     public long randomNumber() {
-        int numberOfDigits = decimalBetween(1, 10).intValue();
+        int numberOfDigits = faker.random().nextInt(1, 10);
         return randomNumber(numberOfDigits, false);
     }
 

--- a/src/test/java/net/datafaker/NumberTest.java
+++ b/src/test/java/net/datafaker/NumberTest.java
@@ -5,10 +5,8 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -325,12 +323,11 @@ class NumberTest extends AbstractFakerTest {
      */
     private <T> double uniquePercentageOfResults(long iterations, Callable<T> callable) {
         try {
-            List<T> values = new ArrayList<>();
+            Set<T> values = new HashSet<>();
             for (long i = 0; i < iterations; i++) {
                 values.add(callable.call());
             }
-            long setSize = new HashSet<>(values).size();
-            return (double) setSize / (double) values.size();
+            return (double) values.size() / (double) iterations;
         } catch (Exception e) {
             throw new RuntimeException("error in uniquePercentageOfResults", e);
         }
@@ -340,7 +337,7 @@ class NumberTest extends AbstractFakerTest {
      * given a range, what is the number of values to get within that range for the randomization quality tests.
      */
     private long calculateNumbersToGet(long min, long max) {
-        long numbersToGet = Math.min((max - min) / 4, RANDOMIZATION_TESTS_MAX_NUMBERS_TO_GET);
+        long numbersToGet = Math.min(max / 4 - min / 4, RANDOMIZATION_TESTS_MAX_NUMBERS_TO_GET);
         if (numbersToGet == 0) numbersToGet = RANDOMIZATION_TESTS_MAX_NUMBERS_TO_GET;
         return numbersToGet;
     }


### PR DESCRIPTION
The PR makes use of primitive int and long wherever possible
It leads to speed up of `Number#numberBetween`
Before
```
Benchmark                              Mode  Cnt     Score    Error   Units
DatafakerSimpleMethods.numberBetween  thrpt   10  5342.357 ± 77.561  ops/ms
```
After
```
Benchmark                              Mode  Cnt       Score       Error   Units
DatafakerSimpleMethods.numberBetween  thrpt   10  168671.569 ± 18585.414  ops/ms
```