### PR TITLE
Introduce AbstractProvider

### DIFF
--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -21,12 +21,11 @@ Create a custom provider of data:
 === "Java"
 
     ``` java
-    public static class Insect {
+    public static class Insect extends AbstractProvider {
         private static final String[] INSECT_NAMES = new String[]{"Ant", "Beetle", "Butterfly", "Wasp"};
-        private final Faker faker;
 
         public Insect(Faker faker) {
-            this.faker = faker;
+            super(faker);
         }
 
         public String nextInsectName() {
@@ -83,12 +82,11 @@ First, create the custom provider which loads the data from a file:
 === "Java"
 
     ``` java
-    public static class InsectFromFile {
+    public static class InsectFromFile extends AbstractProvider {
         private static final String KEY = "insectsfromfile";
-        private final Faker faker;
-
+        
         public InsectFromFile(Faker faker) {
-            this.faker = faker;
+            super(faker);
             faker.addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
             faker.addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));
         }

--- a/src/main/java/net/datafaker/AbstractProvider.java
+++ b/src/main/java/net/datafaker/AbstractProvider.java
@@ -1,0 +1,13 @@
+package net.datafaker;
+
+public class AbstractProvider {
+    protected final Faker faker;
+
+    protected AbstractProvider(Faker faker) {
+        this.faker = faker;
+    }
+
+    public final Faker getFaker() {
+        return faker;
+    }
+}

