### PR TITLE
Simplify api for collections, add initial sizes for string builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,11 @@ also more examples at https://www.datafaker.net/documentation/expressions/
 ### Collections
 ```java
 Faker faker = new Faker();
-List<String> names = faker.<String>collection()
-                         .suppliers(
+List<String> names = faker.collection(
                               () -> faker.name().firstName(),
                               () -> faker.name().lastName())
-                         .minLen(3)
-                         .maxLen(5)
-                         .build().get();
+                         .len(3, 5)
+                         .generate();
 System.out.println(names);
 // [Skiles, O'Connell, Lorenzo, West]
 ```
@@ -107,14 +105,11 @@ more examples about that at https://www.datafaker.net/documentation/collections/
 ### File formats
 #### csv
 ```java
-String csv = Format.toCsv(
-                 faker.<Name>collection()
-                     .suppliers(() -> faker.name())
-                     .build())
-                 .headers(() -> "first_name", () -> "last_name")
-                 .columns(Name::firstName, Name::lastName)
-                 .separator(" ; ")
-                 .limit(2).build().get();
+String csv = Format.toCsv(faker.collection(faker::name).build())
+                .headers(() -> "first_name", () -> "last_name")
+                .columns(Name::firstName, Name::lastName)
+                .separator(" ; ")
+                .limit(2).build().get();
 // "first_name" ; "last_name"
 // "Kimberely" ; "Considine"
 // "Mariela" ; "Krajcik"
@@ -123,8 +118,7 @@ String csv = Format.toCsv(
 ```java
 Faker faker = new Faker();
 String json = Format.toJson(
-                  faker.<Name>collection()
-                  .suppliers(faker::name)
+                faker.collection(faker::name)
                   .maxLen(2)
                   .build())
               .set("firstName", Name::firstName)

--- a/docs/documentation/collections.md
+++ b/docs/documentation/collections.md
@@ -9,13 +9,11 @@ For example, the following code will generate a list of first and last names wit
 
     ``` java 
     List<String> names = 
-        faker.<String>collection()
-            .suppliers(
+        faker.collection(
                 () -> faker.name().firstName(), 
                 () -> faker.name().lastName())
-            .minLen(3)
-            .maxLen(5)
-            .build().get();
+            .len(3, 5)
+            .generate();
     ```
 
 A list can also contain different types:
@@ -23,13 +21,12 @@ A list can also contain different types:
 === "Java"
 
     ``` java 
-    List<Object> objects = 
-        faker.collection()
-            .suppliers(
-                () -> faker.name().firstName(), 
+    List<Object> objects =
+        faker.<Object>collection(
+                () -> faker.name().firstName(),
                 () -> faker.random().nextInt(100))
             .maxLen(5)
-            .build().get();
+            .generate();
     ```
 
 With usage of `nullRate` it is possible to specify how often it should contain null values.
@@ -38,14 +35,13 @@ By default, it's value is 0, i.e. no null values will be generated.
 === "Java"
 
     ``` java 
-    List<Object> objects = 
-        faker.collection()
-            .suppliers(
-                () -> faker.name().firstName(), 
+    List<Object> objects =
+        faker.<Object>collection(
+                () -> faker.name().firstName(),
                 () -> faker.random().nextInt(100))
             .nullRate(1)
             .maxLen(5)
-            .build().get();
+            .generate();
     ```
 will generate a collection where every value is null.
 And to generate a collection with only about 30% values of null `nullRate(0.3)` will do it
@@ -53,12 +49,11 @@ And to generate a collection with only about 30% values of null `nullRate(0.3)` 
 === "Java"
 
     ``` java 
-    List<Object> objects = 
-        faker.collection()
-            .suppliers(
-                () -> faker.name().firstName(), 
+    List<Object> objects =
+        faker.<Object>collection(
+                () -> faker.name().firstName(),
                 () -> faker.random().nextInt(100))
             .nullRate(0.3)
             .maxLen(5)
-            .build().get();
+            .generate();
     ```

