### PR TITLE
Change error count threshold value in PhoneNumberValidityFinderTest.testAllPhoneNumber

### DIFF
--- a/src/test/java/net/datafaker/PhoneNumberValidityFinderTest.java
+++ b/src/test/java/net/datafaker/PhoneNumberValidityFinderTest.java
@@ -88,7 +88,7 @@ class PhoneNumberValidityFinderTest {
 
         // sort by error count
         errorCounts.entrySet().stream()
-            .filter(e -> e.getValue() > 50)
+            .filter(e -> e.getValue() > 35)
             .sorted(Map.Entry.comparingByValue())
             .forEach(System.out::println);
     }


### PR DESCRIPTION
I want to propose lower error count in the test, all the locales (except for 2, they are not actually phone numbers locale, I will raise an issue later on this) are now under 50 error count threshold, so I think it would be better to lower error count in order to be able to detect some incorrect phone number formats, and improve them more.