--- a/src/main/java/net/datafaker/Address.java
+++ b/src/main/java/net/datafaker/Address.java
@@ -3,15 +3,13 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Address {
-    private final Faker faker;
-
+public class Address extends AbstractProvider{
     protected Address(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String streetName() {
-        return faker.fakeValuesService().resolve("address.street_name", this, faker);
+        return faker.fakeValuesService().resolve("address.street_name", this);
     }
 
     public String streetAddressNumber() {
@@ -19,11 +17,11 @@ public class Address {
     }
 
     public String streetAddress() {
-        return faker.fakeValuesService().resolve("address.street_address", this, faker);
+        return faker.fakeValuesService().resolve("address.street_address", this);
     }
 
     public String streetAddress(boolean includeSecondary) {
-        String streetAddress = faker.fakeValuesService().resolve("address.street_address", this, faker);
+        String streetAddress = faker.fakeValuesService().resolve("address.street_address", this);
         if (includeSecondary) {
             streetAddress = streetAddress + " " + secondaryAddress();
         }
@@ -31,7 +29,7 @@ public class Address {
     }
 
     public String secondaryAddress() {
-        return faker.numerify(faker.fakeValuesService().resolve("address.secondary_address", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("address.secondary_address", this));
     }
 
     /**
@@ -40,11 +38,11 @@ public class Address {
      * @return a String representing a standard zip code
      */
     public String zipCode() {
-        return faker.bothify(faker.fakeValuesService().resolve("address.postcode", this, faker));
+        return faker.bothify(faker.fakeValuesService().resolve("address.postcode", this));
     }
 
     public String postcode() {
-        return faker.bothify(faker.fakeValuesService().resolve("address.postcode", this, faker));
+        return faker.bothify(faker.fakeValuesService().resolve("address.postcode", this));
     }
 
     /**
@@ -54,11 +52,11 @@ public class Address {
      * @return a String representing a ZIP+4 code
      */
     public String zipCodePlus4() {
-        return faker.bothify(faker.fakeValuesService().resolve("address.postcode_plus_four", this, faker));
+        return faker.bothify(faker.fakeValuesService().resolve("address.postcode_plus_four", this));
     }
 
     public String zipCodeByState(String stateAbbr) {
-        return faker.fakeValuesService().resolve("address.postcode_by_state." + stateAbbr, this, faker);
+        return faker.fakeValuesService().resolve("address.postcode_by_state." + stateAbbr, this);
     }
 
     public String countyByZipCode(String postCode) {
@@ -66,35 +64,35 @@ public class Address {
     }
 
     public String streetSuffix() {
-        return faker.fakeValuesService().resolve("address.street_suffix", this, faker);
+        return faker.fakeValuesService().resolve("address.street_suffix", this);
     }
 
     public String streetPrefix() {
-        return faker.fakeValuesService().resolve("address.street_prefix", this, faker);
+        return faker.fakeValuesService().resolve("address.street_prefix", this);
     }
 
     public String citySuffix() {
-        return faker.fakeValuesService().resolve("address.city_suffix", this, faker);
+        return faker.fakeValuesService().resolve("address.city_suffix", this);
     }
 
     public String cityPrefix() {
-        return faker.fakeValuesService().resolve("address.city_prefix", this, faker);
+        return faker.fakeValuesService().resolve("address.city_prefix", this);
     }
 
     public String city() {
-        return faker.fakeValuesService().resolve("address.city", this, faker);
+        return faker.fakeValuesService().resolve("address.city", this);
     }
 
     public String cityName() {
-        return faker.fakeValuesService().resolve("address.city_name", this, faker);
+        return faker.fakeValuesService().resolve("address.city_name", this);
     }
 
     public String state() {
-        return faker.fakeValuesService().resolve("address.state", this, faker);
+        return faker.fakeValuesService().resolve("address.state", this);
     }
 
     public String stateAbbr() {
-        return faker.fakeValuesService().resolve("address.state_abbr", this, faker);
+        return faker.fakeValuesService().resolve("address.state_abbr", this);
     }
 
     /**
@@ -140,26 +138,26 @@ public class Address {
     }
 
     public String timeZone() {
-        return faker.fakeValuesService().resolve("address.time_zone", this, faker);
+        return faker.fakeValuesService().resolve("address.time_zone", this);
     }
 
     public String country() {
-        return faker.fakeValuesService().resolve("address.country", this, faker);
+        return faker.fakeValuesService().resolve("address.country", this);
     }
 
     public String countryCode() {
-        return faker.fakeValuesService().resolve("address.country_code", this, faker);
+        return faker.fakeValuesService().resolve("address.country_code", this);
     }
 
     public String buildingNumber() {
-        return faker.numerify(faker.fakeValuesService().resolve("address.building_number", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("address.building_number", this));
     }
 
     public String fullAddress() {
-        return faker.fakeValuesService().resolve("address.full_address", this, faker);
+        return faker.fakeValuesService().resolve("address.full_address", this);
     }
 
     public String mailBox() {
-        return faker.numerify(faker.fakeValuesService().resolve("address.mail_box", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("address.mail_box", this));
     }
 }

--- a/src/main/java/net/datafaker/Ancient.java
+++ b/src/main/java/net/datafaker/Ancient.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Ancient {
-
-    private final Faker faker;
+public class Ancient extends AbstractProvider {
 
     protected Ancient(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String god() {

--- a/src/main/java/net/datafaker/Animal.java
+++ b/src/main/java/net/datafaker/Animal.java
@@ -5,15 +5,14 @@ import net.datafaker.internal.helper.WordUtils;
 /**
  * @since 0.8.0
  */
-public class Animal {
-    private final Faker faker;
+public class Animal extends AbstractProvider {
 
     protected Animal(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.animal.name", this, faker);
+        return faker.fakeValuesService().resolve("creature.animal.name", this);
     }
 
     public String scientificName() {
@@ -21,10 +20,10 @@ public class Animal {
     }
 
     public String genus() {
-        return WordUtils.capitalize(faker.fakeValuesService().resolve("creature.animal.genus", this, faker));
+        return WordUtils.capitalize(faker.fakeValuesService().resolve("creature.animal.genus", this));
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("creature.animal.species", this, faker).toLowerCase();
+        return faker.fakeValuesService().resolve("creature.animal.species", this).toLowerCase();
     }
 }

--- a/src/main/java/net/datafaker/App.java
+++ b/src/main/java/net/datafaker/App.java
@@ -3,22 +3,21 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class App {
-    private final Faker faker;
+public class App extends AbstractProvider {
 
     protected App(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("app.name", this, faker);
+        return faker.fakeValuesService().resolve("app.name", this);
     }
 
     public String version() {
-        return faker.numerify(faker.fakeValuesService().resolve("app.version", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("app.version", this));
     }
 
     public String author() {
-        return faker.fakeValuesService().resolve("app.author", this, faker);
+        return faker.fakeValuesService().resolve("app.author", this);
     }
 }

--- a/src/main/java/net/datafaker/Appliance.java
+++ b/src/main/java/net/datafaker/Appliance.java
@@ -3,18 +3,17 @@ package net.datafaker;
 /**
  * @since 1.0.0
  */
-public class Appliance {
-    private final Faker faker;
+public class Appliance extends AbstractProvider {
 
     protected Appliance(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String brand() {
-        return faker.fakeValuesService().resolve("appliance.brand", this, faker);
+        return faker.fakeValuesService().resolve("appliance.brand", this);
     }
 
     public String equipment() {
-        return faker.fakeValuesService().resolve("appliance.equipment", this, faker);
+        return faker.fakeValuesService().resolve("appliance.equipment", this);
     }
 }

--- a/src/main/java/net/datafaker/AquaTeenHungerForce.java
+++ b/src/main/java/net/datafaker/AquaTeenHungerForce.java
@@ -3,16 +3,14 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class AquaTeenHungerForce {
-
-    private final Faker faker;
+public class AquaTeenHungerForce extends AbstractProvider {
 
     protected AquaTeenHungerForce(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("aqua_teen_hunger_force.character", this, faker);
+        return faker.fakeValuesService().resolve("aqua_teen_hunger_force.character", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Artist.java
+++ b/src/main/java/net/datafaker/Artist.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Artist {
-
-    private final Faker faker;
+public class Artist extends AbstractProvider {
 
     protected Artist(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {

--- a/src/main/java/net/datafaker/Australia.java
+++ b/src/main/java/net/datafaker/Australia.java
@@ -3,24 +3,22 @@ package net.datafaker;
 /**
  * @since 1.2.0
  */
-public class Australia {
-
-    private final Faker faker;
+public class Australia extends AbstractProvider {
 
     protected Australia(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String locations() {
-        return faker.fakeValuesService().resolve("australia.locations", this, faker);
+        return faker.fakeValuesService().resolve("australia.locations", this);
     }
 
     public String animals() {
-        return faker.fakeValuesService().resolve("australia.animals", this, faker);
+        return faker.fakeValuesService().resolve("australia.animals", this);
     }
 
     public String states() {
-        return faker.fakeValuesService().resolve("australia.states", this, faker);
+        return faker.fakeValuesService().resolve("australia.states", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Avatar.java
+++ b/src/main/java/net/datafaker/Avatar.java
@@ -3,12 +3,11 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Avatar {
-    private final Faker faker;
+public class Avatar extends AbstractProvider {
     private final String baseUrl;
 
     protected Avatar(Faker faker) {
-        this.faker = faker;
+        super(faker);
         this.baseUrl = "https://robohash.org/";
     }
 

--- a/src/main/java/net/datafaker/Aviation.java
+++ b/src/main/java/net/datafaker/Aviation.java
@@ -5,12 +5,10 @@ package net.datafaker;
  *
  * @since 0.8.0
  */
-public class Aviation {
-
-    private final Faker faker;
+public class Aviation extends AbstractProvider {
 
     protected Aviation(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Aws.java
+++ b/src/main/java/net/datafaker/Aws.java
@@ -5,16 +5,14 @@ import java.util.UUID;
 /**
  * @since 1.3.0
  */
-public class Aws {
-
-    private final Faker faker;
+public class Aws extends AbstractProvider {
 
     protected Aws(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String region() {
-        return faker.fakeValuesService().resolve("aws.regions", this, faker);
+        return faker.fakeValuesService().resolve("aws.regions", this);
     }
 
     public String accountId() {

--- a/src/main/java/net/datafaker/Babylon5.java
+++ b/src/main/java/net/datafaker/Babylon5.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Babylon5 {
-    private final Faker faker;
+public class Babylon5 extends AbstractProvider {
 
     protected Babylon5(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/BackToTheFuture.java
+++ b/src/main/java/net/datafaker/BackToTheFuture.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class BackToTheFuture {
-    private final Faker faker;
+public class BackToTheFuture extends AbstractProvider {
 
     protected BackToTheFuture(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Barcode.java
+++ b/src/main/java/net/datafaker/Barcode.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Barcode {
-    private final Faker faker;
+public class Barcode extends AbstractProvider {
 
     public Barcode(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public long ean13() {

--- a/src/main/java/net/datafaker/Basketball.java
+++ b/src/main/java/net/datafaker/Basketball.java
@@ -6,8 +6,7 @@ package net.datafaker;
  * @author unknown and irakatz
  * @since 0.8.0
  */
-public class Basketball {
-    private final Faker faker;
+public class Basketball extends AbstractProvider {
 
     /**
      * Create a constructor for Basketball.
@@ -15,7 +14,7 @@ public class Basketball {
      * @param faker The Faker instance for generating random, different kinds of disease, e.g. the internal disease.
      */
     protected Basketball(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -24,7 +23,7 @@ public class Basketball {
      * @return Basketball teams
      */
     public String teams() {
-        return faker.fakeValuesService().resolve("basketball.teams", this, faker);
+        return faker.fakeValuesService().resolve("basketball.teams", this);
     }
 
     /**
@@ -33,7 +32,7 @@ public class Basketball {
      * @return Basketball coaches
      */
     public String coaches() {
-        return faker.fakeValuesService().resolve("basketball.coaches", this, faker);
+        return faker.fakeValuesService().resolve("basketball.coaches", this);
     }
 
     /**
@@ -42,7 +41,7 @@ public class Basketball {
      * @return Basketball positions
      */
     public String positions() {
-        return faker.fakeValuesService().resolve("basketball.positions", this, faker);
+        return faker.fakeValuesService().resolve("basketball.positions", this);
     }
 
     /**
@@ -51,6 +50,6 @@ public class Basketball {
      * @return Basketball players
      */
     public String players() {
-        return faker.fakeValuesService().resolve("basketball.players", this, faker);
+        return faker.fakeValuesService().resolve("basketball.players", this);
     }
 }

--- a/src/main/java/net/datafaker/Battlefield1.java
+++ b/src/main/java/net/datafaker/Battlefield1.java
@@ -8,9 +8,7 @@ package net.datafaker;
  * @since 1.4.0
  */
 
-public class Battlefield1 {
-
-    private final Faker faker;
+public class Battlefield1 extends AbstractProvider {
 
     /**
      * Create a constructor for Battlefield1.
@@ -18,7 +16,7 @@ public class Battlefield1 {
      * @param faker The Faker instance for generating random names of things.
      */
     protected Battlefield1(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Beer.java
+++ b/src/main/java/net/datafaker/Beer.java
@@ -3,30 +3,29 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Beer {
-    private final Faker faker;
+public class Beer extends AbstractProvider {
 
     protected Beer(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("beer.name", this, faker);
+        return faker.fakeValuesService().resolve("beer.name", this);
     }
 
     public String style() {
-        return faker.fakeValuesService().resolve("beer.style", this, faker);
+        return faker.fakeValuesService().resolve("beer.style", this);
     }
 
     public String hop() {
-        return faker.fakeValuesService().resolve("beer.hop", this, faker);
+        return faker.fakeValuesService().resolve("beer.hop", this);
     }
 
     public String yeast() {
-        return faker.fakeValuesService().resolve("beer.yeast", this, faker);
+        return faker.fakeValuesService().resolve("beer.yeast", this);
     }
 
     public String malt() {
-        return faker.fakeValuesService().resolve("beer.malt", this, faker);
+        return faker.fakeValuesService().resolve("beer.malt", this);
     }
 }

--- a/src/main/java/net/datafaker/BigBangTheory.java
+++ b/src/main/java/net/datafaker/BigBangTheory.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class BigBangTheory {
-
-    private final Faker faker;
+public class BigBangTheory extends AbstractProvider {
 
     protected BigBangTheory(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class BigBangTheory {
      * @return a string of Big Bang Theory's character's name.
      */
     public String character() {
-        return faker.fakeValuesService().resolve("big_bang_theory.characters", this, faker);
+        return faker.fakeValuesService().resolve("big_bang_theory.characters", this);
     }
 
     /**
@@ -26,6 +24,6 @@ public class BigBangTheory {
      * @return a string of Big Bang Theory's character's quote.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("big_bang_theory.quotes", this, faker);
+        return faker.fakeValuesService().resolve("big_bang_theory.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/BloodType.java
+++ b/src/main/java/net/datafaker/BloodType.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 1.4.0
  */
-public class BloodType {
-    private final Faker faker;
+public class BloodType extends AbstractProvider {
 
     protected BloodType(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -44,6 +43,6 @@ public class BloodType {
      * @return a blood group such as O−, O+, A-, A+, B-, B+, AB-, AB+
      */
     public String bloodGroup() {
-        return faker.fakeValuesService().resolve("blood_type.blood_group", this, faker);
+        return faker.fakeValuesService().resolve("blood_type.blood_group", this);
     }
 }

--- a/src/main/java/net/datafaker/BojackHorseman.java
+++ b/src/main/java/net/datafaker/BojackHorseman.java
@@ -6,8 +6,7 @@ package net.datafaker;
  * @author unknown and irakatz
  * @since 0.8.0
  */
-public class BojackHorseman {
-    private final Faker faker;
+public class BojackHorseman extends AbstractProvider {
 
     /**
      * Create a constructor for BojackHorseman.
@@ -15,7 +14,7 @@ public class BojackHorseman {
      * @param faker The Faker instance for generating random parts in BojackHorseman.
      */
     protected BojackHorseman(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -24,7 +23,7 @@ public class BojackHorseman {
      * @return Characters in BojackHorseman
      */
     public String characters() {
-        return faker.fakeValuesService().resolve("bojack_horseman.characters", this, faker);
+        return faker.fakeValuesService().resolve("bojack_horseman.characters", this);
     }
 
     /**
@@ -33,7 +32,7 @@ public class BojackHorseman {
      * @return Quotes in BojackHorseman
      */
     public String quotes() {
-        return faker.fakeValuesService().resolve("bojack_horseman.quotes", this, faker);
+        return faker.fakeValuesService().resolve("bojack_horseman.quotes", this);
     }
 
     /**
@@ -42,7 +41,7 @@ public class BojackHorseman {
      * @return Tongue twisters in BojackHorseman
      */
     public String tongueTwisters() {
-        return faker.fakeValuesService().resolve("bojack_horseman.tongue_twisters", this, faker);
+        return faker.fakeValuesService().resolve("bojack_horseman.tongue_twisters", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Book.java
+++ b/src/main/java/net/datafaker/Book.java
@@ -3,26 +3,25 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Book {
-    private final Faker faker;
+public class Book extends AbstractProvider {
 
     protected Book(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String author() {
-        return faker.fakeValuesService().resolve("book.author", this, faker);
+        return faker.fakeValuesService().resolve("book.author", this);
     }
 
     public String title() {
-        return faker.fakeValuesService().resolve("book.title", this, faker);
+        return faker.fakeValuesService().resolve("book.title", this);
     }
 
     public String publisher() {
-        return faker.fakeValuesService().resolve("book.publisher", this, faker);
+        return faker.fakeValuesService().resolve("book.publisher", this);
     }
 
     public String genre() {
-        return faker.fakeValuesService().resolve("book.genre", this, faker);
+        return faker.fakeValuesService().resolve("book.genre", this);
     }
 }

--- a/src/main/java/net/datafaker/Bool.java
+++ b/src/main/java/net/datafaker/Bool.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Bool {
-    private final Faker faker;
+public class Bool extends AbstractProvider {
 
     protected Bool(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public boolean bool() {

--- a/src/main/java/net/datafaker/BossaNova.java
+++ b/src/main/java/net/datafaker/BossaNova.java
@@ -7,18 +7,17 @@ package net.datafaker;
  *
  * @since 1.0.0
  */
-public class BossaNova {
-    private final Faker faker;
+public class BossaNova extends AbstractProvider {
 
     protected BossaNova(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String artist() {
-        return faker.fakeValuesService().resolve("bossa_nova.artists", this, faker);
+        return faker.fakeValuesService().resolve("bossa_nova.artists", this);
     }
 
     public String song() {
-        return faker.fakeValuesService().resolve("bossa_nova.songs", this, faker);
+        return faker.fakeValuesService().resolve("bossa_nova.songs", this);
     }
 }

--- a/src/main/java/net/datafaker/BreakingBad.java
+++ b/src/main/java/net/datafaker/BreakingBad.java
@@ -8,18 +8,17 @@ package net.datafaker;
  *
  * @since 1.0.0
  */
-public class BreakingBad {
-    private final Faker faker;
+public class BreakingBad extends AbstractProvider {
 
     protected BreakingBad(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("breaking_bad.characters", this, faker);
+        return faker.fakeValuesService().resolve("breaking_bad.characters", this);
     }
 
     public String episode() {
-        return faker.fakeValuesService().resolve("breaking_bad.episodes", this, faker);
+        return faker.fakeValuesService().resolve("breaking_bad.episodes", this);
     }
 }

--- a/src/main/java/net/datafaker/BrooklynNineNine.java
+++ b/src/main/java/net/datafaker/BrooklynNineNine.java
@@ -5,20 +5,18 @@ package net.datafaker;
  *
  * @since 1.3.0
  */
-public class BrooklynNineNine {
-
-    private final Faker faker;
+public class BrooklynNineNine extends AbstractProvider {
 
     protected BrooklynNineNine(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("brooklyn_nine_nine.characters", this, faker);
+        return faker.fakeValuesService().resolve("brooklyn_nine_nine.characters", this);
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("brooklyn_nine_nine.quotes", this, faker);
+        return faker.fakeValuesService().resolve("brooklyn_nine_nine.quotes", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Buffy.java
+++ b/src/main/java/net/datafaker/Buffy.java
@@ -3,31 +3,30 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Buffy {
-    private final Faker faker;
+public class Buffy extends AbstractProvider {
 
     protected Buffy(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("buffy.characters", this, faker);
+        return faker.fakeValuesService().resolve("buffy.characters", this);
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("buffy.quotes", this, faker);
+        return faker.fakeValuesService().resolve("buffy.quotes", this);
     }
 
     public String celebrities() {
-        return faker.fakeValuesService().resolve("buffy.celebrities", this, faker);
+        return faker.fakeValuesService().resolve("buffy.celebrities", this);
     }
 
     public String bigBads() {
-        return faker.fakeValuesService().resolve("buffy.big_bads", this, faker);
+        return faker.fakeValuesService().resolve("buffy.big_bads", this);
     }
 
     public String episodes() {
-        return faker.fakeValuesService().resolve("buffy.episodes", this, faker);
+        return faker.fakeValuesService().resolve("buffy.episodes", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Business.java
+++ b/src/main/java/net/datafaker/Business.java
@@ -3,23 +3,21 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Business {
-
-    private final Faker faker;
+public class Business extends AbstractProvider {
 
     protected Business(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String creditCardNumber() {
-        return faker.fakeValuesService().resolve("business.credit_card_numbers", this, faker);
+        return faker.fakeValuesService().resolve("business.credit_card_numbers", this);
     }
 
     public String creditCardType() {
-        return faker.fakeValuesService().resolve("business.credit_card_types", this, faker);
+        return faker.fakeValuesService().resolve("business.credit_card_types", this);
     }
 
     public String creditCardExpiry() {
-        return faker.fakeValuesService().resolve("business.credit_card_expiry_dates", this, faker);
+        return faker.fakeValuesService().resolve("business.credit_card_expiry_dates", this);
     }
 }

--- a/src/main/java/net/datafaker/CNPJ.java
+++ b/src/main/java/net/datafaker/CNPJ.java
@@ -13,12 +13,10 @@ import net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil;
  * @see <a href="https://en.wikipedia.org/wiki/CNPJ">CNPJ</a>
  * @since 1.1.0
  */
-public class CNPJ {
-
-    private final Faker faker;
+public class CNPJ extends AbstractProvider {
 
     protected CNPJ(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/CPF.java
+++ b/src/main/java/net/datafaker/CPF.java
@@ -11,12 +11,10 @@ import net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil;
  * @see <a href="https://en.wikipedia.org/wiki/CPF_number">CPF</a>
  * @since 0.8.0
  */
-public class CPF {
-
-    private final Faker faker;
+public class CPF extends AbstractProvider {
 
     protected CPF(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Camera.java
+++ b/src/main/java/net/datafaker/Camera.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.4.0
  */
-public class Camera {
-
-    private final Faker faker;
+public class Camera extends AbstractProvider {
 
     protected Camera(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class Camera {
      * @return a string of camera brand.
      */
     public String brand() {
-        return faker.fakeValuesService().resolve("camera.brand", this, faker);
+        return faker.fakeValuesService().resolve("camera.brand", this);
     }
 
     /**
@@ -26,7 +24,7 @@ public class Camera {
      * @return a string of camera model.
      */
     public String model() {
-        return faker.fakeValuesService().resolve("camera.model", this, faker);
+        return faker.fakeValuesService().resolve("camera.model", this);
     }
 
     /**
@@ -35,6 +33,6 @@ public class Camera {
      * @return a string of camera brand with a model.
      */
     public String brandWithModel() {
-        return faker.fakeValuesService().resolve("camera.brand_with_model", this, faker);
+        return faker.fakeValuesService().resolve("camera.brand_with_model", this);
     }
 }

--- a/src/main/java/net/datafaker/Cannabis.java
+++ b/src/main/java/net/datafaker/Cannabis.java
@@ -3,50 +3,49 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-class Cannabis {
-    private final Faker faker;
+public class Cannabis extends AbstractProvider {
 
     protected Cannabis(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String strains() {
-        return faker.fakeValuesService().resolve("cannabis.strains", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.strains", this);
     }
 
     public String cannabinoidAbbreviations() {
-        return faker.fakeValuesService().resolve("cannabis.cannabinoid_abbreviations", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.cannabinoid_abbreviations", this);
     }
 
     public String cannabinoids() {
-        return faker.fakeValuesService().resolve("cannabis.cannabinoids", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.cannabinoids", this);
     }
 
     public String terpenes() {
-        return faker.fakeValuesService().resolve("cannabis.terpenes", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.terpenes", this);
     }
 
     public String medicalUses() {
-        return faker.fakeValuesService().resolve("cannabis.medical_uses", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.medical_uses", this);
     }
 
     public String healthBenefits() {
-        return faker.fakeValuesService().resolve("cannabis.health_benefits", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.health_benefits", this);
     }
 
     public String categories() {
-        return faker.fakeValuesService().resolve("cannabis.categories", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.categories", this);
     }
 
     public String types() {
-        return faker.fakeValuesService().resolve("cannabis.types", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.types", this);
     }
 
     public String buzzwords() {
-        return faker.fakeValuesService().resolve("cannabis.buzzwords", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.buzzwords", this);
     }
 
     public String brands() {
-        return faker.fakeValuesService().resolve("cannabis.brands", this, faker);
+        return faker.fakeValuesService().resolve("cannabis.brands", this);
     }
 }

--- a/src/main/java/net/datafaker/Cat.java
+++ b/src/main/java/net/datafaker/Cat.java
@@ -3,23 +3,21 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Cat {
-
-    private final Faker faker;
+public class Cat extends AbstractProvider {
 
     protected Cat(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.cat.name", this, faker);
+        return faker.fakeValuesService().resolve("creature.cat.name", this);
     }
 
     public String breed() {
-        return faker.fakeValuesService().resolve("creature.cat.breed", this, faker);
+        return faker.fakeValuesService().resolve("creature.cat.breed", this);
     }
 
     public String registry() {
-        return faker.fakeValuesService().resolve("creature.cat.registry", this, faker);
+        return faker.fakeValuesService().resolve("creature.cat.registry", this);
     }
 }

--- a/src/main/java/net/datafaker/ChuckNorris.java
+++ b/src/main/java/net/datafaker/ChuckNorris.java
@@ -3,14 +3,13 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class ChuckNorris {
-    private final Faker faker;
+public class ChuckNorris extends AbstractProvider {
 
     protected ChuckNorris(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String fact() {
-        return faker.fakeValuesService().resolve("chuck_norris.fact", this, faker);
+        return faker.fakeValuesService().resolve("chuck_norris.fact", this);
     }
 }

--- a/src/main/java/net/datafaker/Code.java
+++ b/src/main/java/net/datafaker/Code.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
  *
  * @since 0.8.0
  */
-public class Code {
+public class Code extends AbstractProvider {
 
     private static final int[] GTIN_8_CHECK_DIGITS = {3, 1, 3, 1, 3, 1, 3};
     private static final int[] GTIN_13_CHECK_DIGITS = {1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3};
@@ -17,10 +17,9 @@ public class Code {
         = {"01", "10", "30", "33", "35", "44", "45", "49", "50", "51", "52", "53", "54", "86", "91", "98", "99"};
 
     private static final Pattern HYPHEN = Pattern.compile("-");
-    private final Faker faker;
 
     protected Code(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Coffee.java
+++ b/src/main/java/net/datafaker/Coffee.java
@@ -6,16 +6,14 @@ import java.util.Locale;
 /**
  * @since 1.5.0
  */
-class Coffee {
-
-    private final Faker faker;
+public class Coffee extends AbstractProvider {
 
     protected Coffee(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String country() {
-        return faker.fakeValuesService().resolve("coffee.country", this, faker);
+        return faker.fakeValuesService().resolve("coffee.country", this);
     }
 
     public String region() {
@@ -23,39 +21,39 @@ class Coffee {
     }
 
     public String region(Coffee.Country country) {
-        return faker.fakeValuesService().resolve("coffee.regions." + country.name().toLowerCase(Locale.ROOT), this, faker);
+        return faker.fakeValuesService().resolve("coffee.regions." + country.name().toLowerCase(Locale.ROOT), this);
     }
 
     public String variety() {
-        return faker.fakeValuesService().resolve("coffee.variety", this, faker);
+        return faker.fakeValuesService().resolve("coffee.variety", this);
     }
 
     public String intensifier() {
-        return faker.fakeValuesService().resolve("coffee.intensifier", this, faker);
+        return faker.fakeValuesService().resolve("coffee.intensifier", this);
     }
 
     public String body() {
-        return faker.fakeValuesService().resolve("coffee.body", this, faker);
+        return faker.fakeValuesService().resolve("coffee.body", this);
     }
 
     public String descriptor() {
-        return faker.fakeValuesService().resolve("coffee.descriptor", this, faker);
+        return faker.fakeValuesService().resolve("coffee.descriptor", this);
     }
 
     public String notes() {
-        return faker.fakeValuesService().resolve("coffee.notes", this, faker);
+        return faker.fakeValuesService().resolve("coffee.notes", this);
     }
 
     public String name1() {
-        return faker.fakeValuesService().resolve("coffee.name_1", this, faker);
+        return faker.fakeValuesService().resolve("coffee.name_1", this);
     }
 
     public String name2() {
-        return faker.fakeValuesService().resolve("coffee.name_2", this, faker);
+        return faker.fakeValuesService().resolve("coffee.name_2", this);
     }
 
     public String blendName() {
-        return faker.fakeValuesService().resolve("coffee.blend_name", this, faker);
+        return faker.fakeValuesService().resolve("coffee.blend_name", this);
     }
 
     public enum Country {

--- a/src/main/java/net/datafaker/Coin.java
+++ b/src/main/java/net/datafaker/Coin.java
@@ -3,18 +3,16 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Coin {
-
-    private final Faker faker;
+public class Coin extends AbstractProvider {
 
     protected Coin(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
      * @return coin side e.g. "Heads", "Tails".
      */
     public String flip() {
-        return faker.fakeValuesService().resolve("coin.flip", this, faker);
+        return faker.fakeValuesService().resolve("coin.flip", this);
     }
 }

--- a/src/main/java/net/datafaker/Color.java
+++ b/src/main/java/net/datafaker/Color.java
@@ -3,15 +3,14 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Color {
-    private final Faker faker;
+public class Color extends AbstractProvider {
 
     protected Color(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("color.name", this, faker);
+        return faker.fakeValuesService().resolve("color.name", this);
     }
 
     public String hex() {

--- a/src/main/java/net/datafaker/Commerce.java
+++ b/src/main/java/net/datafaker/Commerce.java
@@ -8,12 +8,11 @@ import java.util.TreeSet;
 /**
  * @since 0.8.0
  */
-public class Commerce {
-    private final Faker faker;
+public class Commerce extends AbstractProvider {
     private final DecimalFormatSymbols decimalFormatSymbols;
 
     protected Commerce(Faker faker) {
-        this.faker = faker;
+        super(faker);
         decimalFormatSymbols = new DecimalFormatSymbols(faker.getLocale());
     }
 
@@ -21,7 +20,7 @@ public class Commerce {
         int numberOfDepartments = Math.max(faker.random().nextInt(4), 1);
         SortedSet<String> departments = new TreeSet<>();
         while (departments.size() < numberOfDepartments) {
-            departments.add(faker.fakeValuesService().resolve("commerce.department", this, faker));
+            departments.add(faker.fakeValuesService().resolve("commerce.department", this));
         }
         if (departments.size() > 1) {
             String lastDepartment = departments.last();
@@ -34,22 +33,22 @@ public class Commerce {
 
     public String productName() {
         return String.join(" ",
-            faker.fakeValuesService().resolve("commerce.product_name.adjective", this, faker),
-            faker.fakeValuesService().resolve("commerce.product_name.material", this, faker),
-            faker.fakeValuesService().resolve("commerce.product_name.product", this, faker)
+            faker.fakeValuesService().resolve("commerce.product_name.adjective", this),
+            faker.fakeValuesService().resolve("commerce.product_name.material", this),
+            faker.fakeValuesService().resolve("commerce.product_name.product", this)
         );
     }
 
     public String material() {
-        return faker.fakeValuesService().resolve("commerce.product_name.material", this, faker);
+        return faker.fakeValuesService().resolve("commerce.product_name.material", this);
     }
 
     public String brand() {
-        return faker.fakeValuesService().resolve("commerce.brand", this, faker);
+        return faker.fakeValuesService().resolve("commerce.brand", this);
     }
 
     public String vendor() {
-        return faker.fakeValuesService().resolve("commerce.vendor", this, faker);
+        return faker.fakeValuesService().resolve("commerce.vendor", this);
     }
 
     /**

--- a/src/main/java/net/datafaker/Company.java
+++ b/src/main/java/net/datafaker/Company.java
@@ -9,29 +9,28 @@ import java.util.regex.Pattern;
 /**
  * @since 0.8.0
  */
-public class Company {
+public class Company extends AbstractProvider {
 
     private static final Pattern UNWANTED_CHARACTERS = Pattern.compile("[.,' ]");
-    private final Faker faker;
 
     protected Company(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("company.name", this, faker);
+        return faker.fakeValuesService().resolve("company.name", this);
     }
 
     public String suffix() {
-        return faker.fakeValuesService().resolve("company.suffix", this, faker);
+        return faker.fakeValuesService().resolve("company.suffix", this);
     }
 
     public String industry() {
-        return faker.fakeValuesService().resolve("company.industry", this, faker);
+        return faker.fakeValuesService().resolve("company.industry", this);
     }
 
     public String profession() {
-        return faker.fakeValuesService().resolve("company.profession", this, faker);
+        return faker.fakeValuesService().resolve("company.profession", this);
     }
 
     public String buzzword() {
@@ -83,7 +82,7 @@ public class Company {
     }
 
     private String domainSuffix() {
-        return faker.fakeValuesService().resolve("internet.domain_suffix", this, faker);
+        return faker.fakeValuesService().resolve("internet.domain_suffix", this);
     }
 
     private String joinSampleOfEachList(List<List<String>> listOfLists) {

--- a/src/main/java/net/datafaker/Computer.java
+++ b/src/main/java/net/datafaker/Computer.java
@@ -1,11 +1,9 @@
 package net.datafaker;
 
-public class Computer {
-
-    private final Faker faker;
+public class Computer extends AbstractProvider {
 
     protected Computer(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String type() {

--- a/src/main/java/net/datafaker/Construction.java
+++ b/src/main/java/net/datafaker/Construction.java
@@ -3,36 +3,34 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-class Construction {
-
-    private final Faker faker;
+public class Construction extends AbstractProvider {
 
     protected Construction(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String heavyEquipment() {
-        return faker.fakeValuesService().resolve("construction.heavy_equipment", this, faker);
+        return faker.fakeValuesService().resolve("construction.heavy_equipment", this);
     }
 
     public String materials() {
-        return faker.fakeValuesService().resolve("construction.materials", this, faker);
+        return faker.fakeValuesService().resolve("construction.materials", this);
     }
 
     public String subcontractCategories() {
-        return faker.fakeValuesService().resolve("construction.subcontract_categories", this, faker);
+        return faker.fakeValuesService().resolve("construction.subcontract_categories", this);
     }
 
     public String roles() {
-        return faker.fakeValuesService().resolve("construction.roles", this, faker);
+        return faker.fakeValuesService().resolve("construction.roles", this);
     }
 
     public String trades() {
-        return faker.fakeValuesService().resolve("construction.trades", this, faker);
+        return faker.fakeValuesService().resolve("construction.trades", this);
     }
 
     public String standardCostCodes() {
-        return faker.fakeValuesService().resolve("construction.standard_cost_codes", this, faker);
+        return faker.fakeValuesService().resolve("construction.standard_cost_codes", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Country.java
+++ b/src/main/java/net/datafaker/Country.java
@@ -3,41 +3,40 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Country {
-    private final Faker faker;
+public class Country extends AbstractProvider {
     private final String flagUrl;
 
     protected Country(Faker faker) {
-        this.faker = faker;
+        super(faker);
         this.flagUrl = "https://flags.fmcdn.net/data/flags/w580/";
     }
 
     public String flag() {
-        return flagUrl + faker.fakeValuesService().resolve("country.code2", this, faker) + ".png";
+        return flagUrl + faker.fakeValuesService().resolve("country.code2", this) + ".png";
     }
 
     public String countryCode2() {
-        return faker.fakeValuesService().resolve("country.code2", this, faker);
+        return faker.fakeValuesService().resolve("country.code2", this);
     }
 
     public String countryCode3() {
-        return faker.fakeValuesService().resolve("country.code3", this, faker);
+        return faker.fakeValuesService().resolve("country.code3", this);
     }
 
     public String capital() {
-        return faker.fakeValuesService().resolve("country.capital", this, faker);
+        return faker.fakeValuesService().resolve("country.capital", this);
     }
 
     public String currency() {
-        return faker.fakeValuesService().resolve("country.currency", this, faker);
+        return faker.fakeValuesService().resolve("country.currency", this);
     }
 
     public String currencyCode() {
-        return faker.fakeValuesService().resolve("country.currency_code", this, faker);
+        return faker.fakeValuesService().resolve("country.currency_code", this);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("country.name", this, faker);
+        return faker.fakeValuesService().resolve("country.name", this);
     }
 
 }

--- a/src/main/java/net/datafaker/CryptoCoin.java
+++ b/src/main/java/net/datafaker/CryptoCoin.java
@@ -3,16 +3,14 @@ package net.datafaker;
 /**
  * @since 1.3.0
  */
-public class CryptoCoin {
-
-    private final Faker faker;
+public class CryptoCoin extends AbstractProvider {
 
     protected CryptoCoin(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String coin() {
-        return faker.fakeValuesService().resolve("crypto_coin.coin", this, faker);
+        return faker.fakeValuesService().resolve("crypto_coin.coin", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Currency.java
+++ b/src/main/java/net/datafaker/Currency.java
@@ -3,19 +3,17 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Currency {
-
-    private final Faker faker;
+public class Currency extends AbstractProvider {
 
     public Currency(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("currency.name", this, faker);
+        return faker.fakeValuesService().resolve("currency.name", this);
     }
 
     public String code() {
-        return faker.fakeValuesService().resolve("currency.code", this, faker);
+        return faker.fakeValuesService().resolve("currency.code", this);
     }
 }

--- a/src/main/java/net/datafaker/DarkSoul.java
+++ b/src/main/java/net/datafaker/DarkSoul.java
@@ -1,32 +1,31 @@
 package net.datafaker;
 
 /**
- * issue for: https://github.com/datafaker-net/datafaker/issues/159
+ * issue for: <a href="https://github.com/datafaker-net/datafaker/issues/159">159</a>
  *
  * @since 1.5.0
  * @author SickDawn
  */
-public class DarkSoul {
-    private final Faker faker;
+public class DarkSoul extends AbstractProvider {
 
     public DarkSoul(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String stats() {
-        return faker.fakeValuesService().resolve("dark_soul.stats", this, faker);
+        return faker.fakeValuesService().resolve("dark_soul.stats", this);
     }
 
     public String covenants() {
-        return faker.fakeValuesService().resolve("dark_soul.covenants", this, faker);
+        return faker.fakeValuesService().resolve("dark_soul.covenants", this);
     }
 
     public String classes() {
-        return faker.fakeValuesService().resolve("dark_soul.classes", this, faker);
+        return faker.fakeValuesService().resolve("dark_soul.classes", this);
     }
 
     public String shield() {
-        return faker.fakeValuesService().resolve("dark_soul.shield", this, faker);
+        return faker.fakeValuesService().resolve("dark_soul.shield", this);
     }
 
 }

--- a/src/main/java/net/datafaker/DateAndTime.java
+++ b/src/main/java/net/datafaker/DateAndTime.java
@@ -19,14 +19,12 @@ import java.util.concurrent.TimeUnit;
  * @author pmiklos
  * @since 0.8.0
  */
-public class DateAndTime {
+public class DateAndTime extends AbstractProvider {
     private static final int DEFAULT_MIN_AGE = 18;
     private static final int DEFAULT_MAX_AGE = 65;
 
-    private final Faker faker;
-
     protected DateAndTime(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/DcComics.java
+++ b/src/main/java/net/datafaker/DcComics.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class DcComics {
-
-    private final Faker faker;
+public class DcComics extends AbstractProvider {
 
     public DcComics(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String hero() {

--- a/src/main/java/net/datafaker/Demographic.java
+++ b/src/main/java/net/datafaker/Demographic.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Demographic {
-
-    private final Faker faker;
+public class Demographic extends AbstractProvider {
 
     protected Demographic(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String race() {

--- a/src/main/java/net/datafaker/Departed.java
+++ b/src/main/java/net/datafaker/Departed.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Departed {
-
-    private final Faker faker;
+public class Departed extends AbstractProvider {
 
     protected Departed(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class Departed {
      * @return a string of actor's name from The Departed.
      */
     public String actor() {
-        return faker.fakeValuesService().resolve("departed.actors", this, faker);
+        return faker.fakeValuesService().resolve("departed.actors", this);
     }
 
     /**
@@ -26,7 +24,7 @@ public class Departed {
      * @return a string of character's name from The Departed.
      */
     public String character() {
-        return faker.fakeValuesService().resolve("departed.characters", this, faker);
+        return faker.fakeValuesService().resolve("departed.characters", this);
     }
 
     /**
@@ -35,6 +33,6 @@ public class Departed {
      * @return a string of quote from The Departed.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("departed.quotes", this, faker);
+        return faker.fakeValuesService().resolve("departed.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/Dessert.java
+++ b/src/main/java/net/datafaker/Dessert.java
@@ -3,32 +3,30 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Dessert {
-
-    private final Faker faker;
+public class Dessert extends AbstractProvider {
 
     protected Dessert(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
      * @return dessert variety e.g. "Cake".
      */
     public String variety() {
-        return faker.fakeValuesService().resolve("dessert.variety", this, faker);
+        return faker.fakeValuesService().resolve("dessert.variety", this);
     }
 
     /**
      * @return dessert topping e.g. "Rainbow Sprinkles".
      */
     public String topping() {
-        return faker.fakeValuesService().resolve("dessert.topping", this, faker);
+        return faker.fakeValuesService().resolve("dessert.topping", this);
     }
 
     /**
      * @return dessert flavor e.g. "Vanilla".
      */
     public String flavor() {
-        return faker.fakeValuesService().resolve("dessert.flavor", this, faker);
+        return faker.fakeValuesService().resolve("dessert.flavor", this);
     }
 }

--- a/src/main/java/net/datafaker/Device.java
+++ b/src/main/java/net/datafaker/Device.java
@@ -3,28 +3,26 @@ package net.datafaker;
 /**
  * @since 1.4.0
  */
-public class Device {
-
-    private final Faker faker;
+public class Device extends AbstractProvider {
 
     protected Device(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String modelName() {
-        return faker.fakeValuesService().resolve("device.model_name", this, faker);
+        return faker.fakeValuesService().resolve("device.model_name", this);
     }
 
     public String platform() {
-        return faker.fakeValuesService().resolve("device.platform", this, faker);
+        return faker.fakeValuesService().resolve("device.platform", this);
     }
 
     public String manufacturer() {
-        return faker.fakeValuesService().resolve("device.manufacturer", this, faker);
+        return faker.fakeValuesService().resolve("device.manufacturer", this);
     }
 
     public String serial() {
-        return faker.fakeValuesService().resolve("device.serial", this, faker);
+        return faker.fakeValuesService().resolve("device.serial", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Disease.java
+++ b/src/main/java/net/datafaker/Disease.java
@@ -5,8 +5,7 @@ package net.datafaker;
  *
  * @since 0.8.0
  */
-public class Disease {
-    private final Faker faker;
+public class Disease extends AbstractProvider {
 
     /**
      * Create a constructor for Disease
@@ -14,7 +13,7 @@ public class Disease {
      * @param faker The Faker instance for generating random, different kinds of disease, e.g. the internal disease.
      */
     protected Disease(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -23,7 +22,7 @@ public class Disease {
      * @return An internal disease
      */
     public String internalDisease() {
-        return faker.fakeValuesService().resolve("disease.internal_disease", this, faker);
+        return faker.fakeValuesService().resolve("disease.internal_disease", this);
     }
 
     /**
@@ -32,7 +31,7 @@ public class Disease {
      * @return A neurology disease
      */
     public String neurology() {
-        return faker.fakeValuesService().resolve("disease.neurology", this, faker);
+        return faker.fakeValuesService().resolve("disease.neurology", this);
     }
 
     /**
@@ -41,7 +40,7 @@ public class Disease {
      * @return A surgery disease
      */
     public String surgery() {
-        return faker.fakeValuesService().resolve("disease.surgery", this, faker);
+        return faker.fakeValuesService().resolve("disease.surgery", this);
     }
 
     /**
@@ -50,7 +49,7 @@ public class Disease {
      * @return A paediatrics disease
      */
     public String paediatrics() {
-        return faker.fakeValuesService().resolve("disease.paediatrics", this, faker);
+        return faker.fakeValuesService().resolve("disease.paediatrics", this);
     }
 
     /**
@@ -59,7 +58,7 @@ public class Disease {
      * @return A gynecology and obstetrics disease
      */
     public String gynecologyAndObstetrics() {
-        return faker.fakeValuesService().resolve("disease.gynecology_and_obstetrics", this, faker);
+        return faker.fakeValuesService().resolve("disease.gynecology_and_obstetrics", this);
     }
 
     /**
@@ -68,7 +67,7 @@ public class Disease {
      * @return A ophthalmology and otorhinolaryngology disease
      */
     public String ophthalmologyAndOtorhinolaryngology() {
-        return faker.fakeValuesService().resolve("disease.ophthalmology_and_otorhinolaryngology", this, faker);
+        return faker.fakeValuesService().resolve("disease.ophthalmology_and_otorhinolaryngology", this);
     }
 
     /**
@@ -77,7 +76,7 @@ public class Disease {
      * @return A dermatolory disease
      */
     public String dermatolory() {
-        return faker.fakeValuesService().resolve("disease.dermatolory", this, faker);
+        return faker.fakeValuesService().resolve("disease.dermatolory", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Dog.java
+++ b/src/main/java/net/datafaker/Dog.java
@@ -3,43 +3,41 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Dog {
-
-    private final Faker faker;
+public class Dog extends AbstractProvider {
 
     protected Dog(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.dog.name", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.name", this);
     }
 
     public String breed() {
-        return faker.fakeValuesService().resolve("creature.dog.breed", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.breed", this);
     }
 
     public String sound() {
-        return faker.fakeValuesService().resolve("creature.dog.sound", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.sound", this);
     }
 
     public String memePhrase() {
-        return faker.fakeValuesService().resolve("creature.dog.meme_phrase", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.meme_phrase", this);
     }
 
     public String age() {
-        return faker.fakeValuesService().resolve("creature.dog.age", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.age", this);
     }
 
     public String coatLength() {
-        return faker.fakeValuesService().resolve("creature.dog.coat_length", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.coat_length", this);
     }
 
     public String gender() {
-        return faker.fakeValuesService().resolve("creature.dog.gender", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.gender", this);
     }
 
     public String size() {
-        return faker.fakeValuesService().resolve("creature.dog.size", this, faker);
+        return faker.fakeValuesService().resolve("creature.dog.size", this);
     }
 }

--- a/src/main/java/net/datafaker/Domain.java
+++ b/src/main/java/net/datafaker/Domain.java
@@ -8,8 +8,7 @@ import net.datafaker.service.RandomService;
  *
  * @since 0.9.0
  */
-public class Domain {
-    private final Faker faker;
+public class Domain extends AbstractProvider {
 
     /**
      * Instantiates a new Domain.
@@ -17,7 +16,7 @@ public class Domain {
      * @param faker the faker
      */
     protected Domain(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -27,7 +26,7 @@ public class Domain {
      * @return the
      */
     public String firstLevelDomain(String name) {
-        String top = faker.fakeValuesService().resolve("domain.top", this, faker);
+        String top = faker.fakeValuesService().resolve("domain.top", this);
         return String.join("",
             name,
             ".",
@@ -42,8 +41,8 @@ public class Domain {
      * @return the second level domain with company name
      */
     public String secondLevelDomain(String name) {
-        String top = faker.fakeValuesService().resolve("domain.top", this, faker);
-        String suffix = faker.fakeValuesService().resolve("domain.country", this, faker);
+        String top = faker.fakeValuesService().resolve("domain.top", this);
+        String suffix = faker.fakeValuesService().resolve("domain.country", this);
         return String.join("",
             name,
             ".",
@@ -60,9 +59,9 @@ public class Domain {
      * @return the full domain name
      */
     public String fullDomain(String name) {
-        String prefix = faker.fakeValuesService().resolve("domain.prefix", this, faker);
-        String top = faker.fakeValuesService().resolve("domain.top", this, faker);
-        String suffix = faker.fakeValuesService().resolve("domain.country", this, faker);
+        String prefix = faker.fakeValuesService().resolve("domain.prefix", this);
+        String top = faker.fakeValuesService().resolve("domain.top", this);
+        String suffix = faker.fakeValuesService().resolve("domain.country", this);
         return String.join("",
             prefix,
             ".",
@@ -87,7 +86,7 @@ public class Domain {
         boolean hasPrefix = random.nextInt(3) == 1;
         boolean hasSuffix = random.nextInt(2) == 1;
 
-        String top = faker.fakeValuesService().resolve("domain.top", this, faker);
+        String top = faker.fakeValuesService().resolve("domain.top", this);
 
         String result = String.join("",
             name,
@@ -96,7 +95,7 @@ public class Domain {
         );
 
         if (hasPrefix) {
-            String prefix = faker.fakeValuesService().resolve("domain.prefix", this, faker);
+            String prefix = faker.fakeValuesService().resolve("domain.prefix", this);
             result = String.join("",
                 prefix,
                 ".",
@@ -105,7 +104,7 @@ public class Domain {
         }
 
         if (hasSuffix) {
-            String suffix = faker.fakeValuesService().resolve("domain.country", this, faker);
+            String suffix = faker.fakeValuesService().resolve("domain.country", this);
             result = String.join("",
                 result,
                 ".",

--- a/src/main/java/net/datafaker/DragonBall.java
+++ b/src/main/java/net/datafaker/DragonBall.java
@@ -3,14 +3,13 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class DragonBall {
-    private final Faker faker;
+public class DragonBall extends AbstractProvider {
 
     protected DragonBall(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("dragon_ball.characters", this, faker);
+        return faker.fakeValuesService().resolve("dragon_ball.characters", this);
     }
 }

--- a/src/main/java/net/datafaker/DrivingLicense.java
+++ b/src/main/java/net/datafaker/DrivingLicense.java
@@ -5,12 +5,10 @@ import java.util.Locale;
 /**
  * @since 1.5.0
  */
-public class DrivingLicense {
-
-    private final Faker faker;
+public class DrivingLicense extends AbstractProvider {
 
     protected DrivingLicense(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String drivingLicense(String stateAbbreviation) {

--- a/src/main/java/net/datafaker/Dune.java
+++ b/src/main/java/net/datafaker/Dune.java
@@ -3,24 +3,22 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Dune {
-
-    private final Faker faker;
+public class Dune extends AbstractProvider {
 
     protected Dune(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("dune.characters", this, faker);
+        return faker.fakeValuesService().resolve("dune.characters", this);
     }
 
     public String title() {
-        return faker.fakeValuesService().resolve("dune.titles", this, faker);
+        return faker.fakeValuesService().resolve("dune.titles", this);
     }
 
     public String planet() {
-        return faker.fakeValuesService().resolve("dune.planets", this, faker);
+        return faker.fakeValuesService().resolve("dune.planets", this);
     }
 
     public String quote() {
@@ -28,7 +26,7 @@ public class Dune {
     }
 
     public String quote(Quote quote) {
-        return faker.fakeValuesService().resolve("dune.quotes." + quote.yamlKey, this, faker);
+        return faker.fakeValuesService().resolve("dune.quotes." + quote.yamlKey, this);
     }
 
     public String saying() {
@@ -36,7 +34,7 @@ public class Dune {
     }
 
     public String saying(Saying saying) {
-        return faker.fakeValuesService().resolve("dune.sayings." + saying.yamlKey, this, faker);
+        return faker.fakeValuesService().resolve("dune.sayings." + saying.yamlKey, this);
     }
 
     public enum Quote {

--- a/src/main/java/net/datafaker/Educator.java
+++ b/src/main/java/net/datafaker/Educator.java
@@ -3,34 +3,33 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Educator {
-    private final Faker faker;
+public class Educator extends AbstractProvider {
 
     protected Educator(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     // TODO - move these all out to en.yml by default. 
     public String university() {
-        return faker.fakeValuesService().resolve("educator.name", this, faker)
+        return faker.fakeValuesService().resolve("educator.name", this)
             + " "
-            + faker.fakeValuesService().resolve("educator.tertiary.type", this, faker);
+            + faker.fakeValuesService().resolve("educator.tertiary.type", this);
     }
 
     public String course() {
-        return faker.fakeValuesService().resolve("educator.tertiary.degree.type", this, faker)
+        return faker.fakeValuesService().resolve("educator.tertiary.degree.type", this)
             + " "
-            + faker.fakeValuesService().resolve("educator.tertiary.degree.subject", this, faker);
+            + faker.fakeValuesService().resolve("educator.tertiary.degree.subject", this);
     }
 
     public String secondarySchool() {
-        return faker.fakeValuesService().resolve("educator.name", this, faker)
+        return faker.fakeValuesService().resolve("educator.name", this)
             + " "
-            + faker.fakeValuesService().resolve("educator.secondary", this, faker);
+            + faker.fakeValuesService().resolve("educator.secondary", this);
     }
 
     public String campus() {
-        return faker.fakeValuesService().resolve("educator.name", this, faker) + " Campus";
+        return faker.fakeValuesService().resolve("educator.name", this) + " Campus";
     }
 
 }

--- a/src/main/java/net/datafaker/EldenRing.java
+++ b/src/main/java/net/datafaker/EldenRing.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 1.4.0
  */
-public class EldenRing {
-    private final Faker faker;
+public class EldenRing extends AbstractProvider {
 
     protected EldenRing(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String location() {

--- a/src/main/java/net/datafaker/ElderScrolls.java
+++ b/src/main/java/net/datafaker/ElderScrolls.java
@@ -3,43 +3,41 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class ElderScrolls {
-
-    private final Faker faker;
+public class ElderScrolls extends AbstractProvider {
 
     protected ElderScrolls(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String race() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.race", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.race", this);
     }
 
     public String creature() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.creature", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.creature", this);
     }
 
     public String region() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.region", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.region", this);
     }
 
     public String dragon() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.dragon", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.dragon", this);
     }
 
     public String city() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.city", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.city", this);
     }
 
     public String firstName() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.first_name", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.first_name", this);
     }
 
     public String lastName() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.last_name", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.last_name", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.quote", this, faker);
+        return faker.fakeValuesService().resolve("games.elder_scrolls.quote", this);
     }
 }

--- a/src/main/java/net/datafaker/ElectricalComponents.java
+++ b/src/main/java/net/datafaker/ElectricalComponents.java
@@ -3,23 +3,21 @@ package net.datafaker;
 /**
  * @since 1.4.0
  */
-public class ElectricalComponents {
-
-    private final Faker faker;
+public class ElectricalComponents extends AbstractProvider {
 
     protected ElectricalComponents(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String active() {
-        return faker.fakeValuesService().resolve("electrical_components.active", this, faker);
+        return faker.fakeValuesService().resolve("electrical_components.active", this);
     }
 
     public String passive() {
-        return faker.fakeValuesService().resolve("electrical_components.passive", this, faker);
+        return faker.fakeValuesService().resolve("electrical_components.passive", this);
     }
 
     public String electromechanical() {
-        return faker.fakeValuesService().resolve("electrical_components.electromechanical", this, faker);
+        return faker.fakeValuesService().resolve("electrical_components.electromechanical", this);
     }
 }

--- a/src/main/java/net/datafaker/EnglandFootBall.java
+++ b/src/main/java/net/datafaker/EnglandFootBall.java
@@ -3,19 +3,17 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class EnglandFootBall {
-
-    private final Faker faker;
+public class EnglandFootBall extends AbstractProvider {
 
     protected EnglandFootBall(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String league() {
-        return faker.fakeValuesService().resolve("englandfootball.leagues", this, faker);
+        return faker.fakeValuesService().resolve("englandfootball.leagues", this);
     }
 
     public String team() {
-        return faker.fakeValuesService().resolve("englandfootball.teams", this, faker);
+        return faker.fakeValuesService().resolve("englandfootball.teams", this);
     }
 }

--- a/src/main/java/net/datafaker/Esports.java
+++ b/src/main/java/net/datafaker/Esports.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Esports {
-    private final Faker faker;
+public class Esports extends AbstractProvider {
 
     protected Esports(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String player() {

--- a/src/main/java/net/datafaker/FakeDuration.java
+++ b/src/main/java/net/datafaker/FakeDuration.java
@@ -5,11 +5,10 @@ import java.time.Duration;
 /**
  * @since 0.8.0
  */
-public class FakeDuration {
-    private final Faker faker;
+public class FakeDuration extends AbstractProvider {
 
     protected FakeDuration(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 public class Faker {
     private final RandomService randomService;
     private final FakeValuesService fakeValuesService;
-    private final Map<Class<?>, Object> providersMap = new IdentityHashMap<>();
+    private final Map<Class<? extends AbstractProvider>, AbstractProvider> providersMap = new IdentityHashMap<>();
 
     public Faker() {
         this(Locale.ENGLISH);
@@ -288,7 +288,7 @@ public class Faker {
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> T getProvider(Class<T> clazz, Supplier<T> valueSupplier) {
+    public <T extends AbstractProvider> T getProvider(Class<T> clazz, Supplier<T> valueSupplier) {
         T result = (T) providersMap.get(clazz);
         if (result == null) {
             providersMap.putIfAbsent(clazz, valueSupplier.get());

--- a/src/main/java/net/datafaker/FamousLastWords.java
+++ b/src/main/java/net/datafaker/FamousLastWords.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class FamousLastWords {
-
-    private final Faker faker;
+public class FamousLastWords extends AbstractProvider {
 
     protected FamousLastWords(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,6 +15,6 @@ public class FamousLastWords {
      * @return a string of last words.
      */
     public String lastWords() {
-        return faker.fakeValuesService().resolve("famous_last_words.last_words", this, faker);
+        return faker.fakeValuesService().resolve("famous_last_words.last_words", this);
     }
 }

--- a/src/main/java/net/datafaker/File.java
+++ b/src/main/java/net/datafaker/File.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class File {
-    private final Faker faker;
+public class File extends AbstractProvider {
 
     protected File(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String extension() {

--- a/src/main/java/net/datafaker/Finance.java
+++ b/src/main/java/net/datafaker/Finance.java
@@ -7,25 +7,24 @@ import java.util.regex.Pattern;
 /**
  * @since 0.8.0
  */
-public class Finance {
+public class Finance extends AbstractProvider {
     private static final Pattern NUMBERS = Pattern.compile("[^0-9]");
     private static final Pattern EMPTY_STRING = Pattern.compile("");
-    private final Faker faker;
 
     protected Finance(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String nasdaqTicker() {
-        return faker.fakeValuesService().resolve("finance.ticker.nasdaq", this, faker);
+        return faker.fakeValuesService().resolve("finance.ticker.nasdaq", this);
     }
 
     public String nyseTicker() {
-        return faker.fakeValuesService().resolve("finance.ticker.nyse", this, faker);
+        return faker.fakeValuesService().resolve("finance.ticker.nyse", this);
     }
 
     public String stockMarket() {
-        return faker.fakeValuesService().resolve("finance.stock_market", this, faker);
+        return faker.fakeValuesService().resolve("finance.stock_market", this);
     }
 
     private static final Map<String, String> countryCodeToBasicBankAccountNumberPattern =
@@ -33,7 +32,7 @@ public class Finance {
 
     public String creditCard(CreditCardType creditCardType) {
         final String key = String.format("finance.credit_card.%s", creditCardType.toString().toLowerCase(Locale.ROOT));
-        String value = faker.fakeValuesService().resolve(key, this, faker);
+        String value = faker.fakeValuesService().resolve(key, this);
         final String template = faker.numerify(value);
 
         String[] split = EMPTY_STRING.split(NUMBERS.matcher(template).replaceAll(""));

--- a/src/main/java/net/datafaker/Food.java
+++ b/src/main/java/net/datafaker/Food.java
@@ -3,40 +3,38 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Food {
-
-    private final Faker faker;
+public class Food extends AbstractProvider {
 
     protected Food(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String ingredient() {
-        return faker.fakeValuesService().resolve("food.ingredients", this, faker);
+        return faker.fakeValuesService().resolve("food.ingredients", this);
     }
 
     public String spice() {
-        return faker.fakeValuesService().resolve("food.spices", this, faker);
+        return faker.fakeValuesService().resolve("food.spices", this);
     }
 
     public String dish() {
-        return faker.fakeValuesService().resolve("food.dish", this, faker);
+        return faker.fakeValuesService().resolve("food.dish", this);
     }
 
     public String fruit() {
-        return faker.fakeValuesService().resolve("food.fruits", this, faker);
+        return faker.fakeValuesService().resolve("food.fruits", this);
     }
 
     public String vegetable() {
-        return faker.fakeValuesService().resolve("food.vegetables", this, faker);
+        return faker.fakeValuesService().resolve("food.vegetables", this);
     }
 
     public String sushi() {
-        return faker.fakeValuesService().resolve("food.sushi", this, faker);
+        return faker.fakeValuesService().resolve("food.sushi", this);
     }
 
     public String measurement() {
-        return faker.fakeValuesService().resolve("food.measurement_sizes", this, faker) +
-            " " + faker.fakeValuesService().resolve("food.measurements", this, faker);
+        return faker.fakeValuesService().resolve("food.measurement_sizes", this) +
+            " " + faker.fakeValuesService().resolve("food.measurements", this);
     }
 }

--- a/src/main/java/net/datafaker/Football.java
+++ b/src/main/java/net/datafaker/Football.java
@@ -3,32 +3,30 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-class Football {
-
-    private final Faker faker;
+public class Football extends AbstractProvider {
 
     protected Football(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String teams() {
-        return faker.fakeValuesService().resolve("football.teams", this, faker);
+        return faker.fakeValuesService().resolve("football.teams", this);
     }
 
     public String players() {
-        return faker.fakeValuesService().resolve("football.players", this, faker);
+        return faker.fakeValuesService().resolve("football.players", this);
     }
 
     public String coaches() {
-        return faker.fakeValuesService().resolve("football.coaches", this, faker);
+        return faker.fakeValuesService().resolve("football.coaches", this);
     }
 
     public String competitions() {
-        return faker.fakeValuesService().resolve("football.competitions", this, faker);
+        return faker.fakeValuesService().resolve("football.competitions", this);
     }
 
     public String positions() {
-        return faker.fakeValuesService().resolve("football.positions", this, faker);
+        return faker.fakeValuesService().resolve("football.positions", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Formula1.java
+++ b/src/main/java/net/datafaker/Formula1.java
@@ -3,26 +3,25 @@ package net.datafaker;
 /**
  * @since 1.2.0
  */
-public class Formula1 {
-    private final Faker faker;
+public class Formula1 extends AbstractProvider {
 
     protected Formula1(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String driver() {
-        return faker.fakeValuesService().resolve("formula1.driver", this, faker);
+        return faker.fakeValuesService().resolve("formula1.driver", this);
     }
 
     public String team() {
-        return faker.fakeValuesService().resolve("formula1.team", this, faker);
+        return faker.fakeValuesService().resolve("formula1.team", this);
     }
 
     public String circuit() {
-        return faker.fakeValuesService().resolve("formula1.circuit", this, faker);
+        return faker.fakeValuesService().resolve("formula1.circuit", this);
     }
 
     public String grandPrix() {
-        return faker.fakeValuesService().resolve("formula1.grand_prix", this, faker);
+        return faker.fakeValuesService().resolve("formula1.grand_prix", this);
     }
 }

--- a/src/main/java/net/datafaker/Friends.java
+++ b/src/main/java/net/datafaker/Friends.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Friends {
-    private final Faker faker;
+public class Friends extends AbstractProvider {
 
     protected Friends(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/FunnyName.java
+++ b/src/main/java/net/datafaker/FunnyName.java
@@ -3,14 +3,13 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class FunnyName {
-    private final Faker faker;
+public class FunnyName extends AbstractProvider {
 
     protected FunnyName(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("funny_name.name", this, faker);
+        return faker.fakeValuesService().resolve("funny_name.name", this);
     }
 }

--- a/src/main/java/net/datafaker/GameOfThrones.java
+++ b/src/main/java/net/datafaker/GameOfThrones.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class GameOfThrones {
-
-    private final Faker faker;
+public class GameOfThrones extends AbstractProvider {
 
     protected GameOfThrones(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Gender.java
+++ b/src/main/java/net/datafaker/Gender.java
@@ -5,11 +5,10 @@ package net.datafaker;
  *
  * @since 0.8.0
  */
-public class Gender {
-    private final Faker faker;
+public class Gender extends AbstractProvider {
 
     protected Gender(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Ghostbusters.java
+++ b/src/main/java/net/datafaker/Ghostbusters.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Ghostbusters {
-
-    private final Faker faker;
+public class Ghostbusters extends AbstractProvider {
 
     protected Ghostbusters(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String actor() {

--- a/src/main/java/net/datafaker/GratefulDead.java
+++ b/src/main/java/net/datafaker/GratefulDead.java
@@ -6,20 +6,18 @@ package net.datafaker;
  *
  * @since 1.4.0
  */
-public class GratefulDead {
-
-    private final Faker faker;
+public class GratefulDead extends AbstractProvider {
 
     protected GratefulDead(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String players() {
-        return faker.fakeValuesService().resolve("grateful_dead.players", this, faker);
+        return faker.fakeValuesService().resolve("grateful_dead.players", this);
     }
 
     public String songs() {
-        return faker.fakeValuesService().resolve("grateful_dead.songs", this, faker);
+        return faker.fakeValuesService().resolve("grateful_dead.songs", this);
     }
 
 }

--- a/src/main/java/net/datafaker/GreekPhilosopher.java
+++ b/src/main/java/net/datafaker/GreekPhilosopher.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class GreekPhilosopher {
-
-    private final Faker faker;
+public class GreekPhilosopher extends AbstractProvider {
 
     protected GreekPhilosopher(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class GreekPhilosopher {
      * @return a string of greek philosopher's name.
      */
     public String name() {
-        return faker.fakeValuesService().resolve("greek_philosophers.names", this, faker);
+        return faker.fakeValuesService().resolve("greek_philosophers.names", this);
     }
 
     /**
@@ -26,6 +24,6 @@ public class GreekPhilosopher {
      * @return a string of greek philosopher's quote.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("greek_philosophers.quotes", this, faker);
+        return faker.fakeValuesService().resolve("greek_philosophers.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/Hacker.java
+++ b/src/main/java/net/datafaker/Hacker.java
@@ -3,30 +3,29 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Hacker {
-    private final Faker faker;
+public class Hacker extends AbstractProvider {
 
     protected Hacker(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String abbreviation() {
-        return faker.fakeValuesService().resolve("hacker.abbreviation", this, faker);
+        return faker.fakeValuesService().resolve("hacker.abbreviation", this);
     }
 
     public String adjective() {
-        return faker.fakeValuesService().resolve("hacker.adjective", this, faker);
+        return faker.fakeValuesService().resolve("hacker.adjective", this);
     }
 
     public String noun() {
-        return faker.fakeValuesService().resolve("hacker.noun", this, faker);
+        return faker.fakeValuesService().resolve("hacker.noun", this);
     }
 
     public String verb() {
-        return faker.fakeValuesService().resolve("hacker.verb", this, faker);
+        return faker.fakeValuesService().resolve("hacker.verb", this);
     }
 
     public String ingverb() {
-        return faker.fakeValuesService().resolve("hacker.ingverb", this, faker);
+        return faker.fakeValuesService().resolve("hacker.ingverb", this);
     }
 }

--- a/src/main/java/net/datafaker/HarryPotter.java
+++ b/src/main/java/net/datafaker/HarryPotter.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class HarryPotter {
-    private final Faker faker;
+public class HarryPotter extends AbstractProvider {
 
     protected HarryPotter(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Hashing.java
+++ b/src/main/java/net/datafaker/Hashing.java
@@ -8,11 +8,10 @@ import java.security.NoSuchAlgorithmException;
 /**
  * @since 0.8.0
  */
-public class Hashing {
-    private final Faker faker;
+public class Hashing extends AbstractProvider {
 
     protected Hashing(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String md2() {

--- a/src/main/java/net/datafaker/Hearthstone.java
+++ b/src/main/java/net/datafaker/Hearthstone.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Hearthstone {
-
-    private final Faker faker;
+public class Hearthstone extends AbstractProvider {
 
     protected Hearthstone(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String mainProfession() {
@@ -16,7 +14,7 @@ public class Hearthstone {
     }
 
     public String mainCharacter() {
-        return faker.fakeValuesService().resolve("games.hearthstone.characters", this, faker);
+        return faker.fakeValuesService().resolve("games.hearthstone.characters", this);
     }
 
     public String mainPattern() {

--- a/src/main/java/net/datafaker/HeyArnold.java
+++ b/src/main/java/net/datafaker/HeyArnold.java
@@ -5,24 +5,22 @@ package net.datafaker;
  *
  * @since 1.4.0
  */
-public class HeyArnold {
-
-    private final Faker faker;
+public class HeyArnold extends AbstractProvider {
 
     protected HeyArnold(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("hey_arnold.characters", this, faker);
+        return faker.fakeValuesService().resolve("hey_arnold.characters", this);
     }
 
     public String locations() {
-        return faker.fakeValuesService().resolve("hey_arnold.locations", this, faker);
+        return faker.fakeValuesService().resolve("hey_arnold.locations", this);
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("hey_arnold.quotes", this, faker);
+        return faker.fakeValuesService().resolve("hey_arnold.quotes", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Hipster.java
+++ b/src/main/java/net/datafaker/Hipster.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Hipster {
-    private final Faker faker;
+public class Hipster extends AbstractProvider {
 
     protected Hipster(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String word() {

--- a/src/main/java/net/datafaker/HitchhikersGuideToTheGalaxy.java
+++ b/src/main/java/net/datafaker/HitchhikersGuideToTheGalaxy.java
@@ -3,38 +3,37 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class HitchhikersGuideToTheGalaxy {
-    private final Faker faker;
+public class HitchhikersGuideToTheGalaxy extends AbstractProvider {
 
     protected HitchhikersGuideToTheGalaxy(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.characters", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.characters", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.locations", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.locations", this);
     }
 
     public String marvinQuote() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.marvin_quote", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.marvin_quote", this);
     }
 
     public String planet() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.planets", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.planets", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.quotes", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.quotes", this);
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.species", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.species", this);
     }
 
     public String starship() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.starships", this, faker);
+        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.starships", this);
     }
 }

--- a/src/main/java/net/datafaker/Hobbit.java
+++ b/src/main/java/net/datafaker/Hobbit.java
@@ -3,26 +3,25 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Hobbit {
-    private final Faker faker;
+public class Hobbit extends AbstractProvider {
 
     protected Hobbit(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("hobbit.character", this, faker);
+        return faker.fakeValuesService().resolve("hobbit.character", this);
     }
 
     public String thorinsCompany() {
-        return faker.fakeValuesService().resolve("hobbit.thorins_company", this, faker);
+        return faker.fakeValuesService().resolve("hobbit.thorins_company", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("hobbit.quote", this, faker);
+        return faker.fakeValuesService().resolve("hobbit.quote", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("hobbit.location", this, faker);
+        return faker.fakeValuesService().resolve("hobbit.location", this);
     }
 }

--- a/src/main/java/net/datafaker/Hobby.java
+++ b/src/main/java/net/datafaker/Hobby.java
@@ -3,16 +3,14 @@ package net.datafaker;
 /**
  * @since 1.3.0
  */
-public class Hobby {
-
-    private final Faker faker;
+public class Hobby extends AbstractProvider {
 
     protected Hobby(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String activity() {
-        return faker.fakeValuesService().resolve("hobby.activity", this, faker);
+        return faker.fakeValuesService().resolve("hobby.activity", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Hololive.java
+++ b/src/main/java/net/datafaker/Hololive.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Hololive {
-    private final Faker faker;
+public class Hololive extends AbstractProvider {
 
     protected Hololive(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String talent() {

--- a/src/main/java/net/datafaker/Horse.java
+++ b/src/main/java/net/datafaker/Horse.java
@@ -3,20 +3,18 @@ package net.datafaker;
 /**
  * @since 1.3.0
  */
-public class Horse {
-
-    private final Faker faker;
+public class Horse extends AbstractProvider {
 
     protected Horse(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.horse.name", this, faker);
+        return faker.fakeValuesService().resolve("creature.horse.name", this);
     }
 
     public String breed() {
-        return faker.fakeValuesService().resolve("creature.horse.breed", this, faker);
+        return faker.fakeValuesService().resolve("creature.horse.breed", this);
     }
 
 }

--- a/src/main/java/net/datafaker/House.java
+++ b/src/main/java/net/datafaker/House.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class House {
-
-    private final Faker faker;
+public class House extends AbstractProvider {
 
     protected House(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class House {
      * @return a string of furniture.
      */
     public String furniture() {
-        return faker.fakeValuesService().resolve("house.furniture", this, faker);
+        return faker.fakeValuesService().resolve("house.furniture", this);
     }
 
     /**
@@ -26,6 +24,6 @@ public class House {
      * @return a string of room.
      */
     public String room() {
-        return faker.fakeValuesService().resolve("house.rooms", this, faker);
+        return faker.fakeValuesService().resolve("house.rooms", this);
     }
 }

--- a/src/main/java/net/datafaker/HowIMetYourMother.java
+++ b/src/main/java/net/datafaker/HowIMetYourMother.java
@@ -3,26 +3,25 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class HowIMetYourMother {
-    private final Faker faker;
+public class HowIMetYourMother extends AbstractProvider {
 
     protected HowIMetYourMother(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.character", this, faker);
+        return faker.fakeValuesService().resolve("how_i_met_your_mother.character", this);
     }
 
     public String catchPhrase() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.catch_phrase", this, faker);
+        return faker.fakeValuesService().resolve("how_i_met_your_mother.catch_phrase", this);
     }
 
     public String highFive() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.high_five", this, faker);
+        return faker.fakeValuesService().resolve("how_i_met_your_mother.high_five", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.quote", this, faker);
+        return faker.fakeValuesService().resolve("how_i_met_your_mother.quote", this);
     }
 }

--- a/src/main/java/net/datafaker/IdNumber.java
+++ b/src/main/java/net/datafaker/IdNumber.java
@@ -17,19 +17,18 @@ import net.datafaker.idnumbers.ZhCnIdNumber;
 /**
  * @since 0.8.0
  */
-public class IdNumber {
-    private final Faker faker;
+public class IdNumber extends AbstractProvider {
 
     protected IdNumber(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String valid() {
-        return faker.fakeValuesService().resolve("id_number.valid", this, faker);
+        return faker.fakeValuesService().resolve("id_number.valid", this);
     }
 
     public String invalid() {
-        return faker.numerify(faker.fakeValuesService().resolve("id_number.invalid", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("id_number.invalid", this));
     }
 
     public String ssnValid() {

--- a/src/main/java/net/datafaker/IndustrySegments.java
+++ b/src/main/java/net/datafaker/IndustrySegments.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class IndustrySegments {
-
-    private final Faker faker;
+public class IndustrySegments extends AbstractProvider {
 
     protected IndustrySegments(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String industry() {

--- a/src/main/java/net/datafaker/Internet.java
+++ b/src/main/java/net/datafaker/Internet.java
@@ -16,13 +16,12 @@ import java.util.regex.Pattern;
 /**
  * @since 0.8.0
  */
-public class Internet {
+public class Internet extends AbstractProvider {
     private static final Pattern SINGLE_QUOTE = Pattern.compile("'");
     private static final Pattern COLON = Pattern.compile(":");
-    private final Faker faker;
 
     protected Internet(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String emailAddress() {
@@ -30,7 +29,7 @@ public class Internet {
     }
 
     public String emailAddress(String localPart) {
-        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.free_email", this, faker)));
+        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.free_email", this)));
     }
 
     public String safeEmailAddress() {
@@ -38,7 +37,7 @@ public class Internet {
     }
 
     public String safeEmailAddress(String localPart) {
-        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.safe_email", this, faker)));
+        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.safe_email", this)));
     }
 
     private String emailAddress(String localPart, String domain) {
@@ -64,7 +63,7 @@ public class Internet {
     }
 
     public String domainSuffix() {
-        return faker.fakeValuesService().resolve("internet.domain_suffix", this, faker);
+        return faker.fakeValuesService().resolve("internet.domain_suffix", this);
     }
 
     public String url() {
@@ -97,7 +96,7 @@ public class Internet {
      * @see <a href="http://lorempixel.com/">lorempixel - Placeholder Images for every case</a>
      */
     public String image() {
-        String[] dimension = faker.fakeValuesService().resolve("internet.image_dimension", this, faker).split("x");
+        String[] dimension = faker.fakeValuesService().resolve("internet.image_dimension", this).split("x");
         if (dimension.length == 0) {
             return "";
         } else {
@@ -118,7 +117,7 @@ public class Internet {
      */
     public String image(Integer width, Integer height, Boolean gray, String text) {
         return String.format("https://lorempixel.com/%s%s/%s/%s/%s",
-            gray ? "g/" : "", width, height, faker.fakeValuesService().resolve("internet.image_category", this, faker),
+            gray ? "g/" : "", width, height, faker.fakeValuesService().resolve("internet.image_category", this),
             (text == null || text.length() == 0) ? "" : text);
     }
 
@@ -371,7 +370,7 @@ public class Internet {
         }
 
         String userAgentKey = "internet.user_agent." + agent.toString();
-        return faker.fakeValuesService().resolve(userAgentKey, this, faker);
+        return faker.fakeValuesService().resolve(userAgentKey, this);
     }
 
     public String userAgentAny() {

--- a/src/main/java/net/datafaker/Job.java
+++ b/src/main/java/net/datafaker/Job.java
@@ -3,31 +3,29 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Job {
-
-    private final Faker faker;
+public class Job extends AbstractProvider {
 
     public Job(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String field() {
-        return faker.fakeValuesService().resolve("job.field", this, faker);
+        return faker.fakeValuesService().resolve("job.field", this);
     }
 
     public String seniority() {
-        return faker.fakeValuesService().resolve("job.seniority", this, faker);
+        return faker.fakeValuesService().resolve("job.seniority", this);
     }
 
     public String position() {
-        return faker.fakeValuesService().resolve("job.position", this, faker);
+        return faker.fakeValuesService().resolve("job.position", this);
     }
 
     public String keySkills() {
-        return faker.fakeValuesService().resolve("job.key_skills", this, faker);
+        return faker.fakeValuesService().resolve("job.key_skills", this);
     }
 
     public String title() {
-        return faker.fakeValuesService().resolve("job.title", this, faker);
+        return faker.fakeValuesService().resolve("job.title", this);
     }
 }

--- a/src/main/java/net/datafaker/Kaamelott.java
+++ b/src/main/java/net/datafaker/Kaamelott.java
@@ -3,18 +3,17 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Kaamelott {
-    private final Faker faker;
+public class Kaamelott extends AbstractProvider {
 
     protected Kaamelott(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("kaamelott.characters", this, faker);
+        return faker.fakeValuesService().resolve("kaamelott.characters", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("kaamelott.quotes", this, faker);
+        return faker.fakeValuesService().resolve("kaamelott.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/Kpop.java
+++ b/src/main/java/net/datafaker/Kpop.java
@@ -5,36 +5,34 @@ package net.datafaker;
  *
  * @since 1.3.0
  */
-public class Kpop {
-
-    private final Faker faker;
+public class Kpop extends AbstractProvider {
 
     protected Kpop(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String iGroups() {
-        return faker.fakeValuesService().resolve("kpop.i_groups", this, faker);
+        return faker.fakeValuesService().resolve("kpop.i_groups", this);
     }
 
     public String iiGroups() {
-        return faker.fakeValuesService().resolve("kpop.ii_groups", this, faker);
+        return faker.fakeValuesService().resolve("kpop.ii_groups", this);
     }
 
     public String iiiGroups() {
-        return faker.fakeValuesService().resolve("kpop.iii_groups", this, faker);
+        return faker.fakeValuesService().resolve("kpop.iii_groups", this);
     }
 
     public String girlGroups() {
-        return faker.fakeValuesService().resolve("kpop.girl_groups", this, faker);
+        return faker.fakeValuesService().resolve("kpop.girl_groups", this);
     }
 
     public String boyBands() {
-        return faker.fakeValuesService().resolve("kpop.boy_bands", this, faker);
+        return faker.fakeValuesService().resolve("kpop.boy_bands", this);
     }
 
     public String solo() {
-        return faker.fakeValuesService().resolve("kpop.solo", this, faker);
+        return faker.fakeValuesService().resolve("kpop.solo", this);
     }
 
 }

--- a/src/main/java/net/datafaker/LeagueOfLegends.java
+++ b/src/main/java/net/datafaker/LeagueOfLegends.java
@@ -3,34 +3,33 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class LeagueOfLegends {
-    private final Faker faker;
+public class LeagueOfLegends extends AbstractProvider {
 
     protected LeagueOfLegends(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String champion() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.champion", this, faker);
+        return faker.fakeValuesService().resolve("games.league_of_legends.champion", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.location", this, faker);
+        return faker.fakeValuesService().resolve("games.league_of_legends.location", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.quote", this, faker);
+        return faker.fakeValuesService().resolve("games.league_of_legends.quote", this);
     }
 
     public String summonerSpell() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.summoner_spell", this, faker);
+        return faker.fakeValuesService().resolve("games.league_of_legends.summoner_spell", this);
     }
 
     public String masteries() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.masteries", this, faker);
+        return faker.fakeValuesService().resolve("games.league_of_legends.masteries", this);
     }
 
     public String rank() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.rank", this, faker);
+        return faker.fakeValuesService().resolve("games.league_of_legends.rank", this);
     }
 }

--- a/src/main/java/net/datafaker/Lebowski.java
+++ b/src/main/java/net/datafaker/Lebowski.java
@@ -3,22 +3,21 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Lebowski {
-    private final Faker faker;
+public class Lebowski extends AbstractProvider {
 
     public Lebowski(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String actor() {
-        return faker.fakeValuesService().resolve("lebowski.actors", this, faker);
+        return faker.fakeValuesService().resolve("lebowski.actors", this);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("lebowski.characters", this, faker);
+        return faker.fakeValuesService().resolve("lebowski.characters", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("lebowski.quotes", this, faker);
+        return faker.fakeValuesService().resolve("lebowski.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/LordOfTheRings.java
+++ b/src/main/java/net/datafaker/LordOfTheRings.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class LordOfTheRings {
-    private final Faker faker;
+public class LordOfTheRings extends AbstractProvider {
 
     protected LordOfTheRings(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Lorem.java
+++ b/src/main/java/net/datafaker/Lorem.java
@@ -8,11 +8,10 @@ import static net.datafaker.internal.helper.WordUtils.capitalize;
 /**
  * @since 0.8.0
  */
-public class Lorem {
-    private final Faker faker;
+public class Lorem extends AbstractProvider {
 
     protected Lorem(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public char character() {
@@ -175,7 +174,7 @@ public class Lorem {
     }
 
     public String word() {
-        return faker.fakeValuesService().resolve("lorem.words", this, faker);
+        return faker.fakeValuesService().resolve("lorem.words", this);
     }
 
     /**

--- a/src/main/java/net/datafaker/Marketing.java
+++ b/src/main/java/net/datafaker/Marketing.java
@@ -5,15 +5,13 @@ package net.datafaker;
  *
  * @since 1.2.0
  */
-public class Marketing {
-
-    private final Faker faker;
+public class Marketing extends AbstractProvider {
 
     protected Marketing(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String buzzwords() {
-        return faker.fakeValuesService().resolve("marketing.buzzwords", this, faker);
+        return faker.fakeValuesService().resolve("marketing.buzzwords", this);
     }
 }

--- a/src/main/java/net/datafaker/Matz.java
+++ b/src/main/java/net/datafaker/Matz.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Matz {
-    private final Faker faker;
+public class Matz extends AbstractProvider {
 
     protected Matz(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String quote() {

--- a/src/main/java/net/datafaker/Mbti.java
+++ b/src/main/java/net/datafaker/Mbti.java
@@ -5,12 +5,12 @@ package net.datafaker;
  *
  * @since 1.5.0
  */
-public class Mbti {
-    private final Faker faker;
+public class Mbti extends AbstractProvider {
+    
     private final String choice;
 
     public Mbti(final Faker faker) {
-        this.faker = faker;
+        super(faker);
         this.choice = this.faker.resolve("mbti.choice");
     }
 

--- a/src/main/java/net/datafaker/Measurement.java
+++ b/src/main/java/net/datafaker/Measurement.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Measurement {
-
-    private final Faker faker;
+public class Measurement extends AbstractProvider {
 
     protected Measurement(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class Measurement {
      * @return a string of height measurement.
      */
     public String height() {
-        return faker.fakeValuesService().resolve("measurement.height", this, faker);
+        return faker.fakeValuesService().resolve("measurement.height", this);
     }
 
     /**
@@ -26,7 +24,7 @@ public class Measurement {
      * @return a string of length measurement.
      */
     public String length() {
-        return faker.fakeValuesService().resolve("measurement.length", this, faker);
+        return faker.fakeValuesService().resolve("measurement.length", this);
     }
 
     /**
@@ -35,7 +33,7 @@ public class Measurement {
      * @return a string of volume measurement.
      */
     public String volume() {
-        return faker.fakeValuesService().resolve("measurement.volume", this, faker);
+        return faker.fakeValuesService().resolve("measurement.volume", this);
     }
 
     /**
@@ -44,7 +42,7 @@ public class Measurement {
      * @return a string of weight measurement.
      */
     public String weight() {
-        return faker.fakeValuesService().resolve("measurement.weight", this, faker);
+        return faker.fakeValuesService().resolve("measurement.weight", this);
     }
 
     /**
@@ -53,7 +51,7 @@ public class Measurement {
      * @return a string of metric height measurement.
      */
     public String metricHeight() {
-        return faker.fakeValuesService().resolve("measurement.metric_height", this, faker);
+        return faker.fakeValuesService().resolve("measurement.metric_height", this);
     }
 
     /**
@@ -62,7 +60,7 @@ public class Measurement {
      * @return a string of metric length measurement.
      */
     public String metricLength() {
-        return faker.fakeValuesService().resolve("measurement.metric_length", this, faker);
+        return faker.fakeValuesService().resolve("measurement.metric_length", this);
     }
 
     /**
@@ -71,7 +69,7 @@ public class Measurement {
      * @return a string of metric volume measurement.
      */
     public String metricVolume() {
-        return faker.fakeValuesService().resolve("measurement.metric_volume", this, faker);
+        return faker.fakeValuesService().resolve("measurement.metric_volume", this);
     }
 
     /**
@@ -80,6 +78,6 @@ public class Measurement {
      * @return a string of metric weight measurement.
      */
     public String metricWeight() {
-        return faker.fakeValuesService().resolve("measurement.metric_weight", this, faker);
+        return faker.fakeValuesService().resolve("measurement.metric_weight", this);
     }
 }

--- a/src/main/java/net/datafaker/Medical.java
+++ b/src/main/java/net/datafaker/Medical.java
@@ -3,37 +3,35 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Medical {
-
-    private final Faker faker;
+public class Medical extends AbstractProvider {
 
     protected Medical(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String medicineName() {
-        return faker.fakeValuesService().resolve("medical.medicine_name", this, faker);
+        return faker.fakeValuesService().resolve("medical.medicine_name", this);
     }
 
     public String diseaseName() {
-        return faker.fakeValuesService().resolve("medical.disease_name", this, faker);
+        return faker.fakeValuesService().resolve("medical.disease_name", this);
     }
 
     public String hospitalName() {
-        return faker.fakeValuesService().resolve("medical.hospital_name", this, faker);
+        return faker.fakeValuesService().resolve("medical.hospital_name", this);
     }
 
     public String symptoms() {
-        return faker.fakeValuesService().resolve("medical.symptoms", this, faker);
+        return faker.fakeValuesService().resolve("medical.symptoms", this);
     }
 
     public String diagnosisCode() {
-        String regex = faker.fakeValuesService().resolve("medical.diagnosis_code.icd10", this, faker);
+        String regex = faker.fakeValuesService().resolve("medical.diagnosis_code.icd10", this);
         return faker.regexify(regex);
     }
 
     public String procedureCode() {
-        String regex = faker.fakeValuesService().resolve("medical.procedure_code.icd10", this, faker);
+        String regex = faker.fakeValuesService().resolve("medical.procedure_code.icd10", this);
         return faker.regexify(regex);
     }
 }

--- a/src/main/java/net/datafaker/Military.java
+++ b/src/main/java/net/datafaker/Military.java
@@ -5,32 +5,30 @@ package net.datafaker;
  *
  * @since 1.2.0
  */
-public class Military {
-
-    private final Faker faker;
+public class Military extends AbstractProvider {
 
     protected Military(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String armyRank() {
-        return faker.fakeValuesService().resolve("military.army_rank", this, faker);
+        return faker.fakeValuesService().resolve("military.army_rank", this);
     }
 
     public String marinesRank() {
-        return faker.fakeValuesService().resolve("military.marines_rank", this, faker);
+        return faker.fakeValuesService().resolve("military.marines_rank", this);
     }
 
     public String navyRank() {
-        return faker.fakeValuesService().resolve("military.navy_rank", this, faker);
+        return faker.fakeValuesService().resolve("military.navy_rank", this);
     }
 
     public String airForceRank() {
-        return faker.fakeValuesService().resolve("military.air_force_rank", this, faker);
+        return faker.fakeValuesService().resolve("military.air_force_rank", this);
     }
 
     public String dodPaygrade() {
-        return faker.fakeValuesService().resolve("military.dod_paygrade", this, faker);
+        return faker.fakeValuesService().resolve("military.dod_paygrade", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Minecraft.java
+++ b/src/main/java/net/datafaker/Minecraft.java
@@ -3,31 +3,30 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Minecraft {
-    private final Faker faker;
+public class Minecraft extends AbstractProvider {
 
     public Minecraft(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String itemName() {
-        return faker.fakeValuesService().resolve("minecraft.item_name", this, faker);
+        return faker.fakeValuesService().resolve("minecraft.item_name", this);
     }
 
     public String tileName() {
-        return faker.fakeValuesService().resolve("minecraft.tile_name", this, faker);
+        return faker.fakeValuesService().resolve("minecraft.tile_name", this);
     }
 
     public String entityName() {
-        return faker.fakeValuesService().resolve("minecraft.entity_name", this, faker);
+        return faker.fakeValuesService().resolve("minecraft.entity_name", this);
     }
 
     public String monsterName() {
-        return faker.fakeValuesService().resolve("minecraft.monster_name", this, faker);
+        return faker.fakeValuesService().resolve("minecraft.monster_name", this);
     }
 
     public String animalName() {
-        return faker.fakeValuesService().resolve("minecraft.animal_name", this, faker);
+        return faker.fakeValuesService().resolve("minecraft.animal_name", this);
     }
 
     public String tileItemName() {

--- a/src/main/java/net/datafaker/Money.java
+++ b/src/main/java/net/datafaker/Money.java
@@ -5,12 +5,10 @@ package net.datafaker;
  *
  * @since 1.5.0
  */
-public class Money {
-
-    private final Faker faker;
+public class Money extends AbstractProvider {
 
     public Money(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -19,7 +17,7 @@ public class Money {
      * @return detailed currency value.
      */
     public String currency() {
-        return faker.fakeValuesService().resolve("money.currency", this, faker);
+        return faker.fakeValuesService().resolve("money.currency", this);
     }
 
     /**
@@ -28,6 +26,6 @@ public class Money {
      * @return currency code.
      */
     public String currencyCode() {
-        return faker.fakeValuesService().resolve("money.code", this, faker);
+        return faker.fakeValuesService().resolve("money.code", this);
     }
 }

--- a/src/main/java/net/datafaker/Mood.java
+++ b/src/main/java/net/datafaker/Mood.java
@@ -3,24 +3,22 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Mood {
-
-    private final Faker faker;
+public class Mood extends AbstractProvider {
 
     protected Mood(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String feeling() {
-        return faker.fakeValuesService().resolve("mood.feeling", this, faker);
+        return faker.fakeValuesService().resolve("mood.feeling", this);
     }
 
     public String emotion() {
-        return faker.fakeValuesService().resolve("mood.emotion", this, faker);
+        return faker.fakeValuesService().resolve("mood.emotion", this);
     }
 
     public String tone() {
-        return faker.fakeValuesService().resolve("mood.tone", this, faker);
+        return faker.fakeValuesService().resolve("mood.tone", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Mountain.java
+++ b/src/main/java/net/datafaker/Mountain.java
@@ -5,18 +5,17 @@ package net.datafaker;
  *
  * @since 1.1.0
  */
-public class Mountain {
-    private final Faker faker;
+public class Mountain extends AbstractProvider {
 
     protected Mountain(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("mountain.name", this, faker);
+        return faker.fakeValuesService().resolve("mountain.name", this);
     }
 
     public String range() {
-        return faker.fakeValuesService().resolve("mountain.range", this, faker);
+        return faker.fakeValuesService().resolve("mountain.range", this);
     }
 }

--- a/src/main/java/net/datafaker/Mountaineering.java
+++ b/src/main/java/net/datafaker/Mountaineering.java
@@ -5,16 +5,14 @@ package net.datafaker;
  *
  * @since 1.4.0
  */
-public class Mountaineering {
-
-    private final Faker faker;
+public class Mountaineering extends AbstractProvider {
 
     protected Mountaineering(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String mountaineer() {
-        return faker.fakeValuesService().resolve("mountaineering.mountaineer", this, faker);
+        return faker.fakeValuesService().resolve("mountaineering.mountaineer", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Movie.java
+++ b/src/main/java/net/datafaker/Movie.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Movie {
-
-    private final Faker faker;
+public class Movie extends AbstractProvider {
 
     protected Movie(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,6 +15,6 @@ public class Movie {
      * @return a string of quote from a movie.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("movie.quote", this, faker);
+        return faker.fakeValuesService().resolve("movie.quote", this);
     }
 }

--- a/src/main/java/net/datafaker/Music.java
+++ b/src/main/java/net/datafaker/Music.java
@@ -3,16 +3,14 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Music {
+public class Music extends AbstractProvider {
 
     private static final String[] KEYS = new String[]{"C", "D", "E", "F", "G", "A", "B"};
     private static final String[] KEY_VARIANTS = new String[]{"b", "#", ""};
     private static final String[] CHORD_TYPES = new String[]{"", "maj", "6", "maj7", "m", "m7", "-7", "7", "dom7", "dim", "dim7", "m7b5"};
 
-    private final Faker faker;
-
     protected Music(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String instrument() {

--- a/src/main/java/net/datafaker/Name.java
+++ b/src/main/java/net/datafaker/Name.java
@@ -3,15 +3,14 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Name {
-    private final Faker faker;
+public class Name extends AbstractProvider {
 
     /**
      * Internal constructor, not to be used by clients.  Instances of {@link Name} should be accessed via
      * {@link Faker#name()}.
      */
     protected Name(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -25,7 +24,7 @@ public class Name {
      * @return a random name with given and family names and an optional suffix.
      */
     public String name() {
-        return faker.fakeValuesService().resolve("name.name", this, faker);
+        return faker.fakeValuesService().resolve("name.name", this);
     }
 
     /**
@@ -41,7 +40,7 @@ public class Name {
      * @return a random name with a middle name component with optional prefix and suffix
      */
     public String nameWithMiddle() {
-        return faker.fakeValuesService().resolve("name.name_with_middle", this, faker);
+        return faker.fakeValuesService().resolve("name.name_with_middle", this);
     }
 
     /**
@@ -59,7 +58,7 @@ public class Name {
      * @return a 'given' name such as Aaliyah, Aaron, Abagail or Abbey
      */
     public String firstName() {
-        return faker.fakeValuesService().resolve("name.first_name", this, faker);
+        return faker.fakeValuesService().resolve("name.first_name", this);
     }
 
     /**
@@ -68,7 +67,7 @@ public class Name {
      * @return a random last name such as Smith, Jones or Baldwin
      */
     public String lastName() {
-        return faker.fakeValuesService().resolve("name.last_name", this, faker);
+        return faker.fakeValuesService().resolve("name.last_name", this);
     }
 
     /**
@@ -77,7 +76,7 @@ public class Name {
      * @return a name prefix such as Mr., Mrs., Ms., Miss, or Dr.
      */
     public String prefix() {
-        return faker.fakeValuesService().resolve("name.prefix", this, faker);
+        return faker.fakeValuesService().resolve("name.prefix", this);
     }
 
     /**
@@ -86,7 +85,7 @@ public class Name {
      * @return a name suffix such as Jr., Sr., I, II, III, IV, V, MD, DDS, PhD or DVM
      */
     public String suffix() {
-        return faker.fakeValuesService().resolve("name.suffix", this, faker);
+        return faker.fakeValuesService().resolve("name.suffix", this);
     }
 
     /**
@@ -102,9 +101,9 @@ public class Name {
      */
     public String title() {
         return String.join(" ",
-            faker.fakeValuesService().resolve("name.title.descriptor", this, faker),
-            faker.fakeValuesService().resolve("name.title.level", this, faker),
-            faker.fakeValuesService().resolve("name.title.job", this, faker)
+            faker.fakeValuesService().resolve("name.title.descriptor", this),
+            faker.fakeValuesService().resolve("name.title.level", this),
+            faker.fakeValuesService().resolve("name.title.job", this)
         );
     }
 

--- a/src/main/java/net/datafaker/Nation.java
+++ b/src/main/java/net/datafaker/Nation.java
@@ -10,26 +10,24 @@ import java.util.Locale;
 /**
  * @since 0.8.0
  */
-public class Nation {
+public class Nation extends AbstractProvider {
 
     private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
-    private final Faker faker;
-
     protected Nation(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String nationality() {
-        return faker.fakeValuesService().resolve("nation.nationality", this, faker);
+        return faker.fakeValuesService().resolve("nation.nationality", this);
     }
 
     public String language() {
-        return faker.fakeValuesService().resolve("nation.language", this, faker);
+        return faker.fakeValuesService().resolve("nation.language", this);
     }
 
     public String capitalCity() {
-        return faker.fakeValuesService().resolve("nation.capital_city", this, faker);
+        return faker.fakeValuesService().resolve("nation.capital_city", this);
     }
 
     public String flag() {

--- a/src/main/java/net/datafaker/NatoPhoneticAlphabet.java
+++ b/src/main/java/net/datafaker/NatoPhoneticAlphabet.java
@@ -5,16 +5,14 @@ package net.datafaker;
  *
  * @since 1.2.0
  */
-public class NatoPhoneticAlphabet {
-
-    private final Faker faker;
+public class NatoPhoneticAlphabet extends AbstractProvider {
 
     protected NatoPhoneticAlphabet(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String codeWord() {
-        return faker.fakeValuesService().resolve("nato_phonetic_alphabet.code_word", this, faker);
+        return faker.fakeValuesService().resolve("nato_phonetic_alphabet.code_word", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Nigeria.java
+++ b/src/main/java/net/datafaker/Nigeria.java
@@ -5,32 +5,31 @@ package net.datafaker;
  *
  * @since 1.2.0
  */
-public class Nigeria {
+public class Nigeria extends AbstractProvider {
     private static final String KEY = "nigeria";
-    private final Faker faker;
 
     protected Nigeria(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String places() {
-        return faker.fakeValuesService().resolve(KEY + ".places", this, faker);
+        return faker.fakeValuesService().resolve(KEY + ".places", this);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve(KEY + ".name", this, faker);
+        return faker.fakeValuesService().resolve(KEY + ".name", this);
     }
 
     public String food() {
-        return faker.fakeValuesService().resolve(KEY + ".food", this, faker);
+        return faker.fakeValuesService().resolve(KEY + ".food", this);
     }
 
     public String schools() {
-        return faker.fakeValuesService().resolve(KEY + ".schools", this, faker);
+        return faker.fakeValuesService().resolve(KEY + ".schools", this);
     }
 
     public String celebrities() {
-        return faker.fakeValuesService().resolve(KEY + ".celebrities", this, faker);
+        return faker.fakeValuesService().resolve(KEY + ".celebrities", this);
     }
 }
 

--- a/src/main/java/net/datafaker/Number.java
+++ b/src/main/java/net/datafaker/Number.java
@@ -6,11 +6,10 @@ import java.math.RoundingMode;
 /**
  * @since 0.8.0
  */
-public class Number {
-    private final Faker faker;
+public class Number extends AbstractProvider {
 
     protected Number(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Options.java
+++ b/src/main/java/net/datafaker/Options.java
@@ -10,11 +10,10 @@ import java.util.stream.Stream;
 /**
  * @since 0.8.0
  */
-public class Options {
-    private final Faker faker;
+public class Options extends AbstractProvider {
 
     protected Options(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/OscarMovie.java
+++ b/src/main/java/net/datafaker/OscarMovie.java
@@ -6,9 +6,8 @@ package net.datafaker;
  * @author ak-maker
  * @since 1.4.0
  */
-public class OscarMovie {
+public class OscarMovie extends AbstractProvider {
 
-    private final Faker faker;
     private final String year;
     private final String choice;
 
@@ -21,7 +20,7 @@ public class OscarMovie {
      * @param faker faker The Faker instance for generating random names of things.
      */
     protected OscarMovie(final Faker faker) {
-        this.faker = faker;
+        super(faker);
         this.year = this.faker.resolve("oscar_movie.year.years");
         this.choice = this.faker.resolve("oscar_movie.year.choice");
         this.str = "oscar_movie.".concat(year).concat(".").concat(choice);

--- a/src/main/java/net/datafaker/Overwatch.java
+++ b/src/main/java/net/datafaker/Overwatch.java
@@ -3,22 +3,21 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Overwatch {
-    private final Faker faker;
+public class Overwatch extends AbstractProvider {
 
     protected Overwatch(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String hero() {
-        return faker.fakeValuesService().resolve("games.overwatch.heroes", this, faker);
+        return faker.fakeValuesService().resolve("games.overwatch.heroes", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("games.overwatch.locations", this, faker);
+        return faker.fakeValuesService().resolve("games.overwatch.locations", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.overwatch.quotes", this, faker);
+        return faker.fakeValuesService().resolve("games.overwatch.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/Passport.java
+++ b/src/main/java/net/datafaker/Passport.java
@@ -6,11 +6,10 @@ import net.datafaker.passportnumbers.ChPassportNumber;
 /**
  * @since 0.9.0
  */
-public class Passport {
-    private final Faker faker;
+public class Passport extends AbstractProvider {
 
     protected Passport(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String chValid() {

--- a/src/main/java/net/datafaker/PhoneNumber.java
+++ b/src/main/java/net/datafaker/PhoneNumber.java
@@ -3,19 +3,18 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class PhoneNumber {
-    private final Faker faker;
+public class PhoneNumber extends AbstractProvider {
 
     protected PhoneNumber(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String cellPhone() {
-        return faker.numerify(faker.fakeValuesService().resolve("cell_phone.formats", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("cell_phone.formats", this));
     }
 
     public String phoneNumber() {
-        return faker.numerify(faker.fakeValuesService().resolve("phone_number.formats", this, faker));
+        return faker.numerify(faker.fakeValuesService().resolve("phone_number.formats", this));
     }
 
     public String extension() {

--- a/src/main/java/net/datafaker/Photography.java
+++ b/src/main/java/net/datafaker/Photography.java
@@ -5,12 +5,10 @@ package net.datafaker;
  *
  * @since 0.8.0
  */
-public class Photography {
-
-    private final Faker faker;
+public class Photography extends AbstractProvider {
 
     protected Photography(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Pokemon.java
+++ b/src/main/java/net/datafaker/Pokemon.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Pokemon {
-
-    private final Faker faker;
+public class Pokemon extends AbstractProvider {
 
     protected Pokemon(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {

--- a/src/main/java/net/datafaker/PrincessBride.java
+++ b/src/main/java/net/datafaker/PrincessBride.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class PrincessBride {
-    private final Faker faker;
+public class PrincessBride extends AbstractProvider {
 
     protected PrincessBride(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/ProgrammingLanguage.java
+++ b/src/main/java/net/datafaker/ProgrammingLanguage.java
@@ -3,20 +3,18 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class ProgrammingLanguage {
-
-    private final Faker faker;
+public class ProgrammingLanguage extends AbstractProvider {
 
     public ProgrammingLanguage(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("programming_language.name", this, faker);
+        return faker.fakeValuesService().resolve("programming_language.name", this);
     }
 
     public String creator() {
-        return faker.fakeValuesService().resolve("programming_language.creator", this, faker);
+        return faker.fakeValuesService().resolve("programming_language.creator", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Relationship.java
+++ b/src/main/java/net/datafaker/Relationship.java
@@ -8,11 +8,10 @@ import java.util.Arrays;
 /**
  * @since 0.8.0
  */
-public class Relationship {
-    private final Faker faker;
+public class Relationship extends AbstractProvider {
 
     protected Relationship(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String direct() {

--- a/src/main/java/net/datafaker/ResidentEvil.java
+++ b/src/main/java/net/datafaker/ResidentEvil.java
@@ -5,45 +5,44 @@ package net.datafaker;
  *
  * @since 0.9.0
  */
-public class ResidentEvil {
-    private final Faker faker;
+public class ResidentEvil extends AbstractProvider {
 
     protected ResidentEvil(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
      * @return A random character string (like leon kennedy) of ResidentEvil series.
      */
     public String character() {
-        return faker.fakeValuesService().resolve("games.resident_evil.characters", this, faker);
+        return faker.fakeValuesService().resolve("games.resident_evil.characters", this);
     }
 
     /**
      * @return A random biologicalAgent string of ResidentEvil series. This string may contains special characters.
      */
     public String biologicalAgent() {
-        return faker.fakeValuesService().resolve("games.resident_evil.biological-agents", this, faker);
+        return faker.fakeValuesService().resolve("games.resident_evil.biological-agents", this);
     }
 
     /**
      * @return A random equipment string of ResidentEvil series, which includes weapons and other items.
      */
     public String equipment() {
-        return faker.fakeValuesService().resolve("games.resident_evil.equipments", this, faker);
+        return faker.fakeValuesService().resolve("games.resident_evil.equipments", this);
     }
 
     /**
      * @return A random location string of ResidentEvil series.
      */
     public String location() {
-        return faker.fakeValuesService().resolve("games.resident_evil.locations", this, faker);
+        return faker.fakeValuesService().resolve("games.resident_evil.locations", this);
     }
 
     /**
      * @return A random creature string of ResidentEvil series.
      */
     public String creature() {
-        return faker.fakeValuesService().resolve("games.resident_evil.creatures", this, faker);
+        return faker.fakeValuesService().resolve("games.resident_evil.creatures", this);
     }
 }

--- a/src/main/java/net/datafaker/Restaurant.java
+++ b/src/main/java/net/datafaker/Restaurant.java
@@ -3,36 +3,34 @@ package net.datafaker;
 /**
  * @since 1.2.0
  */
-public class Restaurant {
-
-    private final Faker faker;
+public class Restaurant extends AbstractProvider {
 
     protected Restaurant(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String namePrefix() {
-        return faker.fakeValuesService().resolve("restaurant.name_prefix", this, faker);
+        return faker.fakeValuesService().resolve("restaurant.name_prefix", this);
     }
 
     public String nameSuffix() {
-        return faker.fakeValuesService().resolve("restaurant.name_suffix", this, faker);
+        return faker.fakeValuesService().resolve("restaurant.name_suffix", this);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("restaurant.name", this, faker);
+        return faker.fakeValuesService().resolve("restaurant.name", this);
     }
 
     public String type() {
-        return faker.fakeValuesService().resolve("restaurant.type", this, faker);
+        return faker.fakeValuesService().resolve("restaurant.type", this);
     }
 
     public String description() {
-        return faker.fakeValuesService().resolve("restaurant.description", this, faker);
+        return faker.fakeValuesService().resolve("restaurant.description", this);
     }
 
     public String review() {
-        return faker.fakeValuesService().resolve("restaurant.review", this, faker);
+        return faker.fakeValuesService().resolve("restaurant.review", this);
     }
 
 }

--- a/src/main/java/net/datafaker/RickAndMorty.java
+++ b/src/main/java/net/datafaker/RickAndMorty.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class RickAndMorty {
-    private final Faker faker;
+public class RickAndMorty extends AbstractProvider {
 
     protected RickAndMorty(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Robin.java
+++ b/src/main/java/net/datafaker/Robin.java
@@ -3,14 +3,13 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Robin {
-    private final Faker faker;
+public class Robin extends AbstractProvider {
 
     protected Robin(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("robin.quotes", this, faker);
+        return faker.fakeValuesService().resolve("robin.quotes", this);
     }
 }

--- a/src/main/java/net/datafaker/RockBand.java
+++ b/src/main/java/net/datafaker/RockBand.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class RockBand {
-
-    private final Faker faker;
+public class RockBand extends AbstractProvider {
 
     protected RockBand(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {

--- a/src/main/java/net/datafaker/RuPaulDragRace.java
+++ b/src/main/java/net/datafaker/RuPaulDragRace.java
@@ -5,12 +5,10 @@ package net.datafaker;
  *
  * @since 1.0.0
  */
-public class RuPaulDragRace {
-
-    private final Faker faker;
+public class RuPaulDragRace extends AbstractProvider {
 
     protected RuPaulDragRace(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String queen() {

--- a/src/main/java/net/datafaker/Science.java
+++ b/src/main/java/net/datafaker/Science.java
@@ -3,39 +3,38 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Science {
-    private final Faker faker;
+public class Science extends AbstractProvider {
 
     protected Science(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String element() {
-        return faker.fakeValuesService().resolve("science.element", this, faker);
+        return faker.fakeValuesService().resolve("science.element", this);
     }
 
     public String elementSymbol() {
-        return faker.fakeValuesService().resolve("science.element_symbol", this, faker);
+        return faker.fakeValuesService().resolve("science.element_symbol", this);
     }
 
     public String scientist() {
-        return faker.fakeValuesService().resolve("science.scientist", this, faker);
+        return faker.fakeValuesService().resolve("science.scientist", this);
     }
 
     public String tool() {
-        return faker.fakeValuesService().resolve("science.tool", this, faker);
+        return faker.fakeValuesService().resolve("science.tool", this);
     }
 
     public String quark() {
-        return faker.fakeValuesService().resolve("science.particles.quarks", this, faker);
+        return faker.fakeValuesService().resolve("science.particles.quarks", this);
     }
 
     public String leptons() {
-        return faker.fakeValuesService().resolve("science.particles.leptons", this, faker);
+        return faker.fakeValuesService().resolve("science.particles.leptons", this);
     }
 
     public String bosons() {
-        return faker.fakeValuesService().resolve("science.particles.bosons", this, faker);
+        return faker.fakeValuesService().resolve("science.particles.bosons", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Seinfeld.java
+++ b/src/main/java/net/datafaker/Seinfeld.java
@@ -5,24 +5,22 @@ package net.datafaker;
  *
  * @since 1.4.0
  */
-public class Seinfeld {
-
-    private final Faker faker;
+public class Seinfeld extends AbstractProvider {
 
     protected Seinfeld(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("seinfeld.character", this, faker);
+        return faker.fakeValuesService().resolve("seinfeld.character", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("seinfeld.quote", this, faker);
+        return faker.fakeValuesService().resolve("seinfeld.quote", this);
     }
 
     public String business() {
-        return faker.fakeValuesService().resolve("seinfeld.business", this, faker);
+        return faker.fakeValuesService().resolve("seinfeld.business", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Shakespeare.java
+++ b/src/main/java/net/datafaker/Shakespeare.java
@@ -3,7 +3,7 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Shakespeare {
+public class Shakespeare extends AbstractProvider {
 
     private static final String[] hamletQuotes = {
         "To be, or not to be: that is the question.",
@@ -58,11 +58,8 @@ public class Shakespeare {
         "See, how she leans her cheek upon her hand! O that I were a glove upon that hand, that I might touch that cheek!.",
         "Not stepping o'er the bounds of modesty."};
 
-
-    private final Faker faker;
-
     protected Shakespeare(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String hamletQuote() {

--- a/src/main/java/net/datafaker/Simpsons.java
+++ b/src/main/java/net/datafaker/Simpsons.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Simpsons {
-
-    private final Faker faker;
+public class Simpsons extends AbstractProvider {
 
     public Simpsons(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Sip.java
+++ b/src/main/java/net/datafaker/Sip.java
@@ -8,12 +8,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author TomerFi
  * @since 0.8.0
  */
-public class Sip {
-    private final Faker faker;
+public class Sip extends AbstractProvider {
+    
     private final int[] portPool = new int[5001];
 
     public Sip(final Faker faker) {
-        this.faker = faker;
+        super(faker);
         for (int i = 0; i < portPool.length; i++) {
             portPool[i] = 40000 + 2 * i;
         }

--- a/src/main/java/net/datafaker/Size.java
+++ b/src/main/java/net/datafaker/Size.java
@@ -3,16 +3,14 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Size {
-
-    private final Faker faker;
+public class Size extends AbstractProvider {
 
     protected Size(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String adjective() {
-        return faker.fakeValuesService().resolve("size.adjective", this, faker);
+        return faker.fakeValuesService().resolve("size.adjective", this);
     }
 
 }

--- a/src/main/java/net/datafaker/SlackEmoji.java
+++ b/src/main/java/net/datafaker/SlackEmoji.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class SlackEmoji {
-
-    private final Faker faker;
+public class SlackEmoji extends AbstractProvider {
 
     protected SlackEmoji(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String people() {
@@ -44,6 +42,6 @@ public class SlackEmoji {
     }
 
     public String emoji() {
-        return faker.fakeValuesService().resolve("slack_emoji.emoji", this, faker);
+        return faker.fakeValuesService().resolve("slack_emoji.emoji", this);
     }
 }

--- a/src/main/java/net/datafaker/SoulKnight.java
+++ b/src/main/java/net/datafaker/SoulKnight.java
@@ -7,11 +7,10 @@ package net.datafaker;
  * @author zhou mintao
  * @since 1.4.0
  */
-public class SoulKnight {
-    private final Faker faker;
+public class SoulKnight extends AbstractProvider {
 
     protected SoulKnight(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Space.java
+++ b/src/main/java/net/datafaker/Space.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Space {
-
-    private final Faker faker;
+public class Space extends AbstractProvider {
 
     protected Space(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String planet() {

--- a/src/main/java/net/datafaker/StarCraft.java
+++ b/src/main/java/net/datafaker/StarCraft.java
@@ -3,28 +3,26 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class StarCraft {
-
-    private final Faker faker;
+public class StarCraft extends AbstractProvider {
 
     protected StarCraft(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String unit() {
-        return faker.fakeValuesService().resolve("starcraft.units", this, faker);
+        return faker.fakeValuesService().resolve("starcraft.units", this);
     }
 
     public String building() {
-        return faker.fakeValuesService().resolve("starcraft.buildings", this, faker);
+        return faker.fakeValuesService().resolve("starcraft.buildings", this);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("starcraft.characters", this, faker);
+        return faker.fakeValuesService().resolve("starcraft.characters", this);
     }
 
     public String planet() {
-        return faker.fakeValuesService().resolve("starcraft.planets", this, faker);
+        return faker.fakeValuesService().resolve("starcraft.planets", this);
     }
 
 }

--- a/src/main/java/net/datafaker/StarTrek.java
+++ b/src/main/java/net/datafaker/StarTrek.java
@@ -3,30 +3,29 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class StarTrek {
-    private final Faker faker;
+public class StarTrek extends AbstractProvider {
 
     protected StarTrek(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("star_trek.character", this, faker);
+        return faker.fakeValuesService().resolve("star_trek.character", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("star_trek.location", this, faker);
+        return faker.fakeValuesService().resolve("star_trek.location", this);
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("star_trek.species", this, faker);
+        return faker.fakeValuesService().resolve("star_trek.species", this);
     }
 
     public String villain() {
-        return faker.fakeValuesService().resolve("star_trek.villain", this, faker);
+        return faker.fakeValuesService().resolve("star_trek.villain", this);
     }
 
     public String klingon() {
-        return faker.fakeValuesService().resolve("star_trek.klingon", this, faker);
+        return faker.fakeValuesService().resolve("star_trek.klingon", this);
     }
 }

--- a/src/main/java/net/datafaker/Stock.java
+++ b/src/main/java/net/datafaker/Stock.java
@@ -3,20 +3,18 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Stock {
-
-    private final Faker faker;
+public class Stock extends AbstractProvider {
 
     protected Stock(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String nsdqSymbol() {
-        return faker.fakeValuesService().resolve("stock.symbol_nsdq", this, faker);
+        return faker.fakeValuesService().resolve("stock.symbol_nsdq", this);
     }
 
     public String nyseSymbol() {
-        return faker.fakeValuesService().resolve("stock.symbol_nyse", this, faker);
+        return faker.fakeValuesService().resolve("stock.symbol_nyse", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Subscription.java
+++ b/src/main/java/net/datafaker/Subscription.java
@@ -3,32 +3,30 @@ package net.datafaker;
 /**
  * @since 1.3.0
  */
-public class Subscription {
-
-    private final Faker faker;
+public class Subscription extends AbstractProvider {
 
     protected Subscription(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String plans() {
-        return faker.fakeValuesService().resolve("subscription.plans", this, faker);
+        return faker.fakeValuesService().resolve("subscription.plans", this);
     }
 
     public String statuses() {
-        return faker.fakeValuesService().resolve("subscription.statuses", this, faker);
+        return faker.fakeValuesService().resolve("subscription.statuses", this);
     }
 
     public String paymentMethods() {
-        return faker.fakeValuesService().resolve("subscription.payment_methods", this, faker);
+        return faker.fakeValuesService().resolve("subscription.payment_methods", this);
     }
 
     public String subscriptionTerms() {
-        return faker.fakeValuesService().resolve("subscription.subscription_terms", this, faker);
+        return faker.fakeValuesService().resolve("subscription.subscription_terms", this);
     }
 
     public String paymentTerms() {
-        return faker.fakeValuesService().resolve("subscription.payment_terms", this, faker);
+        return faker.fakeValuesService().resolve("subscription.payment_terms", this);
     }
 
 }

--- a/src/main/java/net/datafaker/SuperMario.java
+++ b/src/main/java/net/datafaker/SuperMario.java
@@ -3,24 +3,22 @@ package net.datafaker;
 /**
  * @since 1.3.0
  */
-public class SuperMario {
-
-    private final Faker faker;
+public class SuperMario extends AbstractProvider {
 
     protected SuperMario(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("games.super_mario.characters", this, faker);
+        return faker.fakeValuesService().resolve("games.super_mario.characters", this);
     }
 
     public String games() {
-        return faker.fakeValuesService().resolve("games.super_mario.games", this, faker);
+        return faker.fakeValuesService().resolve("games.super_mario.games", this);
     }
 
     public String locations() {
-        return faker.fakeValuesService().resolve("games.super_mario.locations", this, faker);
+        return faker.fakeValuesService().resolve("games.super_mario.locations", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Superhero.java
+++ b/src/main/java/net/datafaker/Superhero.java
@@ -3,30 +3,29 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Superhero {
-    private final Faker faker;
+public class Superhero extends AbstractProvider {
 
     protected Superhero(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("superhero.name", this, faker);
+        return faker.fakeValuesService().resolve("superhero.name", this);
     }
 
     public String prefix() {
-        return faker.fakeValuesService().resolve("superhero.prefix", this, faker);
+        return faker.fakeValuesService().resolve("superhero.prefix", this);
     }
 
     public String suffix() {
-        return faker.fakeValuesService().resolve("superhero.suffix", this, faker);
+        return faker.fakeValuesService().resolve("superhero.suffix", this);
     }
 
     public String power() {
-        return faker.fakeValuesService().resolve("superhero.power", this, faker);
+        return faker.fakeValuesService().resolve("superhero.power", this);
     }
 
     public String descriptor() {
-        return faker.fakeValuesService().resolve("superhero.descriptor", this, faker);
+        return faker.fakeValuesService().resolve("superhero.descriptor", this);
     }
 }

--- a/src/main/java/net/datafaker/Tea.java
+++ b/src/main/java/net/datafaker/Tea.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.4.0
  */
-public class Tea {
-
-    private final Faker faker;
+public class Tea extends AbstractProvider {
 
     protected Tea(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class Tea {
      * @return a string of tea variety.
      */
     public String variety() {
-        return faker.fakeValuesService().resolve("tea.variety." + type().toLowerCase(), this, faker);
+        return faker.fakeValuesService().resolve("tea.variety." + type().toLowerCase(), this);
     }
 
     /**
@@ -26,6 +24,6 @@ public class Tea {
      * @return a string of tea type.
      */
     public String type() {
-        return faker.fakeValuesService().resolve("tea.type", this, faker);
+        return faker.fakeValuesService().resolve("tea.type", this);
     }
 }

--- a/src/main/java/net/datafaker/Team.java
+++ b/src/main/java/net/datafaker/Team.java
@@ -3,26 +3,25 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Team {
-    private final Faker faker;
+public class Team extends AbstractProvider {
 
     protected Team(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("team.name", this, faker);
+        return faker.fakeValuesService().resolve("team.name", this);
     }
 
     public String creature() {
-        return faker.fakeValuesService().resolve("team.creature", this, faker);
+        return faker.fakeValuesService().resolve("team.creature", this);
     }
 
     public String state() {
-        return faker.fakeValuesService().resolve("address.state", this, faker);
+        return faker.fakeValuesService().resolve("address.state", this);
     }
 
     public String sport() {
-        return faker.fakeValuesService().resolve("team.sport", this, faker);
+        return faker.fakeValuesService().resolve("team.sport", this);
     }
 }

--- a/src/main/java/net/datafaker/TheItCrowd.java
+++ b/src/main/java/net/datafaker/TheItCrowd.java
@@ -3,28 +3,26 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class TheItCrowd {
-
-    private final Faker faker;
+public class TheItCrowd extends AbstractProvider {
 
     protected TheItCrowd(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String actors() {
-        return faker.fakeValuesService().resolve("the_it_crowd.actors", this, faker);
+        return faker.fakeValuesService().resolve("the_it_crowd.actors", this);
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("the_it_crowd.characters", this, faker);
+        return faker.fakeValuesService().resolve("the_it_crowd.characters", this);
     }
 
     public String emails() {
-        return faker.fakeValuesService().resolve("the_it_crowd.emails", this, faker);
+        return faker.fakeValuesService().resolve("the_it_crowd.emails", this);
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("the_it_crowd.quotes", this, faker);
+        return faker.fakeValuesService().resolve("the_it_crowd.quotes", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Time.java
+++ b/src/main/java/net/datafaker/Time.java
@@ -7,12 +7,10 @@ import java.time.temporal.ChronoUnit;
 /**
  * @since 1.4.0
  */
-public class Time {
-
-    private final Faker faker;
+public class Time extends AbstractProvider {
 
     protected Time(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Touhou.java
+++ b/src/main/java/net/datafaker/Touhou.java
@@ -3,31 +3,29 @@ package net.datafaker;
 /**
  * @since 0.9.0
  */
-public class Touhou {
-
-    private final Faker faker;
+public class Touhou extends AbstractProvider {
 
     protected Touhou(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String characterName() {
-        return faker.fakeValuesService().resolve("touhou.full_name", this, faker);
+        return faker.fakeValuesService().resolve("touhou.full_name", this);
     }
 
     public String characterFirstName() {
-        return faker.fakeValuesService().resolve("touhou.first_name", this, faker);
+        return faker.fakeValuesService().resolve("touhou.first_name", this);
     }
 
     public String characterLastName() {
-        return faker.fakeValuesService().resolve("touhou.last_name", this, faker);
+        return faker.fakeValuesService().resolve("touhou.last_name", this);
     }
 
     public String trackName() {
-        return faker.fakeValuesService().resolve("touhou.track_name", this, faker);
+        return faker.fakeValuesService().resolve("touhou.track_name", this);
     }
 
     public String gameName() {
-        return faker.fakeValuesService().resolve("touhou.game_name", this, faker);
+        return faker.fakeValuesService().resolve("touhou.game_name", this);
     }
 }

--- a/src/main/java/net/datafaker/Tron.java
+++ b/src/main/java/net/datafaker/Tron.java
@@ -5,12 +5,10 @@ package net.datafaker;
  *
  * @since 1.4.0
  */
-public class Tron {
-
-    private final Faker faker;
+public class Tron extends AbstractProvider {
 
     protected Tron(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
@@ -18,15 +16,15 @@ public class Tron {
     }
 
     public String character(Character character) {
-        return faker.fakeValuesService().resolve("tron.characters." + character.yamlKey, this, faker);
+        return faker.fakeValuesService().resolve("tron.characters." + character.yamlKey, this);
     }
 
     public String game() {
-        return faker.fakeValuesService().resolve("tron.games", this, faker);
+        return faker.fakeValuesService().resolve("tron.games", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("tron.locations", this, faker);
+        return faker.fakeValuesService().resolve("tron.locations", this);
     }
 
     public String quote() {
@@ -34,15 +32,15 @@ public class Tron {
     }
 
     public String quote(Tron.Quote quote) {
-        return faker.fakeValuesService().resolve("tron.quotes." + quote.yamlKey, this, faker);
+        return faker.fakeValuesService().resolve("tron.quotes." + quote.yamlKey, this);
     }
 
     public String tagline() {
-        return faker.fakeValuesService().resolve("tron.taglines", this, faker);
+        return faker.fakeValuesService().resolve("tron.taglines", this);
     }
 
     public String vehicle() {
-        return faker.fakeValuesService().resolve("tron.vehicles", this, faker);
+        return faker.fakeValuesService().resolve("tron.vehicles", this);
     }
 
     public String alternateCharacterSpelling() {
@@ -50,7 +48,7 @@ public class Tron {
     }
 
     public String alternateCharacterSpelling(AlternateCharacterSpelling alternateCharacterSpelling) {
-        return faker.fakeValuesService().resolve("tron.alternate_character_spellings." + alternateCharacterSpelling.yamlKey, this, faker);
+        return faker.fakeValuesService().resolve("tron.alternate_character_spellings." + alternateCharacterSpelling.yamlKey, this);
     }
 
     public enum AlternateCharacterSpelling {

--- a/src/main/java/net/datafaker/TwinPeaks.java
+++ b/src/main/java/net/datafaker/TwinPeaks.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class TwinPeaks {
-    private final Faker faker;
+public class TwinPeaks extends AbstractProvider {
 
     protected TwinPeaks(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {

--- a/src/main/java/net/datafaker/Twitter.java
+++ b/src/main/java/net/datafaker/Twitter.java
@@ -14,16 +14,16 @@ import java.util.logging.Logger;
  *
  * @since 0.9.0
  */
-public class Twitter {
+public class Twitter extends AbstractProvider {
 
-    private final Faker faker;
+    
     private final String basicstr = "QabR0cYdZ1efSg2hi3jNOPkTUM4VLlmXK5nJo6WIpHGqF7rEs8tDuC9vwBxAyz";
 
     /**
      * @param faker used as constructor
      */
     protected Twitter(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -129,14 +129,14 @@ public class Twitter {
      * @return Return a user name using the twitter.user_name.
      */
     public String userName() {
-        return faker.fakeValuesService().resolve("twitter.user_name", this, faker);
+        return faker.fakeValuesService().resolve("twitter.user_name", this);
     }
 
     /**
      * @return Return a user id using the twitter.user_name.
      */
     public String userId() {
-        return faker.fakeValuesService().resolve("twitter.user_id", this, faker);
+        return faker.fakeValuesService().resolve("twitter.user_id", this);
     }
 
     /**

--- a/src/main/java/net/datafaker/University.java
+++ b/src/main/java/net/datafaker/University.java
@@ -3,22 +3,21 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class University {
-    private final Faker faker;
+public class University extends AbstractProvider {
 
     protected University(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("university.name", this, faker);
+        return faker.fakeValuesService().resolve("university.name", this);
     }
 
     public String prefix() {
-        return faker.fakeValuesService().resolve("university.prefix", this, faker);
+        return faker.fakeValuesService().resolve("university.prefix", this);
     }
 
     public String suffix() {
-        return faker.fakeValuesService().resolve("university.suffix", this, faker);
+        return faker.fakeValuesService().resolve("university.suffix", this);
     }
 }

--- a/src/main/java/net/datafaker/Vehicle.java
+++ b/src/main/java/net/datafaker/Vehicle.java
@@ -8,13 +8,12 @@ import java.util.Locale;
 /**
  * @since 0.8.0
  */
-public class Vehicle {
-    private final Faker faker;
+public class Vehicle extends AbstractProvider {
 
     static final String VIN_REGEX = "([A-HJ-NPR-Z0-9]){3}[A-HJ-NPR-Z0-9]{5}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-0]{1}[A-HJ-NPR-Z0-9]{1}\\d{5}";
 
     public Vehicle(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String vin() {
@@ -114,7 +113,7 @@ public class Vehicle {
             return null;
         }
 
-        String licensePlatesByState = faker.fakeValuesService().resolve("vehicle.license_plate_by_state." + stateAbbreviation, this, faker);
+        String licensePlatesByState = faker.fakeValuesService().resolve("vehicle.license_plate_by_state." + stateAbbreviation, this);
         return licensePlatesByState == null ? null : faker.regexify(faker.bothify(licensePlatesByState)).toUpperCase(Locale.ROOT);
     }
 }

--- a/src/main/java/net/datafaker/Verb.java
+++ b/src/main/java/net/datafaker/Verb.java
@@ -3,12 +3,10 @@ package net.datafaker;
 /**
  * @since 1.5.0
  */
-public class Verb {
-
-    private final Faker faker;
+public class Verb extends AbstractProvider {
 
     protected Verb(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**
@@ -17,7 +15,7 @@ public class Verb {
      * @return a string of base form of a verb.
      */
     public String base() {
-        return faker.fakeValuesService().resolve("verbs.base", this, faker);
+        return faker.fakeValuesService().resolve("verbs.base", this);
     }
 
     /**
@@ -26,7 +24,7 @@ public class Verb {
      * @return a string of verb in past tense.
      */
     public String past() {
-        return faker.fakeValuesService().resolve("verbs.past", this, faker);
+        return faker.fakeValuesService().resolve("verbs.past", this);
     }
 
     /**
@@ -35,7 +33,7 @@ public class Verb {
      * @return a string of verb in past participle tense.
      */
     public String pastParticiple() {
-        return faker.fakeValuesService().resolve("verbs.past_participle", this, faker);
+        return faker.fakeValuesService().resolve("verbs.past_participle", this);
     }
 
     /**
@@ -44,7 +42,7 @@ public class Verb {
      * @return a string of verb in simple present tense.
      */
     public String simplePresent() {
-        return faker.fakeValuesService().resolve("verbs.simple_present", this, faker);
+        return faker.fakeValuesService().resolve("verbs.simple_present", this);
     }
 
     /**
@@ -53,6 +51,6 @@ public class Verb {
      * @return a string of verb in -ing form.
      */
     public String ingForm() {
-        return faker.fakeValuesService().resolve("verbs.ing_form", this, faker);
+        return faker.fakeValuesService().resolve("verbs.ing_form", this);
     }
 }

--- a/src/main/java/net/datafaker/Volleyball.java
+++ b/src/main/java/net/datafaker/Volleyball.java
@@ -3,32 +3,30 @@ package net.datafaker;
 /**
  * @since 1.3.0
  */
-public class Volleyball {
-
-    private final Faker faker;
+public class Volleyball extends AbstractProvider {
 
     protected Volleyball(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String team() {
-        return faker.fakeValuesService().resolve("volleyball.team", this, faker);
+        return faker.fakeValuesService().resolve("volleyball.team", this);
     }
 
     public String player() {
-        return faker.fakeValuesService().resolve("volleyball.player", this, faker);
+        return faker.fakeValuesService().resolve("volleyball.player", this);
     }
 
     public String coach() {
-        return faker.fakeValuesService().resolve("volleyball.coach", this, faker);
+        return faker.fakeValuesService().resolve("volleyball.coach", this);
     }
 
     public String position() {
-        return faker.fakeValuesService().resolve("volleyball.position", this, faker);
+        return faker.fakeValuesService().resolve("volleyball.position", this);
     }
 
     public String formation() {
-        return faker.fakeValuesService().resolve("volleyball.formation", this, faker);
+        return faker.fakeValuesService().resolve("volleyball.formation", this);
     }
 
 }

--- a/src/main/java/net/datafaker/Weather.java
+++ b/src/main/java/net/datafaker/Weather.java
@@ -5,17 +5,15 @@ package net.datafaker;
  *
  * @since 0.8.0
  */
-public class Weather {
+public class Weather extends AbstractProvider {
 
     private static final int DEFAULT_MIN_TEMP_C = -30;
     private static final int DEFAULT_MAX_TEMP_C = 38;
     private static final int DEFAULT_MIN_TEMP_F = -22;
     private static final int DEFAULT_MAX_TEMP_F = 100;
 
-    private final Faker faker;
-
     protected Weather(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     /**

--- a/src/main/java/net/datafaker/Witcher.java
+++ b/src/main/java/net/datafaker/Witcher.java
@@ -3,45 +3,44 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Witcher {
-    private final Faker faker;
+public class Witcher extends AbstractProvider {
 
     protected Witcher(Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("games.witcher.characters", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.characters", this);
     }
 
     public String witcher() {
-        return faker.fakeValuesService().resolve("games.witcher.witchers", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.witchers", this);
     }
 
     public String school() {
-        return faker.fakeValuesService().resolve("games.witcher.schools", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.schools", this);
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("games.witcher.locations", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.locations", this);
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.witcher.quotes", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.quotes", this);
     }
 
     public String monster() {
-        return faker.fakeValuesService().resolve("games.witcher.monsters", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.monsters", this);
     }
     public String sign() {
-        return faker.fakeValuesService().resolve("games.witcher.signs", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.signs", this);
     }
 
     public String potion() {
-        return faker.fakeValuesService().resolve("games.witcher.potions", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.potions", this);
     }
 
     public String book() {
-        return faker.fakeValuesService().resolve("games.witcher.books", this, faker);
+        return faker.fakeValuesService().resolve("games.witcher.books", this);
     }
 }

--- a/src/main/java/net/datafaker/Yoda.java
+++ b/src/main/java/net/datafaker/Yoda.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Yoda {
-    private final Faker faker;
+public class Yoda extends AbstractProvider {
 
     protected Yoda(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String quote() {

--- a/src/main/java/net/datafaker/Zelda.java
+++ b/src/main/java/net/datafaker/Zelda.java
@@ -3,11 +3,10 @@ package net.datafaker;
 /**
  * @since 0.8.0
  */
-public class Zelda {
-    private final Faker faker;
+public class Zelda extends AbstractProvider {
 
     protected Zelda(final Faker faker) {
-        this.faker = faker;
+        super(faker);
     }
 
     public String game() {

--- a/src/main/java/net/datafaker/idnumbers/PeselNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/PeselNumber.java
@@ -21,7 +21,6 @@ public class PeselNumber {
     }
 
     public PeselNumber(Faker faker) {
-        super();
         this.faker = faker;
     }
 

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -1,6 +1,7 @@
 package net.datafaker.service;
 
 import com.mifmif.common.regex.Generex;
+import net.datafaker.AbstractProvider;
 import net.datafaker.Faker;
 import net.datafaker.fileformats.Csv;
 import net.datafaker.fileformats.Format;
@@ -434,6 +435,10 @@ public class FakeValuesService {
      */
     public String resolve(String key, Object current, Faker root) {
         return resolve(key, current, root, () -> key + " resulted in null expression");
+    }
+
+    public String resolve(String key, AbstractProvider provider) {
+        return resolve(key, provider, provider.getFaker(), () -> key + " resulted in null expression");
     }
 
     /**

--- a/src/test/java/net/datafaker/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/CustomFakerTest.java
@@ -23,12 +23,11 @@ class CustomFakerTest {
         }
     }
 
-    public static class Insect {
+    public static class Insect extends AbstractProvider {
         private static final String[] INSECT_NAMES = new String[]{"Ant", "Beetle", "Butterfly", "Wasp"};
-        private final Faker faker;
 
         public Insect(Faker faker) {
-            this.faker = faker;
+            super(faker);
         }
 
         public String nextInsectName() {
@@ -36,12 +35,11 @@ class CustomFakerTest {
         }
     }
 
-    public static class InsectFromFile {
+    public static class InsectFromFile extends AbstractProvider {
         private static final String KEY = "insectsfromfile";
-        private final Faker faker;
 
         public InsectFromFile(Faker faker) {
-            this.faker = faker;
+            super(faker);
             faker.addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
             faker.addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));
         }
@@ -89,5 +87,17 @@ class CustomFakerTest {
     void insectBeeTestExpressionFromFile() {
         MyCustomFaker myFaker = new MyCustomFaker();
         assertThat(myFaker.insectFromFile().bee()).endsWith("bee");
+    }
+
+    @Test
+    void insectBeeTestExpressionFromFileWithoutExtraFaker() {
+        Faker faker = new Faker();
+        assertThat(faker.getProvider(InsectFromFile.class, () -> new InsectFromFile(faker)).bee()).endsWith("bee");
+    }
+
+    @Test
+    void insectTestWithoutExtraFaker() {
+        Faker faker = new Faker();
+        assertThat(faker.getProvider(Insect.class, () -> new Insect(faker)).nextInsectName()).matches("[A-Za-z ]+");
     }
 }

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -64,10 +64,10 @@ class ProviderGenerator {
         System.out.println(" */");
         System.out.println("class " + className + " {");
         System.out.println();
-        System.out.println("    private final Faker faker;");
+        System.out.println("    ");
         System.out.println();
         System.out.println("    protected " + className + "(Faker faker) {");
-        System.out.println("        this.faker = faker;");
+        System.out.println("        super(faker);");
         System.out.println("    }");
         System.out.println();
 
@@ -75,7 +75,7 @@ class ProviderGenerator {
             String methodName = StringUtils.uncapitalize(toJavaConvention(string));
 
             System.out.println("    public String " + methodName + "() {\n" +
-                "        return faker.fakeValuesService().resolve(\"" + key + "." + string + "\", this, faker);\n" +
+                "        return faker.fakeValuesService().resolve(\"" + key + "." + string + "\", this);\n" +
                 "    }");
             System.out.println();
         }


### PR DESCRIPTION
There are 2 issues:
1. currently to create and use your own provider it is required to create a custom faker
2. each time a new provider should contain a faker (minor issue but annoying)

The PR introduces an `AbstractProvider` and makes use it by all providers. Also it allows to create and use custom providers without creation custom fakers, for more details have a look at `net.datafaker.CustomFakerTest#insectBeeTestExpressionFromFileWithoutExtraFaker`