### PR TITLE
Add fast return if a string is already capitalized

### DIFF
--- a/src/main/java/net/datafaker/internal/helper/WordUtils.java
+++ b/src/main/java/net/datafaker/internal/helper/WordUtils.java
@@ -7,6 +7,7 @@ public class WordUtils {
     public static String capitalize(String input) {
         if (input == null) return null;
         if (input.equals("")) return "";
+        if (Character.isUpperCase(input.charAt(0))) return input;
         return input.substring(0, 1).toUpperCase(Locale.ROOT) + input.substring(1);
     }
 }


### PR DESCRIPTION
Add fast return for the case of already capitalized strings instead of creating new objects