### PR TITLE
Changed test method name in MovieTest

### DIFF
--- a/src/test/java/net/datafaker/MovieTest.java
+++ b/src/test/java/net/datafaker/MovieTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MovieTest extends AbstractFakerTest {
 
     @RepeatedTest(50)
-    void testName() {
+    void testQuote() {
         assertThat(faker.movie().quote()).matches("^[a-zA-Z ,'’.?]+$");
     }
 }


### PR DESCRIPTION
In #208, I named my test method as `testName` instead of `testQuote`. This pr fixes it.