### PR TITLE
Use Pattern instead of String for matching

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/EnIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/EnIdNumber.java
@@ -2,20 +2,22 @@ package net.datafaker.idnumbers;
 
 import net.datafaker.Faker;
 
+import java.util.regex.Pattern;
+
 public class EnIdNumber {
-    private static final String[] invalidSSNPatterns = {
-        "0{3}-\\\\d{2}-\\\\d{4}",
-        "\\d{3}-0{2}-\\d{4}",
-        "\\d{3}-\\d{2}-0{4}",
-        "666-\\d{2}-\\d{4}",
-        "9\\d{2}-\\d{2}-\\d{4}"};
+    private static final Pattern[] INVALID_SSN_PATTERNS = {
+        Pattern.compile("0{3}-\\\\d{2}-\\\\d{4}"),
+        Pattern.compile("\\d{3}-0{2}-\\d{4}"),
+        Pattern.compile("\\d{3}-\\d{2}-0{4}"),
+        Pattern.compile("666-\\d{2}-\\d{4}"),
+        Pattern.compile("9\\d{2}-\\d{2}-\\d{4}")};
 
     public String getValidSsn(Faker f) {
         String ssn = f.regexify("[0-8]\\d{2}-\\d{2}-\\d{4}");
 
         boolean isValid = true;
-        for (String invalidSSNPattern : invalidSSNPatterns) {
-            if (ssn.matches(invalidSSNPattern)) {
+        for (Pattern invalidSSNPattern : INVALID_SSN_PATTERNS) {
+            if (invalidSSNPattern.matcher(ssn).matches()) {
                 isValid = false;
                 break;
             }

--- a/src/main/java/net/datafaker/passportnumbers/AmPassportNumber.java
+++ b/src/main/java/net/datafaker/passportnumbers/AmPassportNumber.java
@@ -2,8 +2,10 @@ package net.datafaker.passportnumbers;
 
 import net.datafaker.Faker;
 
+import java.util.regex.Pattern;
+
 public class AmPassportNumber {
-    private static final String[] validAMPatterns = {"[0-9]{8}"};
+    private static final Pattern[] VALID_AM_PATTERNS = {Pattern.compile("\\d{8}")};
 
     /**
      * Generates a valid American passport number
@@ -15,8 +17,8 @@ public class AmPassportNumber {
         String am = faker.regexify("[0-9A-Z]{8}");
 
         boolean isValid = false;
-        for (String validAMPattern : validAMPatterns) {
-            if (am.matches(validAMPattern)) {
+        for (Pattern validAMPattern : VALID_AM_PATTERNS) {
+            if (validAMPattern.matcher(am).matches()) {
                 isValid = true;
                 break;
             }
@@ -37,8 +39,8 @@ public class AmPassportNumber {
         String am = faker.regexify("[A-Z0-9]{1,}");
 
         boolean isValid = true;
-        for (String validAMPattern : validAMPatterns) {
-            if (am.matches(validAMPattern)) {
+        for (Pattern validAMPattern : VALID_AM_PATTERNS) {
+            if (validAMPattern.matcher(am).matches()) {
                 continue;
             }
             isValid = false;

--- a/src/main/java/net/datafaker/passportnumbers/ChPassportNumber.java
+++ b/src/main/java/net/datafaker/passportnumbers/ChPassportNumber.java
@@ -2,10 +2,12 @@ package net.datafaker.passportnumbers;
 
 import net.datafaker.Faker;
 
+import java.util.regex.Pattern;
+
 public class ChPassportNumber {
-    private static final String[] validCHPatterns = {
-        "E[0-9][0-9]{7}",
-        "G[0-9]{8}"};
+    private static final Pattern[] validCHPatterns = {
+        Pattern.compile("E\\d\\d{7}"),
+        Pattern.compile("G\\d{8}")};
 
     /**
      * Generates a valid Chinese passport number
@@ -17,8 +19,8 @@ public class ChPassportNumber {
         String ch = faker.regexify("[A-Z][0-9A-Z][0-9]{7}");
 
         boolean isValid = false;
-        for (String validCHPattern : validCHPatterns) {
-            if (ch.matches(validCHPattern)) {
+        for (Pattern validCHPattern : validCHPatterns) {
+            if (validCHPattern.matcher(ch).matches()) {
                 isValid = true;
                 break;
             }
@@ -39,8 +41,8 @@ public class ChPassportNumber {
         String ch = faker.regexify("[A-Z0-9]{1,}");
 
         boolean isValid = true;
-        for (String validCHPattern : validCHPatterns) {
-            if (ch.matches(validCHPattern)) {
+        for (Pattern validCHPattern : validCHPatterns) {
+            if (validCHPattern.matcher(ch).matches()) {
                 continue;
             }
             isValid = false;

--- a/src/test/java/net/datafaker/PassportTest.java
+++ b/src/test/java/net/datafaker/PassportTest.java
@@ -2,12 +2,15 @@ package net.datafaker;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author CharlotteE67
  */
+@Execution(ExecutionMode.CONCURRENT)
 class PassportTest extends AbstractFakerTest {
 
     @Test
@@ -34,8 +37,8 @@ class PassportTest extends AbstractFakerTest {
 
     @Test
     void testChInValid() {
-        assertThat(faker.passport().chInvalid().matches("E[0-9A-HJ-NP-Z][0-9]{7}")
-            && faker.passport().chInvalid().matches("G[0-9]{8}")).isFalse();
+        assertThat(faker.passport().chInvalid().matches("E[\\dA-HJ-NP-Z]\\d{7}")
+            && faker.passport().chInvalid().matches("G\\d{8}")).isFalse();
     }
 
     @Test
@@ -45,7 +48,7 @@ class PassportTest extends AbstractFakerTest {
 
     @Test
     void testAmValid() {
-        assertThat(faker.passport().amValid().matches("[0-9]{8}")).isTrue();
+        assertThat(faker.passport().amValid()).matches("\\d{8}");
     }
 
     @Test
@@ -55,7 +58,7 @@ class PassportTest extends AbstractFakerTest {
 
     @Test
     void testAmInValid() {
-        assertThat(faker.passport().amInvalid().matches("[0-9]{8}")).isFalse();
+        assertThat(faker.passport().amInvalid()).doesNotMatch("\\d{8}");
     }
 
     @Test


### PR DESCRIPTION
For perf reasons it's better to use precompiled `Pattern` than compiling `String` each time