### PR TITLE
Set spotless checking unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <commons-text.version>1.9</commons-text.version>
         <commons-validator.version>1.7</commons-validator.version>
         <generex.version>1.0.2</generex.version>
+        <google.javaformat.version>1.7</google.javaformat.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <jbanking.version>3.2.0</jbanking.version>
         <junit.version>5.8.2</junit.version>
@@ -46,7 +47,12 @@
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <reflections.version>0.10.2</reflections.version>
         <snakeyaml.version>1.30</snakeyaml.version>
+        <spotless-maven-plugin.version>2.22.8</spotless-maven-plugin.version>
         <coverage.reports.dir>${project.build.directory}/target/coverage-reports</coverage.reports.dir>
+
+        <!-- Run tests in Turkish to make sure that they don't depend on
+                         locale. Turkish is a notoriously tricky locale. -->
+        <surefire.argline>@{argLine} -Duser.language=TR -Duser.country=tr</surefire.argline>
     </properties>
     <licenses>
         <license>
@@ -183,6 +189,25 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
+                <configuration>
+                    <java>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
@@ -304,11 +329,32 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
-                    <!-- Run tests in Turkish to make sure that they don't depend on
-                         locale. Turkish is a notoriously tricky locale. -->
-                    <argLine>@{argLine} -Duser.language=TR -Duser.country=tr</argLine>
+                    <argLine>${surefire.argline}</argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <argLine>${surefire.argline} --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                                </argLine>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/test/java/net/datafaker/MbtiTest.java
+++ b/src/test/java/net/datafaker/MbtiTest.java
@@ -1,6 +1,5 @@
 package net.datafaker;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Add autoformatter `spotless` (https://github.com/diffplug/spotless) embedded into build
Apply google format (version 7) format. Version 7 since it still supports java8.

**Currently it is set to check unused imports only**

Now in case of violations it could being automatically fixed (including removal of unused imports) with `mvn spotless:apply` (this will be also mentioned in error message).

Here the format fix is the result of `mvn spotless:apply`