### PR TITLE
Make concurrent tests more stable

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -39,17 +39,17 @@ public class FakeValuesService {
     private static final String DIGITS = "0123456789";
     private static final String[] EMPTY_ARRAY = new String[0];
     private static final Logger LOG = Logger.getLogger("faker");
-    private static final Map<Locale, FakeValuesInterface> FAKE_VALUES_CACHE = new ConcurrentHashMap<>();
+    private final Map<Locale, FakeValuesInterface> fakeValuesCache = new HashMap<>();
 
-    private static final Map<Locale, FakeValuesInterface> fakeValuesInterfaceMap = new ConcurrentHashMap<>();
+    private final Map<Locale, FakeValuesInterface> fakeValuesInterfaceMap = new HashMap<>();
     private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
     private RandomService currentRandomService;
     private Locale currentLocale;
 
     private final Map<Locale, List<Locale>> locale2localesChain;
 
-    private final Map<Class<?>, Map<String, Collection<Method>>> class2methodsCache = new IdentityHashMap<>();
-    private final Map<Class<?>, Constructor<?>> class2constructorCache = new IdentityHashMap<>();
+    private final Map<Class<?>, Map<String, Collection<Method>>> class2methodsCache = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Constructor<?>> class2constructorCache = new ConcurrentHashMap<>();
     private final Map<String, Generex> expression2generex = new WeakHashMap<>();
     private final Map<Locale, Map<String, String>> key2Expression = new WeakHashMap<>();
     private final Map<String, String[]> args2splittedArgs = new WeakHashMap<>();
@@ -108,7 +108,7 @@ public class FakeValuesService {
         if (DEFAULT_LOCALE.equals(locale)) {
             return FakeValuesGrouping.getEnglishFakeValueGrouping();
         }
-        return FAKE_VALUES_CACHE.computeIfAbsent(locale, FakeValues::new);
+        return fakeValuesCache.computeIfAbsent(locale, FakeValues::new);
     }
 
     /**
@@ -924,7 +924,7 @@ public class FakeValuesService {
                 methodMap.computeIfAbsent(key, k -> new ArrayList<>());
                 methodMap.get(key).add(m);
             }
-            class2methodsCache.put(clazz, methodMap);
+            class2methodsCache.putIfAbsent(clazz, methodMap);
             methods = methodMap.get(name.toLowerCase(Locale.ROOT));
         }
         for (Method m : methods) {

--- a/src/test/java/net/datafaker/CodeTest.java
+++ b/src/test/java/net/datafaker/CodeTest.java
@@ -16,6 +16,7 @@ class CodeTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     void isbn10DefaultIsNoSeparator() {
+        final Faker faker = new Faker();
         String isbn10 = faker.code().isbn10();
 
         assertIsValidISBN10(isbn10);
@@ -24,6 +25,7 @@ class CodeTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     void isbn13DefaultIsNoSeparator() {
+        final Faker faker = new Faker();
         String isbn13 = faker.code().isbn13();
 
         assertIsValidISBN13(isbn13);
@@ -32,6 +34,7 @@ class CodeTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     void testIsbn10() {
+        final Faker faker = new Faker();
         final String isbn10NoSep = faker.code().isbn10(false);
         final String isbn10Sep = faker.code().isbn10(true);
 
@@ -43,6 +46,7 @@ class CodeTest extends AbstractFakerTest {
 
     @RepeatedTest(100)
     void testIsbn13() {
+        final Faker faker = new Faker();
         final String isbn13NoSep = faker.code().isbn13(false);
         final String isbn13Sep = faker.code().isbn13(true);
 

--- a/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
+++ b/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
@@ -32,7 +32,6 @@ import static org.reflections.ReflectionUtils.withReturnType;
  * are correct. These tests just ensure that the methods can be invoked.
  */
 class FakerIntegrationTest {
-    private Faker faker;
     private Locale locale;
 
     /**
@@ -57,23 +56,23 @@ class FakerIntegrationTest {
         exceptions.put(new Locale("pt", "Br", "x2"), Arrays.asList("Address.cityPrefix", "Address.citySuffix"));
     }
 
-    private void init(Locale locale, Random random) {
+    private Faker init(Locale locale, Random random) {
         this.locale = locale;
         if (locale != null && random != null) {
-            faker = new Faker(locale, random);
+            return new Faker(locale, random);
         } else if (locale != null) {
-            faker = new Faker(locale);
+            return new Faker(locale);
         } else if (random != null) {
-            faker = new Faker(random);
+            return new Faker(random);
         } else {
-            faker = new Faker();
+            return new Faker();
         }
     }
 
     @ParameterizedTest
     @MethodSource("dataParameters")
     void testAllFakerMethodsThatReturnStrings(Locale locale, Random random) throws Exception {
-        init(locale, random);
+        final Faker faker = init(locale, random);
         testAllMethodsThatReturnStringsActuallyReturnStrings(faker);
         testAllMethodsThatReturnStringsActuallyReturnStrings(faker.address());
         testAllMethodsThatReturnStringsActuallyReturnStrings(faker.ancient());
@@ -233,7 +232,7 @@ class FakerIntegrationTest {
     @ParameterizedTest
     @MethodSource("dataParameters")
     void testExceptionsNotCoveredInAboveTest(Locale locale, Random random) {
-        init(locale, random);
+        final Faker faker = init(locale, random);
         assertThat(faker.bothify("####???")).isNotNull();
         assertThat(faker.letterify("????")).isNotNull();
         assertThat(faker.numerify("####")).isNotNull();


### PR DESCRIPTION
~~The strange thing about passports is that it generates something strange and then in a loop tries to check if the result of generation is ok or not.
For instance,  in `net.datafaker.passportnumbers.ChPassportNumber#getValidCh` it tries to generates something with regex `[A-Z][0-9A-Z][0-9]{7}` and then checks result against `E\\d\\d{7}` and `G\\d{8}`. It is much faster to generate based on expected data.~~


Update fix concurrent issue at https://github.com/datafaker-net/datafaker/runs/7640952734?check_suite_focus=true
