### PR TITLE
Add CSV format example using a fake collection builder

### DIFF
--- a/docs/documentation/file-formats.md
+++ b/docs/documentation/file-formats.md
@@ -43,7 +43,27 @@ Executing the above will result in something similar to the below:
 "Wade" ; "Herzog" ; "83108 Willy Road"
 "Marg" ; "Effertz" ; "415 Gene Plaza"
 ```
-    
+
+Another example using a fake collection builder:
+
+=== "Java"
+
+    ``` java
+        System.out.println(
+            Format.toCsv(faker.collection(faker::name).build())
+                .headers(() -> "first_name", () -> "last_name")
+                .columns(Name::firstName, Name::lastName)
+                .separator(" ; ")
+                .limit(2).build().get());
+    ```
+
+The result looks something like this:
+
+```csv
+"first_name" ; "last_name"
+"Jonah" ; "Kovacek"
+"John" ; "Murphy"
+```
 
 ## JSON
 


### PR DESCRIPTION
This PR adds a small CSV format example using a fake collection builder. To be honest, I just copy-pasted the example from the repository's README. But this should make it easier for people to understand how it works without having to go to the GitHub repository. Let me know what you think.

See #278.