### PR TITLE
Fix flaky test

### DIFF
--- a/src/test/java/net/datafaker/VehicleTest.java
+++ b/src/test/java/net/datafaker/VehicleTest.java
@@ -61,7 +61,7 @@ class VehicleTest extends AbstractFakerTest {
 
     @Test
     void testUpholsteryFabric() {
-        assertThat(faker.vehicle().upholsteryFabric()).matches(WORD_MATCH);
+        assertThat(faker.vehicle().upholsteryFabric()).matches(WORDS_MATCH);
     }
 
     @Test


### PR DESCRIPTION
Fixes flaky test introduced in #355.

The pattern expects a single word, while one of the possible values consists of 2 words. Used a different pattern for the test.