--- a/docs/documentation/file-formats.md
+++ b/docs/documentation/file-formats.md
@@ -54,28 +54,24 @@ It's also possible to generate JSON output:
     ``` java
     Faker faker = new Faker();
     String json = Format.toJson(
-                    faker.<Name>collection()
-                        .suppliers(() -> faker.name())
-                        .maxLen(2)
-                        .minLen(2)
-                        .build())
-                    .set("firstName", Name::firstName)
-                    .set("lastName", Name::lastName)
-                    .set("address",
-                        Format.toJson(
-                            faker.<Address>collection()
-                                .suppliers(() -> faker.address())
-                                .maxLen(1)
-                                .minLen(1)
-                                .build())
-                        .set("country", Address::country)
-                        .set("city", Address::city)
-                        .set("zipcode", Address::zipCode)
-                        .set("streetAddress", Address::streetAddress)
-                        .build())
-                    .set("phones", name -> faker.<String>collection().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
-                    .build()
-                    .generate();
+                faker.collection(faker::name)
+                    .len(2)
+                    .build())
+            .set("firstName", Name::firstName)
+            .set("lastName", Name::lastName)
+            .set("address",
+                Format.toJson(
+                        faker.collection(faker::address)
+                            .len(1)
+                            .build())
+                    .set("country", Address::country)
+                    .set("city", Address::city)
+                    .set("zipcode", Address::zipCode)
+                    .set("streetAddress", Address::streetAddress)
+                    .build())
+            .set("phones", name -> faker.collection(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
+            .build()
+            .generate();
         System.out.println(json);
     ```
 
@@ -93,28 +89,24 @@ Another example with json payload
     ``` java
         Faker faker = new Faker();
         String json = Format.toJson(
-                        faker.<Name>collection().faker(faker)
-                            .suppliers(faker::name)
-                            .maxLen(2)
-                            .minLen(2)
+                faker.collection(faker::name).faker(faker)
+                    .len(2)
+                    .build())
+            .set("firstName", Name::firstName)
+            .set("lastName", Name::lastName)
+            .set("payload", payload ->
+                Format.toJson(
+                        faker.collection(faker::address)
+                            .len(1)
                             .build())
-                        .set("firstName", Name::firstName)
-                        .set("lastName", Name::lastName)
-                        .set("payload", payload ->
-                                    Format.toJson(
-                                            faker.<Address>collection()
-                                            .suppliers(faker::address)
-                                            .maxLen(1)
-                                            .minLen(1)
-                                            .build())
-                                    .set("country", Address::country)
-                                    .set("city", Address::city)
-                                    .set("zipcode", Address::zipCode)
-                                    .set("streetAddress", Address::streetAddress)
-                                    .build().generate())
-                        .set("phones", name -> faker.<String>collection().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
-                        .build()
-                        .generate();
+                    .set("country", Address::country)
+                    .set("city", Address::city)
+                    .set("zipcode", Address::zipCode)
+                    .set("streetAddress", Address::streetAddress)
+                    .build().generate())
+            .set("phones", name -> faker.collection(() -> faker.phoneNumber().phoneNumber()).maxLen(3).build().get())
+            .build()
+            .generate();
         System.out.println(json);
     ```
 

