### PR TITLE
Add support of doWith

### DIFF
--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 /**
@@ -95,6 +96,21 @@ public class Faker {
     public Locale getLocale() {
         return fakeValuesService.getLocalesChain().isEmpty() || fakeValuesService.getLocalesChain().get(0) == null
             ? Locale.ROOT : fakeValuesService.getLocalesChain().get(0);
+    }
+
+    public <T> T doWith(Callable<T> callable, Locale locale) {
+        final Locale current = fakeValuesService.getCurrentLocale();
+        T result;
+        try {
+            fakeValuesService.setCurrentLocale(locale);
+            result = callable.call();
+            return result;
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        } finally {
+            fakeValuesService.setCurrentLocale(current);
+        }
+
     }
 
     /**

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -39,22 +39,24 @@ public class FakeValuesService {
     private static final Logger LOG = Logger.getLogger("faker");
     private static final Map<Locale, FakeValuesInterface> FAKE_VALUES_CACHE = new HashMap<>();
 
-    private final Map<Locale, FakeValuesInterface> fakeValuesInterfaceMap = new HashMap<>();
+    private static final Map<Locale, FakeValuesInterface> fakeValuesInterfaceMap = new HashMap<>();
+    private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
     private final RandomService randomService;
+    private Locale currentLocale;
 
-    private final List<Locale> localesChain;
+    private final Map<Locale, List<Locale>> locale2localesChain;
 
-    private final Map<Class<?>, Map<String, Collection<Method>>> class2methodsCache = new IdentityHashMap<>();
-    private final Map<Class<?>, Constructor<?>> class2constructorCache = new IdentityHashMap<>();
+    private static final Map<Class<?>, Map<String, Collection<Method>>> class2methodsCache = new IdentityHashMap<>();
+    private static final Map<Class<?>, Constructor<?>> class2constructorCache = new IdentityHashMap<>();
     private final Map<String, Generex> expression2generex = new WeakHashMap<>();
-    private final Map<String, String> key2Expression = new WeakHashMap<>();
+    private final Map<Locale, Map<String, String>> key2Expression = new WeakHashMap<>();
     private final Map<String, String[]> args2splittedArgs = new WeakHashMap<>();
     private final Map<String, String[]> key2splittedKey = new WeakHashMap<>();
 
-    private final Map<String, Object> key2fetchedObject = new WeakHashMap<>();
+    private final Map<Locale, Map<String, Object>> key2fetchedObject = new WeakHashMap<>();
     private final Map<String, String> name2yaml = new WeakHashMap<>();
 
-    private final Map<Class<?>, Map<String, Map<String[], MethodAndCoercedArgs>>> mapOfMethodAndCoercedArgs = new IdentityHashMap<>();
+    private static final Map<Class<?>, Map<String, Map<String[], MethodAndCoercedArgs>>> mapOfMethodAndCoercedArgs = new IdentityHashMap<>();
 
     private static final Map<String, List<String>> EXPRESSION_2_SPLITTED = new WeakHashMap<>();
 
@@ -79,16 +81,23 @@ public class FakeValuesService {
             throw new IllegalArgumentException("locale is required");
         }
         this.randomService = randomService;
-        locale = normalizeLocale(locale);
+        this.locale2localesChain = new HashMap<>();
+        setCurrentLocale(locale);
+    }
 
-        localesChain = localeChain(locale);
-        for (final Locale l : localesChain) {
+    public void setCurrentLocale(Locale locale) {
+        currentLocale = normalizeLocale(locale);
+        if (locale2localesChain.containsKey(currentLocale)) {
+            return;
+        }
+        locale2localesChain.put(currentLocale, localeChain(currentLocale));
+        for (final Locale l : locale2localesChain.get(currentLocale)) {
             fakeValuesInterfaceMap.computeIfAbsent(l, this::getCachedFakeValue);
         }
     }
 
     private FakeValuesInterface getCachedFakeValue(Locale locale) {
-        if (Locale.ENGLISH.equals(locale)) {
+        if (DEFAULT_LOCALE.equals(locale)) {
             return FakeValuesGrouping.getEnglishFakeValueGrouping();
         }
         return FAKE_VALUES_CACHE.computeIfAbsent(locale, FakeValues::new);
@@ -126,18 +135,18 @@ public class FakeValuesService {
      * @return a list of {@link Locale} instances
      */
     protected List<Locale> localeChain(Locale from) {
-        if (Locale.ENGLISH.equals(from)) {
-            return Collections.singletonList(Locale.ENGLISH);
+        if (DEFAULT_LOCALE.equals(from)) {
+            return Collections.singletonList(DEFAULT_LOCALE);
         }
 
         final Locale normalized = normalizeLocale(from);
 
         final List<Locale> chain = new ArrayList<>(3);
         chain.add(normalized);
-        if (!"".equals(normalized.getCountry()) && !Locale.ENGLISH.getLanguage().equals(normalized.getLanguage())) {
+        if (!"".equals(normalized.getCountry()) && !DEFAULT_LOCALE.getLanguage().equals(normalized.getLanguage())) {
             chain.add(new Locale(normalized.getLanguage()));
         }
-        chain.add(Locale.ENGLISH); // default
+        chain.add(DEFAULT_LOCALE); // default
         return chain;
     }
 
@@ -157,7 +166,11 @@ public class FakeValuesService {
     }
 
     public List<Locale> getLocalesChain() {
-        return localesChain;
+        return locale2localesChain.get(currentLocale);
+    }
+
+    public Locale getCurrentLocale() {
+        return currentLocale;
     }
 
     /**
@@ -219,13 +232,23 @@ public class FakeValuesService {
      *            dot. E.g. name.first_name
      */
     public Object fetchObject(String key) {
-        Object result = key2fetchedObject.get(key);
+        Object result = null;
+        for (Locale locale: locale2localesChain.get(currentLocale)) {
+            // exclude default locale from cache checks
+            if (locale.equals(DEFAULT_LOCALE) && locale2localesChain.get(currentLocale).size() > 1) {
+                continue;
+            }
+            if (key2fetchedObject.get(locale) != null && (result = key2fetchedObject.get(locale).get(key)) != null) {
+                break;
+            }
+        }
         if (result != null) {
             return result;
         }
 
         String[] path = split(key);
-        for (Locale locale : localesChain) {
+        Locale local2Add = null;
+        for (Locale locale : locale2localesChain.get(currentLocale)) {
             Object currentValue = fakeValuesInterfaceMap.get(locale);
             for (int p = 0; currentValue != null && p < path.length; p++) {
                 String currentPath = path[p];
@@ -237,10 +260,14 @@ public class FakeValuesService {
             }
             result = currentValue;
             if (result != null) {
+                local2Add = locale;
+                key2fetchedObject.putIfAbsent(local2Add, new HashMap<>());
                 break;
             }
         }
-        key2fetchedObject.put(key, result);
+        if (local2Add != null) {
+            key2fetchedObject.get(local2Add).put(key, result);
+        }
         return result;
     }
 
@@ -417,11 +444,12 @@ public class FakeValuesService {
      * #{Person.hello_someone} will result in a method call to person.helloSomeone();
      */
     public String resolve(String key, Object current, Faker root, Supplier<String> exceptionMessage) {
-        String expression = root == null ? key2Expression.get(key) : null;
+        String expression = root == null ? key2Expression.get(currentLocale).get(key) : null;
         if (expression == null) {
             expression = safeFetch(key, null);
             if (root == null) {
-                key2Expression.put(key, expression);
+                key2Expression.putIfAbsent(currentLocale, new HashMap<>());
+                key2Expression.get(currentLocale).put(key, expression);
             }
         }
 

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Random;
+import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -271,5 +272,17 @@ class FakerTest extends AbstractFakerTest {
         assertThat(Faker.instance(Locale.CANADA)).isInstanceOf(Faker.class);
         assertThat(Faker.instance(new Random(1))).isInstanceOf(Faker.class);
         assertThat(Faker.instance(Locale.CHINA, new Random(2))).isInstanceOf(Faker.class);
+    }
+
+    @Test
+    void differentLocalesTest() {
+        Callable<String> stringCallable = () -> faker.name().firstName();
+        faker.name().firstName();
+        faker.doWith(stringCallable, new Locale("ru_RU"));
+        faker.doWith(stringCallable, Locale.GERMAN);
+        faker.doWith(stringCallable, Locale.SIMPLIFIED_CHINESE);
+        for (int i = 0; i < 10; i++) {
+            assertThat(faker.doWith(stringCallable ,new Locale("ru_RU"))).matches("[а-яА-ЯЁё ]+");
+        }
     }
 }


### PR DESCRIPTION
The PR allows to do some actions in a different locale within same `Faker` object, e.g.
```java
Faker faker = new Faker();
faker.name().firstName() + " "
                + faker.doWith(() -> faker.name().lastName(), Locale.SIMPLIFIED_CHINESE) + " "
                + faker.doWith(() -> faker.name().nameWithMiddle(), new Locale("ru-RU"));
```
Could lead to `Demarcus 罗 Тамара Григорьевна Комиссарова`

Update: also could be used in colections/csv and etc. e.g.
```java
Function<Locale, Supplier<String>> firstNameSupplier = locale -> () -> faker.doWith(() -> faker.name().firstName(), locale);

String csv = Format.toCsv(
        Csv.Column.of("CA First Name", firstNameSupplier.apply(Locale.CANADA)),
        Csv.Column.of("CN First Name", firstNameSupplier.apply(Locale.SIMPLIFIED_CHINESE)),
        Csv.Column.of("DE First Name", firstNameSupplier.apply(Locale.GERMAN)),
        Csv.Column.of("FR First Name", firstNameSupplier.apply(Locale.FRANCE)),
        Csv.Column.of("JP First Name", firstNameSupplier.apply(Locale.JAPAN)),
        Csv.Column.of("KR First Name", firstNameSupplier.apply(Locale.KOREAN)),
        Csv.Column.of("RU First Name", firstNameSupplier.apply(new Locale("ru_RU")))
    )
    .header(true)
    .separator(" ; ")
    .limit(5).build().get();
System.out.println(csv);
```

could output something like this
```
"CA First Name" ; "CN First Name" ; "DE First Name" ; "FR First Name" ; "JP First Name" ; "KR First Name" ; "RU First Name"
"Caleb" ; "志泽" ; "Lydia" ; "Justine" ; "陽子" ; "민재" ; "Анастасия"
"Wilton" ; "琪" ; "Ferdinand" ; "Léo" ; "一郎" ; "은주" ; "Наталья"
"Titus" ; "凯瑞" ; "Lias" ; "Thomas" ; "美穂" ; "현준" ; "Ольга"
"Barrett" ; "雪松" ; "Julienne" ; "Alicia" ; "綾乃" ; "현우" ; "Вячеслав"
"Melvina" ; "思聪" ; "Leonie" ; "Rayan" ; "空" ; "지민" ; "Вадим"

```