### PR TITLE
Use decimal number format for longitude, latitude instead of computerized scientific notation

### DIFF
--- a/src/main/java/net/datafaker/Address.java
+++ b/src/main/java/net/datafaker/Address.java
@@ -103,14 +103,14 @@ public class Address {
      * @return Returns the latitude, a number between -90 to 90.
      */
     public String latitude() {
-        return String.format(Locale.ROOT, "%.8g", (faker.random().nextDouble() * 180) - 90);
+        return String.format(Locale.ROOT, "%.8f", (faker.random().nextDouble() * 180) - 90);
     }
 
     /**
      * @return Returns the longitude, a number between -180 and 180
      */
     public String longitude() {
-        return String.format(Locale.ROOT, "%.8g", (faker.random().nextDouble() * 360) - 180);
+        return String.format(Locale.ROOT, "%.8f", (faker.random().nextDouble() * 360) - 180);
     }
 
     /**

--- a/src/test/java/net/datafaker/AddressTest.java
+++ b/src/test/java/net/datafaker/AddressTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +18,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class AddressTest extends AbstractFakerTest {
 
     private static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols(getFaker().getLocale()).getDecimalSeparator();
+    private static final Faker US_FAKER = new Faker(new Locale("en-us"));
+    private static final Faker NL_FAKER = new Faker(new Locale("nl-nl"));
+
     public static final Condition<String> IS_A_NUMBER = new Condition<>(s -> {
         try {
             Double.valueOf(s);
@@ -26,8 +30,8 @@ class AddressTest extends AbstractFakerTest {
         return true;
     }, "Is a number");
 
-    public static final String LAT_LON_REGEX = "-?\\d{1,2}.\\d{5,10},-?\\d{1,3}.\\d{5,10}+";
-    public static final String LON_LAT_REGEX = "-?\\d{1,3}.\\d{5,10}+,-?\\d{1,2}.\\d{5,10}";
+    public static final Pattern LAT_LON_REGEX = Pattern.compile("-?\\d{1,2}.\\d{5,10},-?\\d{1,3}.\\d{5,10}+");
+    public static final Pattern LON_LAT_REGEX = Pattern.compile("-?\\d{1,3}.\\d{5,10}+,-?\\d{1,2}.\\d{5,10}");
 
     @Test
     void testStreetAddressStartsWithNumber() {
@@ -194,26 +198,22 @@ class AddressTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     void testLatLonEnUs() {
-        final Faker localFaker = new Faker(new Locale("en-us"));
-        assertThat(localFaker.address().latLon()).matches(LAT_LON_REGEX);
+        assertThat(US_FAKER.address().latLon()).matches(LAT_LON_REGEX);
     }
 
     @RepeatedTest(100)
     void testLatLonNl() {
-        final Faker localFaker = new Faker(new Locale("nl-nl"));
-        assertThat(localFaker.address().latLon()).matches(LAT_LON_REGEX);
+        assertThat(NL_FAKER.address().latLon()).matches(LAT_LON_REGEX);
     }
 
     @RepeatedTest(100)
     void testLonLatEnUs() {
-        final Faker localFaker = new Faker(new Locale("en-us"));
-        assertThat(localFaker.address().lonLat()).matches(LON_LAT_REGEX);
+        assertThat(US_FAKER.address().lonLat()).matches(LON_LAT_REGEX);
     }
 
     @RepeatedTest(100)
     void testLonLatNl() {
-        final Faker localFaker = new Faker(new Locale("nl-nl"));
-        assertThat(localFaker.address().lonLat()).matches(LON_LAT_REGEX);
+        assertThat(NL_FAKER.address().lonLat()).matches(LON_LAT_REGEX);
     }
 
 }


### PR DESCRIPTION
The PR fixing failing longitude/latitude test https://github.com/datafaker-net/datafaker/runs/6810315041?check_suite_focus=true#step:4:854