### PR TITLE
Add upholstery fabrics and colors to Vehicle provider

### DIFF
--- a/src/main/java/net/datafaker/Vehicle.java
+++ b/src/main/java/net/datafaker/Vehicle.java
@@ -49,6 +49,18 @@ public class Vehicle extends AbstractProvider {
         return faker.resolve("vehicle.colors");
     }
 
+    public String upholsteryColor() {
+        return faker.resolve("vehicle.upholstery_colors");
+    }
+
+    public String upholsteryFabric() {
+        return faker.resolve("vehicle.upholstery_fabrics");
+    }
+
+    public String upholstery() {
+        return faker.resolve("vehicle.upholsteries");
+    }
+
     public String transmission() {
         return faker.resolve("vehicle.transmissions");
     }

--- a/src/main/resources/en/vehicle.yml
+++ b/src/main/resources/en/vehicle.yml
@@ -16,6 +16,9 @@ en:
         Tesla: [ 'Model S', 'Model 3', 'Model X', 'Model Y', 'Roadster' ]
         Toyota: [ 'Prius', 'Camry', 'Corolla' ]
       colors: ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Violet', 'Black', 'White', 'Grey', 'Beige']
+      upholstery_fabrics: ['Leather', 'Artificial Leather', 'Velvet', 'Vinyl', 'Cloth']
+      upholstery_colors: ['Black', 'Grey', 'Taupe', 'Beige', 'White', 'Anthracite', 'Brown']
+      upholsteries: "#{Vehicle.upholstery_colors} #{Vehicle.upholstery_fabrics}"
       transmissions: ['Automanual', 'Automatic', 'CVT', 'Manual']
       drive_types: ['4x2/2-wheel drive', '4x4/4-wheel drive', 'AWD', 'FWD', 'RWD']
       fuel_types: ['Compressed Natural Gas', 'Diesel', 'E-85/Gasoline', 'Electric', 'Gasoline', 'Gasoline Hybrid', 'Ethanol']

--- a/src/test/java/net/datafaker/VehicleTest.java
+++ b/src/test/java/net/datafaker/VehicleTest.java
@@ -55,6 +55,21 @@ class VehicleTest extends AbstractFakerTest {
     }
 
     @Test
+    void testUpholsteryColor() {
+        assertThat(faker.vehicle().upholsteryColor()).matches(WORD_MATCH);
+    }
+
+    @Test
+    void testUpholsteryFabric() {
+        assertThat(faker.vehicle().upholsteryFabric()).matches(WORD_MATCH);
+    }
+
+    @Test
+    void testUpholstery() {
+        assertThat(faker.vehicle().upholstery()).matches(WORDS_MATCH);
+    }
+
+    @Test
     void testTransmission() {
         assertThat(faker.vehicle().transmission()).matches(WORD_MATCH);
     }


### PR DESCRIPTION
Adds colors and fabrics for upholstery to the Vehicle provider. As well as a method for a combination of both.

I needed this for a use case I'm currently implementing.