### PR TITLE
Make sure that padding is used in Hashing

### DIFF
--- a/src/main/java/net/datafaker/Hashing.java
+++ b/src/main/java/net/datafaker/Hashing.java
@@ -15,35 +15,35 @@ public class Hashing extends AbstractProvider {
     }
 
     public String md2() {
-        return generateString("MD2");
+        return generateString("MD2", "%032x");
     }
 
     public String md5() {
-        return generateString("MD5");
+        return generateString("MD5", "%032x");
     }
 
     public String sha1() {
-        return generateString("SHA-1");
+        return generateString("SHA-1", "%040x");
     }
 
     public String sha384() {
-        return generateString("SHA-384");
+        return generateString("SHA-384", "%096x");
     }
 
     public String sha256() {
-        return generateString("SHA-256");
+        return generateString("SHA-256", "%064x");
     }
 
     public String sha512() {
-        return generateString("SHA-512");
+        return generateString("SHA-512", "%0128x");
     }
 
-    private String generateString(String algorithm) {
+    private String generateString(String algorithm, String format) {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
             String characters = faker.lorem().characters();
             messageDigest.update(characters.getBytes(StandardCharsets.UTF_8), 0, characters.length());
-            return new BigInteger(1, messageDigest.digest()).toString(16);
+            return String.format(format, new BigInteger(1, messageDigest.digest()));
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
             throw new RuntimeException(noSuchAlgorithmException);
         }

--- a/src/test/java/net/datafaker/HashingTest.java
+++ b/src/test/java/net/datafaker/HashingTest.java
@@ -8,31 +8,31 @@ class HashingTest extends AbstractFakerTest {
 
     @Test
     void testMd2() {
-        assertThat(faker.hashing().md2()).matches("[a-z\\d]+");
+        assertThat(faker.hashing().md2()).matches("\\b[a-fA-F\\d]{32}\\b");
     }
 
     @Test
     void testMd5() {
-        assertThat(faker.hashing().md5()).matches("[a-z\\d]+");
+        assertThat(faker.hashing().md5()).matches("\\b[a-fA-F\\d]{32}\\b");
     }
 
     @Test
     void testSha1() {
-        assertThat(faker.hashing().sha1()).matches("[a-z\\d]+");
+        assertThat(faker.hashing().sha1()).matches("\\b[a-fA-F\\d]{40}\\b");
     }
 
     @Test
     void testSha256() {
-        assertThat(faker.hashing().sha256()).matches("[a-z\\d]+");
+        assertThat(faker.hashing().sha256()).matches("\\b[a-fA-F\\d]{64}\\b");
     }
 
     @Test
     void testSha384() {
-        assertThat(faker.hashing().sha384()).matches("[a-z\\d]+");
+        assertThat(faker.hashing().sha384()).matches("\\b[a-fA-F\\d]{96}\\b");
     }
 
     @Test
     void testSha512() {
-        assertThat(faker.hashing().sha512()).matches("[a-z\\d]+");
+        assertThat(faker.hashing().sha512()).matches("\\b[a-fA-F\\d]{128}\\b");
     }
 }


### PR DESCRIPTION
In some cases it's possible to have MD5 hash (and possibly other as well) with the first byte set to 0. In this case it gets removed, while converting to BigInteger and the hex string has 31 characters. To make sure that it works as expected, we need to guarantee proper padding.