--- a/src/main/java/net/datafaker/FakeCollection.java
+++ b/src/main/java/net/datafaker/FakeCollection.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class FakeCollection<T> {
@@ -41,11 +40,24 @@ public class FakeCollection<T> {
     }
 
     public static class Builder<T> {
-        private final List<Supplier<T>> suppliers = new ArrayList<>();
+        private final List<Supplier<T>> suppliers;
         private int minLength = -1; // negative means same as maxLength
         private int maxLength = 10;
         private double nullRate = 0d;
         private Faker faker;
+
+        public Builder() {
+            suppliers = new ArrayList<>();
+        }
+
+        public Builder(List<Supplier<T>> list) {
+            suppliers = new ArrayList<>(list);
+        }
+
+        @SafeVarargs
+        public Builder(Supplier<T>... elems) {
+            suppliers = new ArrayList<>(Arrays.asList(elems));
+        }
 
         public Builder<T> faker(Faker faker) {
             this.faker = faker;
@@ -59,6 +71,16 @@ public class FakeCollection<T> {
 
         public Builder<T> maxLen(int maxLength) {
             this.maxLength = maxLength;
+            return this;
+        }
+
+        public Builder<T> len(int length) {
+            return len(length, length);
+        }
+
+        public Builder<T> len(int minLength, int maxLength) {
+            this.maxLength = maxLength;
+            this.minLength = minLength;
             return this;
         }
 
@@ -91,6 +113,10 @@ public class FakeCollection<T> {
             }
 
             return new FakeCollection<>(suppliers, minLength, maxLength, randomService, nullRate);
+        }
+
+        public List<T> generate() {
+            return build().get();
         }
     }
 }

--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -6,6 +6,7 @@ import net.datafaker.service.RandomService;
 
 import java.nio.file.Path;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
@@ -282,6 +283,15 @@ public class Faker {
      */
     public <T> FakeCollection.Builder<T> collection() {
         return new FakeCollection.Builder<T>().faker(this);
+    }
+
+    @SafeVarargs
+    public final <T> FakeCollection.Builder<T> collection(Supplier<T>... suppliers) {
+        return new FakeCollection.Builder<>(suppliers).faker(this);
+    }
+
+    public final <T> FakeCollection.Builder<T> collection(List<Supplier<T>> suppliers) {
+        return new FakeCollection.Builder<>(suppliers).faker(this);
     }
 
     public Address address() {

--- a/src/main/java/net/datafaker/Finance.java
+++ b/src/main/java/net/datafaker/Finance.java
@@ -95,8 +95,8 @@ public class Finance {
     private static String calculateIbanChecksum(String countryCode, String basicBankAccountNumber) {
         String basis = basicBankAccountNumber + countryCode + "00";
 
-        StringBuilder sb = new StringBuilder();
-        char[] characters = basis.toLowerCase().toCharArray();
+        final char[] characters = basis.toLowerCase().toCharArray();
+        final StringBuilder sb = new StringBuilder(characters.length);
         for (char c : characters) {
             if (Character.isLetter(c)) {
                 sb.append((c - 'a') + 10);
@@ -113,7 +113,7 @@ public class Finance {
         if (inputString.length() >= length) {
             return inputString;
         }
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(length);
         while (sb.length() < length - inputString.length()) {
             sb.append('0');
         }

--- a/src/main/java/net/datafaker/Internet.java
+++ b/src/main/java/net/datafaker/Internet.java
@@ -302,7 +302,7 @@ public class Internet {
      * @return a IPV6 address.
      */
     public InetAddress getIpV6Address() throws UnknownHostException {
-        final StringBuilder tmp = new StringBuilder();
+        final StringBuilder tmp = new StringBuilder(2 * 8 + 7);
         for (int i = 0; i < 8; i++) {
             if (i > 0) {
                 tmp.append(":");

--- a/src/main/java/net/datafaker/Number.java
+++ b/src/main/java/net/datafaker/Number.java
@@ -127,7 +127,7 @@ public class Number {
     }
 
     public String digits(int count) {
-        final StringBuilder tmp = new StringBuilder();
+        final StringBuilder tmp = new StringBuilder(count);
         for (int i = 0; i < count; i++) {
             tmp.append(randomDigit());
         }

--- a/src/test/java/net/datafaker/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/FakeCollectionTest.java
@@ -26,6 +26,28 @@ class FakeCollectionTest extends AbstractFakerTest {
     }
 
     @Test
+    void generateSequence() {
+        List<String> digits = faker
+            .collection(() -> faker.number().digit())
+            .len(3, 10).generate();
+        assertThat(digits).hasSizeBetween(3, 10);
+        for (String digit : digits) {
+            assertThat(digit).matches("\\d");
+        }
+    }
+
+    @Test
+    void generateSequence5() {
+        List<String> digits = faker
+            .collection(() -> faker.number().digit())
+            .len(5).generate();
+        assertThat(digits).hasSize(5);
+        for (String digit : digits) {
+            assertThat(digit).matches("\\d");
+        }
+    }
+
+    @Test
     void generateNullCollection() {
         List<String> names = faker.<String>collection()
             .suppliers(() -> faker.name().firstName(), () -> faker.name().lastName())


### PR DESCRIPTION
The PR simplifies usage of collection API to generate collections.
E.g. to generate a list of numbers between `123` and `12345` of length between 3 and 10 the following code could be used
```java
        List<Integer> numbers = faker
            .collection(() -> faker.number().numberBetween(123, 12345))
            .len(3, 10).generate();
```