### PR TITLE
Introduce FakerContext, extract Faker's changeable info into FakerContext

### DIFF
--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -44,7 +44,7 @@ Create your own custom faker, which extends `Faker`, and register the custom pro
     ``` java
     public static class MyCustomFaker extends Faker {
         public Insect insect() {
-            return getProvider(Insect.class, () -> new Insect(this));
+            return getProvider(Insect.class, Insect::new, this);
         }
     }
     ```
@@ -92,11 +92,11 @@ First, create the custom provider which loads the data from a file:
         }
 
         public String ant() {
-            return faker.fakeValuesService().resolve(KEY + ".ants", null, faker);
+            return resolve(KEY + ".ants", null, faker);
         }
 
         public String bee() {
-            return faker.fakeValuesService().resolve(KEY + ".bees", null, faker);
+            return resolve(KEY + ".bees", null, faker);
         }
     }
     ```
@@ -129,7 +129,7 @@ Registering the provider would happen like this:
     ``` java
     public static class MyCustomFaker extends Faker {
         public InsectFromFile insectFromFile() {
-            return getProvider(InsectFromFile.class, () -> new InsectFromFile(this));
+            return getProvider(InsectFromFile.class, InsectFromFile::new, this);
         }
     }
     ```

--- a/src/main/java/net/datafaker/AbstractProvider.java
+++ b/src/main/java/net/datafaker/AbstractProvider.java
@@ -1,5 +1,7 @@
 package net.datafaker;
 
+import java.util.function.Supplier;
+
 public class AbstractProvider {
     protected final Faker faker;
 
@@ -9,5 +11,13 @@ public class AbstractProvider {
 
     public final Faker getFaker() {
         return faker;
+    }
+
+    protected String resolve(String key) {
+        return faker.fakeValuesService().resolve(key, this, faker.getContext());
+    }
+
+    protected String resolve(String key, Supplier<String> message) {
+        return faker.fakeValuesService().resolve(key, this, faker, message, faker.getContext());
     }
 }

--- a/src/main/java/net/datafaker/Address.java
+++ b/src/main/java/net/datafaker/Address.java
@@ -9,7 +9,7 @@ public class Address extends AbstractProvider{
     }
 
     public String streetName() {
-        return faker.fakeValuesService().resolve("address.street_name", this);
+        return resolve("address.street_name");
     }
 
     public String streetAddressNumber() {
@@ -17,11 +17,11 @@ public class Address extends AbstractProvider{
     }
 
     public String streetAddress() {
-        return faker.fakeValuesService().resolve("address.street_address", this);
+        return resolve("address.street_address");
     }
 
     public String streetAddress(boolean includeSecondary) {
-        String streetAddress = faker.fakeValuesService().resolve("address.street_address", this);
+        String streetAddress = resolve("address.street_address");
         if (includeSecondary) {
             streetAddress = streetAddress + " " + secondaryAddress();
         }
@@ -29,7 +29,7 @@ public class Address extends AbstractProvider{
     }
 
     public String secondaryAddress() {
-        return faker.numerify(faker.fakeValuesService().resolve("address.secondary_address", this));
+        return faker.numerify(resolve("address.secondary_address"));
     }
 
     /**
@@ -38,11 +38,11 @@ public class Address extends AbstractProvider{
      * @return a String representing a standard zip code
      */
     public String zipCode() {
-        return faker.bothify(faker.fakeValuesService().resolve("address.postcode", this));
+        return faker.bothify(resolve("address.postcode"));
     }
 
     public String postcode() {
-        return faker.bothify(faker.fakeValuesService().resolve("address.postcode", this));
+        return faker.bothify(resolve("address.postcode"));
     }
 
     /**
@@ -52,47 +52,47 @@ public class Address extends AbstractProvider{
      * @return a String representing a ZIP+4 code
      */
     public String zipCodePlus4() {
-        return faker.bothify(faker.fakeValuesService().resolve("address.postcode_plus_four", this));
+        return faker.bothify(resolve("address.postcode_plus_four"));
     }
 
     public String zipCodeByState(String stateAbbr) {
-        return faker.fakeValuesService().resolve("address.postcode_by_state." + stateAbbr, this);
+        return resolve("address.postcode_by_state." + stateAbbr);
     }
 
     public String countyByZipCode(String postCode) {
-        return faker.fakeValuesService().resolve("address.county_by_postcode." + postCode, this, faker, () -> "County are not configured for postcode " + postCode);
+        return resolve("address.county_by_postcode." + postCode, () -> "County are not configured for postcode " + postCode);
     }
 
     public String streetSuffix() {
-        return faker.fakeValuesService().resolve("address.street_suffix", this);
+        return resolve("address.street_suffix");
     }
 
     public String streetPrefix() {
-        return faker.fakeValuesService().resolve("address.street_prefix", this);
+        return resolve("address.street_prefix");
     }
 
     public String citySuffix() {
-        return faker.fakeValuesService().resolve("address.city_suffix", this);
+        return resolve("address.city_suffix");
     }
 
     public String cityPrefix() {
-        return faker.fakeValuesService().resolve("address.city_prefix", this);
+        return resolve("address.city_prefix");
     }
 
     public String city() {
-        return faker.fakeValuesService().resolve("address.city", this);
+        return resolve("address.city");
     }
 
     public String cityName() {
-        return faker.fakeValuesService().resolve("address.city_name", this);
+        return resolve("address.city_name");
     }
 
     public String state() {
-        return faker.fakeValuesService().resolve("address.state", this);
+        return resolve("address.state");
     }
 
     public String stateAbbr() {
-        return faker.fakeValuesService().resolve("address.state_abbr", this);
+        return resolve("address.state_abbr");
     }
 
     /**
@@ -138,26 +138,26 @@ public class Address extends AbstractProvider{
     }
 
     public String timeZone() {
-        return faker.fakeValuesService().resolve("address.time_zone", this);
+        return resolve("address.time_zone");
     }
 
     public String country() {
-        return faker.fakeValuesService().resolve("address.country", this);
+        return resolve("address.country");
     }
 
     public String countryCode() {
-        return faker.fakeValuesService().resolve("address.country_code", this);
+        return resolve("address.country_code");
     }
 
     public String buildingNumber() {
-        return faker.numerify(faker.fakeValuesService().resolve("address.building_number", this));
+        return faker.numerify(resolve("address.building_number"));
     }
 
     public String fullAddress() {
-        return faker.fakeValuesService().resolve("address.full_address", this);
+        return resolve("address.full_address");
     }
 
     public String mailBox() {
-        return faker.numerify(faker.fakeValuesService().resolve("address.mail_box", this));
+        return faker.numerify(resolve("address.mail_box"));
     }
 }

--- a/src/main/java/net/datafaker/Ancient.java
+++ b/src/main/java/net/datafaker/Ancient.java
@@ -10,18 +10,18 @@ public class Ancient extends AbstractProvider {
     }
 
     public String god() {
-        return faker.resolve("ancient.god");
+        return resolve("ancient.god");
     }
 
     public String primordial() {
-        return faker.resolve("ancient.primordial");
+        return resolve("ancient.primordial");
     }
 
     public String titan() {
-        return faker.resolve("ancient.titan");
+        return resolve("ancient.titan");
     }
 
     public String hero() {
-        return faker.resolve("ancient.hero");
+        return resolve("ancient.hero");
     }
 }

--- a/src/main/java/net/datafaker/Animal.java
+++ b/src/main/java/net/datafaker/Animal.java
@@ -12,7 +12,7 @@ public class Animal extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.animal.name", this);
+        return resolve("creature.animal.name");
     }
 
     public String scientificName() {
@@ -20,10 +20,10 @@ public class Animal extends AbstractProvider {
     }
 
     public String genus() {
-        return WordUtils.capitalize(faker.fakeValuesService().resolve("creature.animal.genus", this));
+        return WordUtils.capitalize(faker.resolve("creature.animal.genus"));
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("creature.animal.species", this).toLowerCase();
+        return resolve("creature.animal.species").toLowerCase();
     }
 }

--- a/src/main/java/net/datafaker/App.java
+++ b/src/main/java/net/datafaker/App.java
@@ -10,14 +10,14 @@ public class App extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("app.name", this);
+        return resolve("app.name");
     }
 
     public String version() {
-        return faker.numerify(faker.fakeValuesService().resolve("app.version", this));
+        return faker.numerify(faker.resolve("app.version"));
     }
 
     public String author() {
-        return faker.fakeValuesService().resolve("app.author", this);
+        return resolve("app.author");
     }
 }

--- a/src/main/java/net/datafaker/Appliance.java
+++ b/src/main/java/net/datafaker/Appliance.java
@@ -10,10 +10,10 @@ public class Appliance extends AbstractProvider {
     }
 
     public String brand() {
-        return faker.fakeValuesService().resolve("appliance.brand", this);
+        return resolve("appliance.brand");
     }
 
     public String equipment() {
-        return faker.fakeValuesService().resolve("appliance.equipment", this);
+        return resolve("appliance.equipment");
     }
 }

--- a/src/main/java/net/datafaker/AquaTeenHungerForce.java
+++ b/src/main/java/net/datafaker/AquaTeenHungerForce.java
@@ -10,7 +10,7 @@ public class AquaTeenHungerForce extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("aqua_teen_hunger_force.character", this);
+        return resolve("aqua_teen_hunger_force.character");
     }
 
 }

--- a/src/main/java/net/datafaker/Artist.java
+++ b/src/main/java/net/datafaker/Artist.java
@@ -10,6 +10,6 @@ public class Artist extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().fetchString("artist.names");
+        return  resolve("artist.names");
     }
 }

--- a/src/main/java/net/datafaker/Australia.java
+++ b/src/main/java/net/datafaker/Australia.java
@@ -10,15 +10,15 @@ public class Australia extends AbstractProvider {
     }
 
     public String locations() {
-        return faker.fakeValuesService().resolve("australia.locations", this);
+        return resolve("australia.locations");
     }
 
     public String animals() {
-        return faker.fakeValuesService().resolve("australia.animals", this);
+        return resolve("australia.animals");
     }
 
     public String states() {
-        return faker.fakeValuesService().resolve("australia.states", this);
+        return resolve("australia.states");
     }
 
 }

--- a/src/main/java/net/datafaker/Avatar.java
+++ b/src/main/java/net/datafaker/Avatar.java
@@ -12,6 +12,6 @@ public class Avatar extends AbstractProvider {
     }
 
     public String image() {
-        return baseUrl + faker.fakeValuesService().regexify("[a-z]{8}") + ".png";
+        return baseUrl + faker.regexify("[a-z]{8}") + ".png";
     }
 }

--- a/src/main/java/net/datafaker/Aviation.java
+++ b/src/main/java/net/datafaker/Aviation.java
@@ -15,7 +15,7 @@ public class Aviation extends AbstractProvider {
      * @return some aircraft name/model/make e.g. "An-2".
      */
     public String aircraft() {
-        return faker.fakeValuesService().fetchString("aviation.aircraft");
+        return  resolve("aviation.aircraft");
     }
 
     /**
@@ -23,7 +23,7 @@ public class Aviation extends AbstractProvider {
      * See also: <a href="https://en.wikipedia.org/wiki/List_of_airports_by_ICAO_code:_A">https://en.wikipedia.org/wiki/List_of_airports_by_ICAO_code:_A</a>
      */
     public String airport() {
-        return faker.fakeValuesService().fetchString("aviation.airport");
+        return  resolve("aviation.airport");
     }
 
     /**
@@ -31,7 +31,7 @@ public class Aviation extends AbstractProvider {
      * Have a look at <a href="https://en.wikipedia.org/wiki/METAR">https://en.wikipedia.org/wiki/METAR</a>
      */
     public String METAR() {
-        return faker.fakeValuesService().fetchString("aviation.metar");
+        return  resolve("aviation.metar");
     }
 
     /**
@@ -42,9 +42,9 @@ public class Aviation extends AbstractProvider {
     public String flight(String type) {
         String airline;
         if (type.equals("ICAO")) {
-            airline = faker.fakeValuesService().fetchString("aviation.ICAO_airline");
+            airline =  resolve("aviation.ICAO_airline");
         } else {
-            airline = faker.fakeValuesService().fetchString("aviation.IATA_airline");
+            airline =  resolve("aviation.IATA_airline");
         }
         int number = faker.number().numberBetween(0, 9999);
         return airline + number;
@@ -65,7 +65,7 @@ public class Aviation extends AbstractProvider {
      * @return A randomly selected airline name in a String.
      */
     public String airline() {
-        return faker.fakeValuesService().fetchString("aviation.airline");
+        return  resolve("aviation.airline");
     }
 }
 

--- a/src/main/java/net/datafaker/Aws.java
+++ b/src/main/java/net/datafaker/Aws.java
@@ -12,7 +12,7 @@ public class Aws extends AbstractProvider {
     }
 
     public String region() {
-        return faker.fakeValuesService().resolve("aws.regions", this);
+        return resolve("aws.regions");
     }
 
     public String accountId() {

--- a/src/main/java/net/datafaker/Babylon5.java
+++ b/src/main/java/net/datafaker/Babylon5.java
@@ -10,10 +10,10 @@ public class Babylon5 extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("babylon5.characters");
+        return resolve("babylon5.characters");
     }
 
     public String quote() {
-        return faker.resolve("babylon5.quotes");
+        return resolve("babylon5.quotes");
     }
 }

--- a/src/main/java/net/datafaker/BackToTheFuture.java
+++ b/src/main/java/net/datafaker/BackToTheFuture.java
@@ -10,14 +10,14 @@ public class BackToTheFuture extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("back_to_the_future.characters");
+        return resolve("back_to_the_future.characters");
     }
 
     public String date() {
-        return faker.resolve("back_to_the_future.dates");
+        return resolve("back_to_the_future.dates");
     }
 
     public String quote() {
-        return faker.resolve("back_to_the_future.quotes");
+        return resolve("back_to_the_future.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Barcode.java
+++ b/src/main/java/net/datafaker/Barcode.java
@@ -90,6 +90,6 @@ public class Barcode extends AbstractProvider {
     }
 
     public String type() {
-        return faker.resolve("barcode.types");
+        return resolve("barcode.types");
     }
 }

--- a/src/main/java/net/datafaker/Basketball.java
+++ b/src/main/java/net/datafaker/Basketball.java
@@ -23,7 +23,7 @@ public class Basketball extends AbstractProvider {
      * @return Basketball teams
      */
     public String teams() {
-        return faker.fakeValuesService().resolve("basketball.teams", this);
+        return resolve("basketball.teams");
     }
 
     /**
@@ -32,7 +32,7 @@ public class Basketball extends AbstractProvider {
      * @return Basketball coaches
      */
     public String coaches() {
-        return faker.fakeValuesService().resolve("basketball.coaches", this);
+        return resolve("basketball.coaches");
     }
 
     /**
@@ -41,7 +41,7 @@ public class Basketball extends AbstractProvider {
      * @return Basketball positions
      */
     public String positions() {
-        return faker.fakeValuesService().resolve("basketball.positions", this);
+        return resolve("basketball.positions");
     }
 
     /**
@@ -50,6 +50,6 @@ public class Basketball extends AbstractProvider {
      * @return Basketball players
      */
     public String players() {
-        return faker.fakeValuesService().resolve("basketball.players", this);
+        return resolve("basketball.players");
     }
 }

--- a/src/main/java/net/datafaker/Battlefield1.java
+++ b/src/main/java/net/datafaker/Battlefield1.java
@@ -16,34 +16,34 @@ public class Battlefield1 extends AbstractProvider {
      * @return a random unit class name as a string value
      */
     public String classes() {
-        return faker.resolve("battlefield1.classes");
+        return resolve("battlefield1.classes");
     }
 
     /**
      * @return a random weapon name as a string value
      */
     public String weapon() {
-        return faker.resolve("battlefield1.weapon");
+        return resolve("battlefield1.weapon");
     }
 
     /**
      * @return a random vehicle name as a string value
      */
     public String vehicle() {
-        return faker.resolve("battlefield1.vehicle");
+        return resolve("battlefield1.vehicle");
     }
 
     /**
      * @return a random map title as a string value
      */
     public String map() {
-        return faker.resolve("battlefield1.map");
+        return resolve("battlefield1.map");
     }
 
     /**
      * @return a random faction name as a string value
      */
     public String faction() {
-        return faker.resolve("battlefield1.faction");
+        return resolve("battlefield1.faction");
     }
 }

--- a/src/main/java/net/datafaker/Beer.java
+++ b/src/main/java/net/datafaker/Beer.java
@@ -10,22 +10,22 @@ public class Beer extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("beer.name", this);
+        return resolve("beer.name");
     }
 
     public String style() {
-        return faker.fakeValuesService().resolve("beer.style", this);
+        return resolve("beer.style");
     }
 
     public String hop() {
-        return faker.fakeValuesService().resolve("beer.hop", this);
+        return resolve("beer.hop");
     }
 
     public String yeast() {
-        return faker.fakeValuesService().resolve("beer.yeast", this);
+        return resolve("beer.yeast");
     }
 
     public String malt() {
-        return faker.fakeValuesService().resolve("beer.malt", this);
+        return resolve("beer.malt");
     }
 }

--- a/src/main/java/net/datafaker/BigBangTheory.java
+++ b/src/main/java/net/datafaker/BigBangTheory.java
@@ -15,7 +15,7 @@ public class BigBangTheory extends AbstractProvider {
      * @return a string of Big Bang Theory's character's name.
      */
     public String character() {
-        return faker.fakeValuesService().resolve("big_bang_theory.characters", this);
+        return resolve("big_bang_theory.characters");
     }
 
     /**
@@ -24,6 +24,6 @@ public class BigBangTheory extends AbstractProvider {
      * @return a string of Big Bang Theory's character's quote.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("big_bang_theory.quotes", this);
+        return resolve("big_bang_theory.quotes");
     }
 }

--- a/src/main/java/net/datafaker/BloodType.java
+++ b/src/main/java/net/datafaker/BloodType.java
@@ -15,7 +15,7 @@ public class BloodType extends AbstractProvider {
      * @return a string of ABO blood type
      */
     public String aboTypes() {
-        return faker.fakeValuesService().fetchString("blood_type.abo_types");
+        return resolve("blood_type.abo_types");
     }
 
     /**
@@ -24,7 +24,7 @@ public class BloodType extends AbstractProvider {
      * @return a string of Rh blood type
      */
     public String rhTypes() {
-        return faker.fakeValuesService().fetchString("blood_type.rh_types");
+        return resolve("blood_type.rh_types");
     }
 
     /**
@@ -33,7 +33,7 @@ public class BloodType extends AbstractProvider {
      * @return a string of P blood type
      */
     public String pTypes() {
-        return faker.fakeValuesService().fetchString("blood_type.p_types");
+        return resolve("blood_type.p_types");
     }
 
 
@@ -43,6 +43,6 @@ public class BloodType extends AbstractProvider {
      * @return a blood group such as O−, O+, A-, A+, B-, B+, AB-, AB+
      */
     public String bloodGroup() {
-        return faker.fakeValuesService().resolve("blood_type.blood_group", this);
+        return resolve("blood_type.blood_group");
     }
 }

--- a/src/main/java/net/datafaker/BojackHorseman.java
+++ b/src/main/java/net/datafaker/BojackHorseman.java
@@ -23,7 +23,7 @@ public class BojackHorseman extends AbstractProvider {
      * @return Characters in BojackHorseman
      */
     public String characters() {
-        return faker.fakeValuesService().resolve("bojack_horseman.characters", this);
+        return resolve("bojack_horseman.characters");
     }
 
     /**
@@ -32,7 +32,7 @@ public class BojackHorseman extends AbstractProvider {
      * @return Quotes in BojackHorseman
      */
     public String quotes() {
-        return faker.fakeValuesService().resolve("bojack_horseman.quotes", this);
+        return resolve("bojack_horseman.quotes");
     }
 
     /**
@@ -41,7 +41,7 @@ public class BojackHorseman extends AbstractProvider {
      * @return Tongue twisters in BojackHorseman
      */
     public String tongueTwisters() {
-        return faker.fakeValuesService().resolve("bojack_horseman.tongue_twisters", this);
+        return resolve("bojack_horseman.tongue_twisters");
     }
 
 }

--- a/src/main/java/net/datafaker/Book.java
+++ b/src/main/java/net/datafaker/Book.java
@@ -10,18 +10,18 @@ public class Book extends AbstractProvider {
     }
 
     public String author() {
-        return faker.fakeValuesService().resolve("book.author", this);
+        return resolve("book.author");
     }
 
     public String title() {
-        return faker.fakeValuesService().resolve("book.title", this);
+        return resolve("book.title");
     }
 
     public String publisher() {
-        return faker.fakeValuesService().resolve("book.publisher", this);
+        return resolve("book.publisher");
     }
 
     public String genre() {
-        return faker.fakeValuesService().resolve("book.genre", this);
+        return resolve("book.genre");
     }
 }

--- a/src/main/java/net/datafaker/BossaNova.java
+++ b/src/main/java/net/datafaker/BossaNova.java
@@ -14,10 +14,10 @@ public class BossaNova extends AbstractProvider {
     }
 
     public String artist() {
-        return faker.fakeValuesService().resolve("bossa_nova.artists", this);
+        return resolve("bossa_nova.artists");
     }
 
     public String song() {
-        return faker.fakeValuesService().resolve("bossa_nova.songs", this);
+        return resolve("bossa_nova.songs");
     }
 }

--- a/src/main/java/net/datafaker/BreakingBad.java
+++ b/src/main/java/net/datafaker/BreakingBad.java
@@ -15,10 +15,10 @@ public class BreakingBad extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("breaking_bad.characters", this);
+        return resolve("breaking_bad.characters");
     }
 
     public String episode() {
-        return faker.fakeValuesService().resolve("breaking_bad.episodes", this);
+        return resolve("breaking_bad.episodes");
     }
 }

--- a/src/main/java/net/datafaker/BrooklynNineNine.java
+++ b/src/main/java/net/datafaker/BrooklynNineNine.java
@@ -12,11 +12,11 @@ public class BrooklynNineNine extends AbstractProvider {
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("brooklyn_nine_nine.characters", this);
+        return resolve("brooklyn_nine_nine.characters");
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("brooklyn_nine_nine.quotes", this);
+        return resolve("brooklyn_nine_nine.quotes");
     }
 
 }

--- a/src/main/java/net/datafaker/Buffy.java
+++ b/src/main/java/net/datafaker/Buffy.java
@@ -10,23 +10,23 @@ public class Buffy extends AbstractProvider {
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("buffy.characters", this);
+        return resolve("buffy.characters");
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("buffy.quotes", this);
+        return resolve("buffy.quotes");
     }
 
     public String celebrities() {
-        return faker.fakeValuesService().resolve("buffy.celebrities", this);
+        return resolve("buffy.celebrities");
     }
 
     public String bigBads() {
-        return faker.fakeValuesService().resolve("buffy.big_bads", this);
+        return resolve("buffy.big_bads");
     }
 
     public String episodes() {
-        return faker.fakeValuesService().resolve("buffy.episodes", this);
+        return resolve("buffy.episodes");
     }
 
 }

--- a/src/main/java/net/datafaker/Business.java
+++ b/src/main/java/net/datafaker/Business.java
@@ -10,14 +10,14 @@ public class Business extends AbstractProvider {
     }
 
     public String creditCardNumber() {
-        return faker.fakeValuesService().resolve("business.credit_card_numbers", this);
+        return resolve("business.credit_card_numbers");
     }
 
     public String creditCardType() {
-        return faker.fakeValuesService().resolve("business.credit_card_types", this);
+        return resolve("business.credit_card_types");
     }
 
     public String creditCardExpiry() {
-        return faker.fakeValuesService().resolve("business.credit_card_expiry_dates", this);
+        return resolve("business.credit_card_expiry_dates");
     }
 }

--- a/src/main/java/net/datafaker/Camera.java
+++ b/src/main/java/net/datafaker/Camera.java
@@ -15,7 +15,7 @@ public class Camera extends AbstractProvider {
      * @return a string of camera brand.
      */
     public String brand() {
-        return faker.fakeValuesService().resolve("camera.brand", this);
+        return resolve("camera.brand");
     }
 
     /**
@@ -24,7 +24,7 @@ public class Camera extends AbstractProvider {
      * @return a string of camera model.
      */
     public String model() {
-        return faker.fakeValuesService().resolve("camera.model", this);
+        return resolve("camera.model");
     }
 
     /**
@@ -33,6 +33,6 @@ public class Camera extends AbstractProvider {
      * @return a string of camera brand with a model.
      */
     public String brandWithModel() {
-        return faker.fakeValuesService().resolve("camera.brand_with_model", this);
+        return resolve("camera.brand_with_model");
     }
 }

--- a/src/main/java/net/datafaker/Cannabis.java
+++ b/src/main/java/net/datafaker/Cannabis.java
@@ -10,42 +10,42 @@ public class Cannabis extends AbstractProvider {
     }
 
     public String strains() {
-        return faker.fakeValuesService().resolve("cannabis.strains", this);
+        return resolve("cannabis.strains");
     }
 
     public String cannabinoidAbbreviations() {
-        return faker.fakeValuesService().resolve("cannabis.cannabinoid_abbreviations", this);
+        return resolve("cannabis.cannabinoid_abbreviations");
     }
 
     public String cannabinoids() {
-        return faker.fakeValuesService().resolve("cannabis.cannabinoids", this);
+        return resolve("cannabis.cannabinoids");
     }
 
     public String terpenes() {
-        return faker.fakeValuesService().resolve("cannabis.terpenes", this);
+        return resolve("cannabis.terpenes");
     }
 
     public String medicalUses() {
-        return faker.fakeValuesService().resolve("cannabis.medical_uses", this);
+        return resolve("cannabis.medical_uses");
     }
 
     public String healthBenefits() {
-        return faker.fakeValuesService().resolve("cannabis.health_benefits", this);
+        return resolve("cannabis.health_benefits");
     }
 
     public String categories() {
-        return faker.fakeValuesService().resolve("cannabis.categories", this);
+        return resolve("cannabis.categories");
     }
 
     public String types() {
-        return faker.fakeValuesService().resolve("cannabis.types", this);
+        return resolve("cannabis.types");
     }
 
     public String buzzwords() {
-        return faker.fakeValuesService().resolve("cannabis.buzzwords", this);
+        return resolve("cannabis.buzzwords");
     }
 
     public String brands() {
-        return faker.fakeValuesService().resolve("cannabis.brands", this);
+        return resolve("cannabis.brands");
     }
 }

--- a/src/main/java/net/datafaker/Cat.java
+++ b/src/main/java/net/datafaker/Cat.java
@@ -10,14 +10,14 @@ public class Cat extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.cat.name", this);
+        return resolve("creature.cat.name");
     }
 
     public String breed() {
-        return faker.fakeValuesService().resolve("creature.cat.breed", this);
+        return resolve("creature.cat.breed");
     }
 
     public String registry() {
-        return faker.fakeValuesService().resolve("creature.cat.registry", this);
+        return resolve("creature.cat.registry");
     }
 }

--- a/src/main/java/net/datafaker/Chiquito.java
+++ b/src/main/java/net/datafaker/Chiquito.java
@@ -10,19 +10,19 @@ public class Chiquito extends AbstractProvider {
     }
 
     public String expressions() {
-        return faker.fakeValuesService().resolve("chiquito.expressions", this);
+        return resolve("chiquito.expressions");
     }
 
     public String terms() {
-        return faker.fakeValuesService().resolve("chiquito.terms", this);
+        return resolve("chiquito.terms");
     }
 
     public String sentences() {
-        return faker.fakeValuesService().resolve("chiquito.sentences", this);
+        return resolve("chiquito.sentences");
     }
 
     public String jokes() {
-        return faker.fakeValuesService().resolve("chiquito.jokes", this);
+        return resolve("chiquito.jokes");
     }
 
 }

--- a/src/main/java/net/datafaker/ChuckNorris.java
+++ b/src/main/java/net/datafaker/ChuckNorris.java
@@ -10,6 +10,6 @@ public class ChuckNorris extends AbstractProvider {
     }
 
     public String fact() {
-        return faker.fakeValuesService().resolve("chuck_norris.fact", this);
+        return resolve("chuck_norris.fact");
     }
 }

--- a/src/main/java/net/datafaker/ClashOfClans.java
+++ b/src/main/java/net/datafaker/ClashOfClans.java
@@ -10,14 +10,14 @@ public class ClashOfClans extends AbstractProvider {
     }
 
     public String troop() {
-        return faker.fakeValuesService().resolve("clash_of_clans.troops", this);
+        return resolve("clash_of_clans.troops");
     }
 
     public String rank() {
-        return faker.fakeValuesService().resolve("clash_of_clans.ranks", this);
+        return resolve("clash_of_clans.ranks");
     }
 
     public String defensiveBuilding() {
-        return faker.fakeValuesService().resolve("clash_of_clans.defensive_buildings", this);
+        return resolve("clash_of_clans.defensive_buildings");
     }
 }

--- a/src/main/java/net/datafaker/Code.java
+++ b/src/main/java/net/datafaker/Code.java
@@ -158,7 +158,7 @@ public class Code extends AbstractProvider {
     }
 
     public String asin() {
-        return faker.resolve("code.asin");
+        return resolve("code.asin");
     }
 
     public String imei() {

--- a/src/main/java/net/datafaker/Coffee.java
+++ b/src/main/java/net/datafaker/Coffee.java
@@ -13,7 +13,7 @@ public class Coffee extends AbstractProvider {
     }
 
     public String country() {
-        return faker.fakeValuesService().resolve("coffee.country", this);
+        return resolve("coffee.country");
     }
 
     public String region() {
@@ -21,39 +21,39 @@ public class Coffee extends AbstractProvider {
     }
 
     public String region(Coffee.Country country) {
-        return faker.fakeValuesService().resolve("coffee.regions." + country.name().toLowerCase(Locale.ROOT), this);
+        return resolve("coffee.regions." + country.name().toLowerCase(Locale.ROOT));
     }
 
     public String variety() {
-        return faker.fakeValuesService().resolve("coffee.variety", this);
+        return resolve("coffee.variety");
     }
 
     public String intensifier() {
-        return faker.fakeValuesService().resolve("coffee.intensifier", this);
+        return resolve("coffee.intensifier");
     }
 
     public String body() {
-        return faker.fakeValuesService().resolve("coffee.body", this);
+        return resolve("coffee.body");
     }
 
     public String descriptor() {
-        return faker.fakeValuesService().resolve("coffee.descriptor", this);
+        return resolve("coffee.descriptor");
     }
 
     public String notes() {
-        return faker.fakeValuesService().resolve("coffee.notes", this);
+        return resolve("coffee.notes");
     }
 
     public String name1() {
-        return faker.fakeValuesService().resolve("coffee.name_1", this);
+        return resolve("coffee.name_1");
     }
 
     public String name2() {
-        return faker.fakeValuesService().resolve("coffee.name_2", this);
+        return resolve("coffee.name_2");
     }
 
     public String blendName() {
-        return faker.fakeValuesService().resolve("coffee.blend_name", this);
+        return resolve("coffee.blend_name");
     }
 
     public enum Country {

--- a/src/main/java/net/datafaker/Coin.java
+++ b/src/main/java/net/datafaker/Coin.java
@@ -13,6 +13,6 @@ public class Coin extends AbstractProvider {
      * @return coin side e.g. "Heads", "Tails".
      */
     public String flip() {
-        return faker.fakeValuesService().resolve("coin.flip", this);
+        return resolve("coin.flip");
     }
 }

--- a/src/main/java/net/datafaker/Color.java
+++ b/src/main/java/net/datafaker/Color.java
@@ -10,7 +10,7 @@ public class Color extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("color.name", this);
+        return resolve("color.name");
     }
 
     public String hex() {

--- a/src/main/java/net/datafaker/Commerce.java
+++ b/src/main/java/net/datafaker/Commerce.java
@@ -20,7 +20,7 @@ public class Commerce extends AbstractProvider {
         int numberOfDepartments = Math.max(faker.random().nextInt(4), 1);
         SortedSet<String> departments = new TreeSet<>();
         while (departments.size() < numberOfDepartments) {
-            departments.add(faker.fakeValuesService().resolve("commerce.department", this));
+            departments.add(faker.resolve("commerce.department"));
         }
         if (departments.size() > 1) {
             String lastDepartment = departments.last();
@@ -33,22 +33,22 @@ public class Commerce extends AbstractProvider {
 
     public String productName() {
         return String.join(" ",
-            faker.fakeValuesService().resolve("commerce.product_name.adjective", this),
-            faker.fakeValuesService().resolve("commerce.product_name.material", this),
-            faker.fakeValuesService().resolve("commerce.product_name.product", this)
+            resolve("commerce.product_name.adjective"),
+            resolve("commerce.product_name.material"),
+            resolve("commerce.product_name.product")
         );
     }
 
     public String material() {
-        return faker.fakeValuesService().resolve("commerce.product_name.material", this);
+        return resolve("commerce.product_name.material");
     }
 
     public String brand() {
-        return faker.fakeValuesService().resolve("commerce.brand", this);
+        return resolve("commerce.brand");
     }
 
     public String vendor() {
-        return faker.fakeValuesService().resolve("commerce.vendor", this);
+        return resolve("commerce.vendor");
     }
 
     /**
@@ -69,7 +69,7 @@ public class Commerce extends AbstractProvider {
 
     public String promotionCode(int digits) {
         return String.join(faker.resolve("commerce.promotion_code.adjective"),
-            faker.resolve("commerce.promotion_code.noun"),
+            resolve("commerce.promotion_code.noun"),
             faker.number().digits(digits));
     }
 }

--- a/src/main/java/net/datafaker/Community.java
+++ b/src/main/java/net/datafaker/Community.java
@@ -12,10 +12,10 @@ public class Community extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("community.characters");
+        return resolve("community.characters");
     }
 
     public String quote() {
-        return faker.resolve("community.quotes");
+        return resolve("community.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Company.java
+++ b/src/main/java/net/datafaker/Company.java
@@ -18,24 +18,24 @@ public class Company extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("company.name", this);
+        return resolve("company.name");
     }
 
     public String suffix() {
-        return faker.fakeValuesService().resolve("company.suffix", this);
+        return resolve("company.suffix");
     }
 
     public String industry() {
-        return faker.fakeValuesService().resolve("company.industry", this);
+        return resolve("company.industry");
     }
 
     public String profession() {
-        return faker.fakeValuesService().resolve("company.profession", this);
+        return resolve("company.profession");
     }
 
     public String buzzword() {
         @SuppressWarnings("unchecked")
-        List<List<String>> buzzwordLists = (List<List<String>>) faker.fakeValuesService().fetchObject("company.buzzwords");
+        List<List<String>> buzzwordLists = (List<List<String>>) faker.fakeValuesService().fetchObject("company.buzzwords", faker.getContext());
         List<String> buzzwords = new ArrayList<>();
         for (List<String> buzzwordList : buzzwordLists) {
             buzzwords.addAll(buzzwordList);
@@ -48,7 +48,7 @@ public class Company extends AbstractProvider {
      */
     public String catchPhrase() {
         @SuppressWarnings("unchecked")
-        List<List<String>> catchPhraseLists = (List<List<String>>) faker.fakeValuesService().fetchObject("company.buzzwords");
+        List<List<String>> catchPhraseLists = (List<List<String>>) faker.fakeValuesService().fetchObject("company.buzzwords", faker.getContext());
         return joinSampleOfEachList(catchPhraseLists);
     }
 
@@ -57,7 +57,7 @@ public class Company extends AbstractProvider {
      */
     public String bs() {
         @SuppressWarnings("unchecked")
-        List<List<String>> buzzwordLists = (List<List<String>>) faker.fakeValuesService().fetchObject("company.bs");
+        List<List<String>> buzzwordLists = (List<List<String>>) faker.fakeValuesService().fetchObject("company.bs", faker.getContext());
         return joinSampleOfEachList(buzzwordLists);
     }
 
@@ -82,7 +82,7 @@ public class Company extends AbstractProvider {
     }
 
     private String domainSuffix() {
-        return faker.fakeValuesService().resolve("internet.domain_suffix", this);
+        return resolve("internet.domain_suffix");
     }
 
     private String joinSampleOfEachList(List<List<String>> listOfLists) {

--- a/src/main/java/net/datafaker/Computer.java
+++ b/src/main/java/net/datafaker/Computer.java
@@ -12,26 +12,26 @@ public class Computer extends AbstractProvider {
     }
 
     public String type() {
-        return faker.resolve("computer.type");
+        return resolve("computer.type");
     }
 
     public String platform() {
-        return faker.resolve("computer.platform");
+        return resolve("computer.platform");
     }
 
     public String operatingSystem() {
-        return faker.resolve("computer.os." + faker.options().option("linux", "macos", "windows"));
+        return resolve("computer.os." + faker.options().option("linux", "macos", "windows"));
     }
 
     public String linux() {
-        return faker.resolve("computer.os.linux");
+        return resolve("computer.os.linux");
     }
 
     public String macos() {
-        return faker.resolve("computer.os.macos");
+        return resolve("computer.os.macos");
     }
 
     public String windows() {
-        return faker.resolve("computer.os.windows");
+        return resolve("computer.os.windows");
     }
 }

--- a/src/main/java/net/datafaker/Construction.java
+++ b/src/main/java/net/datafaker/Construction.java
@@ -10,27 +10,27 @@ public class Construction extends AbstractProvider {
     }
 
     public String heavyEquipment() {
-        return faker.fakeValuesService().resolve("construction.heavy_equipment", this);
+        return resolve("construction.heavy_equipment");
     }
 
     public String materials() {
-        return faker.fakeValuesService().resolve("construction.materials", this);
+        return resolve("construction.materials");
     }
 
     public String subcontractCategories() {
-        return faker.fakeValuesService().resolve("construction.subcontract_categories", this);
+        return resolve("construction.subcontract_categories");
     }
 
     public String roles() {
-        return faker.fakeValuesService().resolve("construction.roles", this);
+        return resolve("construction.roles");
     }
 
     public String trades() {
-        return faker.fakeValuesService().resolve("construction.trades", this);
+        return resolve("construction.trades");
     }
 
     public String standardCostCodes() {
-        return faker.fakeValuesService().resolve("construction.standard_cost_codes", this);
+        return resolve("construction.standard_cost_codes");
     }
 
 }

--- a/src/main/java/net/datafaker/Country.java
+++ b/src/main/java/net/datafaker/Country.java
@@ -12,31 +12,31 @@ public class Country extends AbstractProvider {
     }
 
     public String flag() {
-        return flagUrl + faker.fakeValuesService().resolve("country.code2", this) + ".png";
+        return flagUrl + resolve("country.code2") + ".png";
     }
 
     public String countryCode2() {
-        return faker.fakeValuesService().resolve("country.code2", this);
+        return resolve("country.code2");
     }
 
     public String countryCode3() {
-        return faker.fakeValuesService().resolve("country.code3", this);
+        return resolve("country.code3");
     }
 
     public String capital() {
-        return faker.fakeValuesService().resolve("country.capital", this);
+        return resolve("country.capital");
     }
 
     public String currency() {
-        return faker.fakeValuesService().resolve("country.currency", this);
+        return resolve("country.currency");
     }
 
     public String currencyCode() {
-        return faker.fakeValuesService().resolve("country.currency_code", this);
+        return resolve("country.currency_code");
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("country.name", this);
+        return resolve("country.name");
     }
 
 }

--- a/src/main/java/net/datafaker/CryptoCoin.java
+++ b/src/main/java/net/datafaker/CryptoCoin.java
@@ -10,7 +10,7 @@ public class CryptoCoin extends AbstractProvider {
     }
 
     public String coin() {
-        return faker.fakeValuesService().resolve("crypto_coin.coin", this);
+        return resolve("crypto_coin.coin");
     }
 
 }

--- a/src/main/java/net/datafaker/Currency.java
+++ b/src/main/java/net/datafaker/Currency.java
@@ -10,10 +10,10 @@ public class Currency extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("currency.name", this);
+        return resolve("currency.name");
     }
 
     public String code() {
-        return faker.fakeValuesService().resolve("currency.code", this);
+        return resolve("currency.code");
     }
 }

--- a/src/main/java/net/datafaker/DarkSoul.java
+++ b/src/main/java/net/datafaker/DarkSoul.java
@@ -13,19 +13,19 @@ public class DarkSoul extends AbstractProvider {
     }
 
     public String stats() {
-        return faker.fakeValuesService().resolve("dark_soul.stats", this);
+        return resolve("dark_soul.stats");
     }
 
     public String covenants() {
-        return faker.fakeValuesService().resolve("dark_soul.covenants", this);
+        return resolve("dark_soul.covenants");
     }
 
     public String classes() {
-        return faker.fakeValuesService().resolve("dark_soul.classes", this);
+        return resolve("dark_soul.classes");
     }
 
     public String shield() {
-        return faker.fakeValuesService().resolve("dark_soul.shield", this);
+        return resolve("dark_soul.shield");
     }
 
 }

--- a/src/main/java/net/datafaker/DcComics.java
+++ b/src/main/java/net/datafaker/DcComics.java
@@ -10,22 +10,22 @@ public class DcComics extends AbstractProvider {
     }
 
     public String hero() {
-        return faker.resolve("dc_comics.hero");
+        return resolve("dc_comics.hero");
     }
 
     public String heroine() {
-        return faker.resolve("dc_comics.heroine");
+        return resolve("dc_comics.heroine");
     }
 
     public String villain() {
-        return faker.resolve("dc_comics.villain");
+        return resolve("dc_comics.villain");
     }
 
     public String name() {
-        return faker.resolve("dc_comics.name");
+        return resolve("dc_comics.name");
     }
 
     public String title() {
-        return faker.resolve("dc_comics.title");
+        return resolve("dc_comics.title");
     }
 }

--- a/src/main/java/net/datafaker/Demographic.java
+++ b/src/main/java/net/datafaker/Demographic.java
@@ -10,22 +10,22 @@ public class Demographic extends AbstractProvider {
     }
 
     public String race() {
-        return faker.fakeValuesService().fetchString("demographic.race");
+        return resolve("demographic.race");
     }
 
     public String educationalAttainment() {
-        return faker.fakeValuesService().fetchString("demographic.educational_attainment");
+        return resolve("demographic.educational_attainment");
     }
 
     public String demonym() {
-        return faker.fakeValuesService().fetchString("demographic.demonym");
+        return resolve("demographic.demonym");
     }
 
     public String sex() {
-        return faker.fakeValuesService().fetchString("demographic.sex");
+        return resolve("demographic.sex");
     }
 
     public String maritalStatus() {
-        return faker.fakeValuesService().fetchString("demographic.marital_status");
+        return resolve("demographic.marital_status");
     }
 }

--- a/src/main/java/net/datafaker/Departed.java
+++ b/src/main/java/net/datafaker/Departed.java
@@ -15,7 +15,7 @@ public class Departed extends AbstractProvider {
      * @return a string of actor's name from The Departed.
      */
     public String actor() {
-        return faker.fakeValuesService().resolve("departed.actors", this);
+        return resolve("departed.actors");
     }
 
     /**
@@ -24,7 +24,7 @@ public class Departed extends AbstractProvider {
      * @return a string of character's name from The Departed.
      */
     public String character() {
-        return faker.fakeValuesService().resolve("departed.characters", this);
+        return resolve("departed.characters");
     }
 
     /**
@@ -33,6 +33,6 @@ public class Departed extends AbstractProvider {
      * @return a string of quote from The Departed.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("departed.quotes", this);
+        return resolve("departed.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Dessert.java
+++ b/src/main/java/net/datafaker/Dessert.java
@@ -13,20 +13,20 @@ public class Dessert extends AbstractProvider {
      * @return dessert variety e.g. "Cake".
      */
     public String variety() {
-        return faker.fakeValuesService().resolve("dessert.variety", this);
+        return resolve("dessert.variety");
     }
 
     /**
      * @return dessert topping e.g. "Rainbow Sprinkles".
      */
     public String topping() {
-        return faker.fakeValuesService().resolve("dessert.topping", this);
+        return resolve("dessert.topping");
     }
 
     /**
      * @return dessert flavor e.g. "Vanilla".
      */
     public String flavor() {
-        return faker.fakeValuesService().resolve("dessert.flavor", this);
+        return resolve("dessert.flavor");
     }
 }

--- a/src/main/java/net/datafaker/Device.java
+++ b/src/main/java/net/datafaker/Device.java
@@ -10,19 +10,19 @@ public class Device extends AbstractProvider {
     }
 
     public String modelName() {
-        return faker.fakeValuesService().resolve("device.model_name", this);
+        return resolve("device.model_name");
     }
 
     public String platform() {
-        return faker.fakeValuesService().resolve("device.platform", this);
+        return resolve("device.platform");
     }
 
     public String manufacturer() {
-        return faker.fakeValuesService().resolve("device.manufacturer", this);
+        return resolve("device.manufacturer");
     }
 
     public String serial() {
-        return faker.fakeValuesService().resolve("device.serial", this);
+        return resolve("device.serial");
     }
 
 }

--- a/src/main/java/net/datafaker/Disease.java
+++ b/src/main/java/net/datafaker/Disease.java
@@ -22,7 +22,7 @@ public class Disease extends AbstractProvider {
      * @return An internal disease
      */
     public String internalDisease() {
-        return faker.fakeValuesService().resolve("disease.internal_disease", this);
+        return resolve("disease.internal_disease");
     }
 
     /**
@@ -31,7 +31,7 @@ public class Disease extends AbstractProvider {
      * @return A neurology disease
      */
     public String neurology() {
-        return faker.fakeValuesService().resolve("disease.neurology", this);
+        return resolve("disease.neurology");
     }
 
     /**
@@ -40,7 +40,7 @@ public class Disease extends AbstractProvider {
      * @return A surgery disease
      */
     public String surgery() {
-        return faker.fakeValuesService().resolve("disease.surgery", this);
+        return resolve("disease.surgery");
     }
 
     /**
@@ -49,7 +49,7 @@ public class Disease extends AbstractProvider {
      * @return A paediatrics disease
      */
     public String paediatrics() {
-        return faker.fakeValuesService().resolve("disease.paediatrics", this);
+        return resolve("disease.paediatrics");
     }
 
     /**
@@ -58,7 +58,7 @@ public class Disease extends AbstractProvider {
      * @return A gynecology and obstetrics disease
      */
     public String gynecologyAndObstetrics() {
-        return faker.fakeValuesService().resolve("disease.gynecology_and_obstetrics", this);
+        return resolve("disease.gynecology_and_obstetrics");
     }
 
     /**
@@ -67,7 +67,7 @@ public class Disease extends AbstractProvider {
      * @return A ophthalmology and otorhinolaryngology disease
      */
     public String ophthalmologyAndOtorhinolaryngology() {
-        return faker.fakeValuesService().resolve("disease.ophthalmology_and_otorhinolaryngology", this);
+        return resolve("disease.ophthalmology_and_otorhinolaryngology");
     }
 
     /**
@@ -76,7 +76,7 @@ public class Disease extends AbstractProvider {
      * @return A dermatolory disease
      */
     public String dermatolory() {
-        return faker.fakeValuesService().resolve("disease.dermatolory", this);
+        return resolve("disease.dermatolory");
     }
 
 }

--- a/src/main/java/net/datafaker/Dog.java
+++ b/src/main/java/net/datafaker/Dog.java
@@ -10,34 +10,34 @@ public class Dog extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.dog.name", this);
+        return resolve("creature.dog.name");
     }
 
     public String breed() {
-        return faker.fakeValuesService().resolve("creature.dog.breed", this);
+        return resolve("creature.dog.breed");
     }
 
     public String sound() {
-        return faker.fakeValuesService().resolve("creature.dog.sound", this);
+        return resolve("creature.dog.sound");
     }
 
     public String memePhrase() {
-        return faker.fakeValuesService().resolve("creature.dog.meme_phrase", this);
+        return resolve("creature.dog.meme_phrase");
     }
 
     public String age() {
-        return faker.fakeValuesService().resolve("creature.dog.age", this);
+        return resolve("creature.dog.age");
     }
 
     public String coatLength() {
-        return faker.fakeValuesService().resolve("creature.dog.coat_length", this);
+        return resolve("creature.dog.coat_length");
     }
 
     public String gender() {
-        return faker.fakeValuesService().resolve("creature.dog.gender", this);
+        return resolve("creature.dog.gender");
     }
 
     public String size() {
-        return faker.fakeValuesService().resolve("creature.dog.size", this);
+        return resolve("creature.dog.size");
     }
 }

--- a/src/main/java/net/datafaker/Domain.java
+++ b/src/main/java/net/datafaker/Domain.java
@@ -26,7 +26,7 @@ public class Domain extends AbstractProvider {
      * @return the
      */
     public String firstLevelDomain(String name) {
-        String top = faker.fakeValuesService().resolve("domain.top", this);
+        String top = resolve("domain.top");
         return String.join("",
             name,
             ".",
@@ -41,8 +41,8 @@ public class Domain extends AbstractProvider {
      * @return the second level domain with company name
      */
     public String secondLevelDomain(String name) {
-        String top = faker.fakeValuesService().resolve("domain.top", this);
-        String suffix = faker.fakeValuesService().resolve("domain.country", this);
+        String top = resolve("domain.top");
+        String suffix = resolve("domain.country");
         return String.join("",
             name,
             ".",
@@ -59,9 +59,9 @@ public class Domain extends AbstractProvider {
      * @return the full domain name
      */
     public String fullDomain(String name) {
-        String prefix = faker.fakeValuesService().resolve("domain.prefix", this);
-        String top = faker.fakeValuesService().resolve("domain.top", this);
-        String suffix = faker.fakeValuesService().resolve("domain.country", this);
+        String prefix = resolve("domain.prefix");
+        String top = resolve("domain.top");
+        String suffix = resolve("domain.country");
         return String.join("",
             prefix,
             ".",
@@ -86,7 +86,7 @@ public class Domain extends AbstractProvider {
         boolean hasPrefix = random.nextInt(3) == 1;
         boolean hasSuffix = random.nextInt(2) == 1;
 
-        String top = faker.fakeValuesService().resolve("domain.top", this);
+        String top = resolve("domain.top");
 
         String result = String.join("",
             name,
@@ -95,7 +95,7 @@ public class Domain extends AbstractProvider {
         );
 
         if (hasPrefix) {
-            String prefix = faker.fakeValuesService().resolve("domain.prefix", this);
+            String prefix = resolve("domain.prefix");
             result = String.join("",
                 prefix,
                 ".",
@@ -104,7 +104,7 @@ public class Domain extends AbstractProvider {
         }
 
         if (hasSuffix) {
-            String suffix = faker.fakeValuesService().resolve("domain.country", this);
+            String suffix = resolve("domain.country");
             result = String.join("",
                 result,
                 ".",

--- a/src/main/java/net/datafaker/DragonBall.java
+++ b/src/main/java/net/datafaker/DragonBall.java
@@ -10,6 +10,6 @@ public class DragonBall extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("dragon_ball.characters", this);
+        return resolve("dragon_ball.characters");
     }
 }

--- a/src/main/java/net/datafaker/DumbAndDumber.java
+++ b/src/main/java/net/datafaker/DumbAndDumber.java
@@ -10,14 +10,14 @@ public class DumbAndDumber extends AbstractProvider {
     }
 
     public String actor() {
-        return faker.resolve("dumb_and_dumber.actors");
+        return resolve("dumb_and_dumber.actors");
     }
 
     public String character() {
-        return faker.resolve("dumb_and_dumber.characters");
+        return resolve("dumb_and_dumber.characters");
     }
 
     public String quote() {
-        return faker.resolve("dumb_and_dumber.quotes");
+        return resolve("dumb_and_dumber.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Dune.java
+++ b/src/main/java/net/datafaker/Dune.java
@@ -10,15 +10,15 @@ public class Dune extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("dune.characters", this);
+        return resolve("dune.characters");
     }
 
     public String title() {
-        return faker.fakeValuesService().resolve("dune.titles", this);
+        return resolve("dune.titles");
     }
 
     public String planet() {
-        return faker.fakeValuesService().resolve("dune.planets", this);
+        return resolve("dune.planets");
     }
 
     public String quote() {
@@ -26,7 +26,7 @@ public class Dune extends AbstractProvider {
     }
 
     public String quote(Quote quote) {
-        return faker.fakeValuesService().resolve("dune.quotes." + quote.yamlKey, this);
+        return resolve("dune.quotes." + quote.yamlKey);
     }
 
     public String saying() {
@@ -34,7 +34,7 @@ public class Dune extends AbstractProvider {
     }
 
     public String saying(Saying saying) {
-        return faker.fakeValuesService().resolve("dune.sayings." + saying.yamlKey, this);
+        return resolve("dune.sayings." + saying.yamlKey);
     }
 
     public enum Quote {

--- a/src/main/java/net/datafaker/Educator.java
+++ b/src/main/java/net/datafaker/Educator.java
@@ -11,25 +11,25 @@ public class Educator extends AbstractProvider {
 
     // TODO - move these all out to en.yml by default. 
     public String university() {
-        return faker.fakeValuesService().resolve("educator.name", this)
+        return resolve("educator.name")
             + " "
-            + faker.fakeValuesService().resolve("educator.tertiary.type", this);
+            + resolve("educator.tertiary.type");
     }
 
     public String course() {
-        return faker.fakeValuesService().resolve("educator.tertiary.degree.type", this)
+        return resolve("educator.tertiary.degree.type")
             + " "
-            + faker.fakeValuesService().resolve("educator.tertiary.degree.subject", this);
+            + resolve("educator.tertiary.degree.subject");
     }
 
     public String secondarySchool() {
-        return faker.fakeValuesService().resolve("educator.name", this)
+        return resolve("educator.name")
             + " "
-            + faker.fakeValuesService().resolve("educator.secondary", this);
+            + resolve("educator.secondary");
     }
 
     public String campus() {
-        return faker.fakeValuesService().resolve("educator.name", this) + " Campus";
+        return resolve("educator.name") + " Campus";
     }
 
 }

--- a/src/main/java/net/datafaker/EldenRing.java
+++ b/src/main/java/net/datafaker/EldenRing.java
@@ -10,22 +10,22 @@ public class EldenRing extends AbstractProvider {
     }
 
     public String location() {
-        return faker.resolve("elden_ring.location");
+        return resolve("elden_ring.location");
     }
 
     public String weapon() {
-        return faker.resolve("elden_ring.weapon");
+        return resolve("elden_ring.weapon");
     }
 
     public String skill(){
-        return faker.resolve("elden_ring.skill");
+        return resolve("elden_ring.skill");
     }
 
     public String spell(){
-        return faker.resolve("elden_ring.spell");
+        return resolve("elden_ring.spell");
     }
 
     public String npc(){
-        return faker.resolve("elden_ring.npc");
+        return resolve("elden_ring.npc");
     }
 }

--- a/src/main/java/net/datafaker/ElderScrolls.java
+++ b/src/main/java/net/datafaker/ElderScrolls.java
@@ -10,34 +10,34 @@ public class ElderScrolls extends AbstractProvider {
     }
 
     public String race() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.race", this);
+        return resolve("games.elder_scrolls.race");
     }
 
     public String creature() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.creature", this);
+        return resolve("games.elder_scrolls.creature");
     }
 
     public String region() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.region", this);
+        return resolve("games.elder_scrolls.region");
     }
 
     public String dragon() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.dragon", this);
+        return resolve("games.elder_scrolls.dragon");
     }
 
     public String city() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.city", this);
+        return resolve("games.elder_scrolls.city");
     }
 
     public String firstName() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.first_name", this);
+        return resolve("games.elder_scrolls.first_name");
     }
 
     public String lastName() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.last_name", this);
+        return resolve("games.elder_scrolls.last_name");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.elder_scrolls.quote", this);
+        return resolve("games.elder_scrolls.quote");
     }
 }

--- a/src/main/java/net/datafaker/ElectricalComponents.java
+++ b/src/main/java/net/datafaker/ElectricalComponents.java
@@ -10,14 +10,14 @@ public class ElectricalComponents extends AbstractProvider {
     }
 
     public String active() {
-        return faker.fakeValuesService().resolve("electrical_components.active", this);
+        return resolve("electrical_components.active");
     }
 
     public String passive() {
-        return faker.fakeValuesService().resolve("electrical_components.passive", this);
+        return resolve("electrical_components.passive");
     }
 
     public String electromechanical() {
-        return faker.fakeValuesService().resolve("electrical_components.electromechanical", this);
+        return resolve("electrical_components.electromechanical");
     }
 }

--- a/src/main/java/net/datafaker/EnglandFootBall.java
+++ b/src/main/java/net/datafaker/EnglandFootBall.java
@@ -10,10 +10,10 @@ public class EnglandFootBall extends AbstractProvider {
     }
 
     public String league() {
-        return faker.fakeValuesService().resolve("englandfootball.leagues", this);
+        return resolve("englandfootball.leagues");
     }
 
     public String team() {
-        return faker.fakeValuesService().resolve("englandfootball.teams", this);
+        return resolve("englandfootball.teams");
     }
 }

--- a/src/main/java/net/datafaker/Esports.java
+++ b/src/main/java/net/datafaker/Esports.java
@@ -10,22 +10,22 @@ public class Esports extends AbstractProvider {
     }
 
     public String player() {
-        return faker.resolve("esport.players");
+        return resolve("esport.players");
     }
 
     public String team() {
-        return faker.resolve("esport.teams");
+        return resolve("esport.teams");
     }
 
     public String event() {
-        return faker.resolve("esport.events");
+        return resolve("esport.events");
     }
 
     public String league() {
-        return faker.resolve("esport.leagues");
+        return resolve("esport.leagues");
     }
 
     public String game() {
-        return faker.resolve("esport.games");
+        return resolve("esport.games");
     }
 }

--- a/src/main/java/net/datafaker/Faker.java
+++ b/src/main/java/net/datafaker/Faker.java
@@ -2,15 +2,17 @@ package net.datafaker;
 
 import net.datafaker.fileformats.Json;
 import net.datafaker.service.FakeValuesService;
+import net.datafaker.service.FakerContext;
 import net.datafaker.service.RandomService;
 
 import java.nio.file.Path;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -20,9 +22,9 @@ import java.util.function.Supplier;
  * @author ren
  */
 public class Faker {
-    private final RandomService randomService;
+    private final FakerContext context;
     private final FakeValuesService fakeValuesService;
-    private final Map<Class<? extends AbstractProvider>, AbstractProvider> providersMap = new IdentityHashMap<>();
+    private static final Map<Class<? extends AbstractProvider>, Map<FakerContext, AbstractProvider>> PROVIDERS_MAP = new ConcurrentHashMap<>();
 
     public Faker() {
         this(Locale.ENGLISH);
@@ -41,21 +43,22 @@ public class Faker {
     }
 
     public Faker(Locale locale, RandomService randomService) {
-        this(new FakeValuesService(locale, randomService), randomService);
+        this(new FakeValuesService(), new FakerContext(locale, randomService));
     }
 
-    public Faker(FakeValuesService fakeValuesService, RandomService random) {
-        this.randomService = random;
+    public Faker(FakeValuesService fakeValuesService, FakerContext context) {
         this.fakeValuesService = fakeValuesService;
+        this.context = context;
+        fakeValuesService.updateFakeValuesInterfaceMap(context.getLocaleChain());
     }
 
     /**
      * Constructs Faker instance with default argument.
      *
-     * @deprecated Use the default contructor instead
+     * @deprecated Use the default constructor instead
      * @return {@link Faker#Faker()}
      */
-    @Deprecated // Use the default contructor instead
+    @Deprecated // Use the default constructor instead
     public static Faker instance() {
         return new Faker();
     }
@@ -102,52 +105,58 @@ public class Faker {
      * @return Returns locale being used
      */
     public Locale getLocale() {
-        return fakeValuesService.getLocalesChain().isEmpty() || fakeValuesService.getLocalesChain().get(0) == null
-            ? Locale.ROOT : fakeValuesService.getLocalesChain().get(0);
+        return context.getLocale() == null
+            ? Locale.ROOT : context.getLocale();
+    }
+
+    public FakerContext getContext() {
+        return context;
     }
 
     public <T> T doWith(Callable<T> callable, Locale locale) {
-        final Locale current = fakeValuesService.getCurrentLocale();
+        final Locale current = context.getLocale();
         T result;
         try {
-            fakeValuesService.setCurrentLocale(locale);
+            context.setCurrentLocale(locale);
+            fakeValuesService.updateFakeValuesInterfaceMap(context.getLocaleChain());
             result = callable.call();
             return result;
         } catch (Throwable t) {
             throw new RuntimeException(t);
         } finally {
-            fakeValuesService.setCurrentLocale(current);
+            context.setCurrentLocale(current);
+            fakeValuesService.updateFakeValuesInterfaceMap(context.getLocaleChain());
         }
     }
 
     public <T> T doWith(Callable<T> callable, long seed) {
-        final RandomService current = fakeValuesService.getCurrentRandomService();
+        final RandomService current = context.getRandomService();
         T result;
         try {
-            fakeValuesService.setCurrentRandomService(new RandomService(new Random(seed)));
+            context.setRandomService(new RandomService(new Random(seed)));
             result = callable.call();
             return result;
         } catch (Throwable t) {
             throw new RuntimeException(t);
         } finally {
-            fakeValuesService.setCurrentRandomService(current);
+            context.setRandomService(current);
         }
     }
 
     public <T> T doWith(Callable<T> callable, Locale locale, long seed) {
-        final Locale currentLocale = fakeValuesService.getCurrentLocale();
-        final RandomService currentRandomService = fakeValuesService.getCurrentRandomService();
+        final Locale currentLocale = context.getLocale();
+        final RandomService currentRandomService = context.getRandomService();
         T result;
         try {
-            fakeValuesService.setCurrentRandomService(new RandomService(new Random(seed)));
-            fakeValuesService.setCurrentLocale(locale);
+            context.setRandomService(new RandomService(new Random(seed)));
+            context.setCurrentLocale(locale);
             result = callable.call();
             return result;
         } catch (Throwable t) {
             throw new RuntimeException(t);
         } finally {
-            fakeValuesService.setCurrentRandomService(currentRandomService);
-            fakeValuesService.setCurrentLocale(currentLocale);
+            context.setRandomService(currentRandomService);
+            context.setCurrentLocale(currentLocale);
         }
     }
 
@@ -161,7 +170,7 @@ public class Faker {
      * @return Generated string
      */
     public String numerify(String numberString) {
-        return fakeValuesService.numerify(numberString);
+        return fakeValuesService.numerify(numberString, context);
     }
 
     /**
@@ -174,7 +183,7 @@ public class Faker {
      * @return Generated string.
      */
     public String letterify(String letterString) {
-        return fakeValuesService.letterify(letterString);
+        return fakeValuesService.letterify(letterString, context);
     }
 
     /**
@@ -184,7 +193,7 @@ public class Faker {
      * For example, the string "12??34" could be replaced with a string like "12AB34".
      */
     public String letterify(String letterString, boolean isUpper) {
-        return fakeValuesService.letterify(letterString, isUpper);
+        return fakeValuesService.letterify(letterString, context, isUpper);
     }
 
     /**
@@ -192,7 +201,7 @@ public class Faker {
      * over the incoming string.
      */
     public String bothify(String string) {
-        return fakeValuesService.bothify(string);
+        return fakeValuesService.bothify(string, context);
     }
 
     /**
@@ -200,14 +209,14 @@ public class Faker {
      * over the incoming string.
      */
     public String bothify(String string, boolean isUpper) {
-        return fakeValuesService.bothify(string, isUpper);
+        return fakeValuesService.bothify(string, context, isUpper);
     }
 
     /**
      * Generates a String that matches the given regular expression.
      */
     public String regexify(String regex) {
-        return fakeValuesService.regexify(regex);
+        return fakeValuesService.regexify(regex, context);
     }
 
     /**
@@ -223,7 +232,7 @@ public class Faker {
      * @return The output string based on the input pattern
      */
     public String examplify(String example) {
-        return fakeValuesService.examplify(example);
+        return fakeValuesService.examplify(example, context);
     }
 
     /**
@@ -238,7 +247,7 @@ public class Faker {
      * @return Generated string
      */
     public String templatify(String string, char char2replace, String... options) {
-        return fakeValuesService().templatify(string, char2replace, options);
+        return fakeValuesService().templatify(string, char2replace, context, options);
     }
 
     /**
@@ -253,7 +262,7 @@ public class Faker {
      * @return Generated string
      */
     public String templatify(String string, Map<Character, String[]> optionsMap) {
-        return fakeValuesService().templatify(string, optionsMap);
+        return fakeValuesService().templatify(string, optionsMap, context);
     }
 
     /**
@@ -308,7 +317,7 @@ public class Faker {
     }
 
     public RandomService random() {
-        return this.randomService;
+        return this.context.getRandomService();
     }
 
     FakeValuesService fakeValuesService() {
@@ -327,11 +336,13 @@ public class Faker {
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends AbstractProvider> T getProvider(Class<T> clazz, Supplier<T> valueSupplier) {
-        T result = (T) providersMap.get(clazz);
+    public static <T extends AbstractProvider> T getProvider(Class<T> clazz, Function<Faker, T> valueSupplier, Faker faker) {
+        PROVIDERS_MAP.putIfAbsent(clazz, new ConcurrentHashMap<>());
+        Map<FakerContext, AbstractProvider> map = PROVIDERS_MAP.get(clazz);
+        T result = (T) map.get(faker.getContext());
         if (result == null) {
-            providersMap.putIfAbsent(clazz, valueSupplier.get());
-            result = (T) providersMap.get(clazz);
+            result = valueSupplier.apply(faker);
+            map.putIfAbsent(faker.getContext(), result);
         }
         return result;
     }
@@ -354,706 +365,710 @@ public class Faker {
     }
 
     public Address address() {
-        return getProvider(Address.class, () -> new Address(this));
+        return getProvider(Address.class, Address::new, this);
     }
 
     public Ancient ancient() {
-        return getProvider(Ancient.class, () -> new Ancient(this));
+        return getProvider(Ancient.class, Ancient::new, this);
     }
 
     public Animal animal() {
-        return getProvider(Animal.class, () -> new Animal(this));
+        return getProvider(Animal.class, Animal::new, this);
     }
 
     public App app() {
-        return getProvider(App.class, () -> new App(this));
+        return getProvider(App.class, App::new, this);
     }
 
     public Appliance appliance() {
-        return getProvider(Appliance.class, () -> new Appliance(this));
+        return getProvider(Appliance.class, Appliance::new, this);
     }
 
     public AquaTeenHungerForce aquaTeenHungerForce() {
-        return getProvider(AquaTeenHungerForce.class, () -> new AquaTeenHungerForce(this));
+        return getProvider(AquaTeenHungerForce.class, AquaTeenHungerForce::new, this);
     }
 
     public Artist artist() {
-        return getProvider(Artist.class, () -> new Artist(this));
+        return getProvider(Artist.class, Artist::new, this);
     }
 
     public Australia australia() {
-        return getProvider(Australia.class, () -> new Australia(this));
+        return getProvider(Australia.class, Australia::new, this);
     }
 
     public Avatar avatar() {
-        return getProvider(Avatar.class, () -> new Avatar(this));
+        return getProvider(Avatar.class, Avatar::new, this);
     }
 
     public Aviation aviation() {
-        return getProvider(Aviation.class, () -> new Aviation(this));
+        return getProvider(Aviation.class, Aviation::new, this);
     }
 
     public Aws aws() {
-        return getProvider(Aws.class, () -> new Aws(this));
+        return getProvider(Aws.class, Aws::new, this);
     }
 
     public BackToTheFuture backToTheFuture() {
-        return getProvider(BackToTheFuture.class, () -> new BackToTheFuture(this));
+        return getProvider(BackToTheFuture.class, BackToTheFuture::new, this);
     }
 
     public Babylon5 babylon5() {
-        return getProvider(Babylon5.class, () -> new Babylon5(this));
+        return getProvider(Babylon5.class, Babylon5::new, this);
     }
 
     public Barcode barcode() {
-        return getProvider(Barcode.class, () -> new Barcode(this));
+        return getProvider(Barcode.class, Barcode::new, this);
     }
 
     public Basketball basketball() {
-        return getProvider(Basketball.class, () -> new Basketball(this));
+        return getProvider(Basketball.class, Basketball::new, this);
     }
 
     public Battlefield1 battlefield1() {
-        return getProvider(Battlefield1.class, () -> new Battlefield1(this));
+        return getProvider(Battlefield1.class, Battlefield1::new, this);
     }
 
     public Beer beer() {
-        return getProvider(Beer.class, () -> new Beer(this));
+        return getProvider(Beer.class, Beer::new, this);
     }
 
     public BigBangTheory bigBangTheory() {
-        return getProvider(BigBangTheory.class, () -> new BigBangTheory(this));
+        return getProvider(BigBangTheory.class, BigBangTheory::new, this);
     }
 
-    public BloodType bloodtype(){return getProvider(BloodType.class, () -> new BloodType(this));}
+    public BloodType bloodtype(){return getProvider(BloodType.class, BloodType::new, this);}
 
     public BojackHorseman bojackHorseman() {
-        return getProvider(BojackHorseman.class, () -> new BojackHorseman(this));
+        return getProvider(BojackHorseman.class, BojackHorseman::new, this);
     }
 
     public Book book() {
-        return getProvider(Book.class, () -> new Book(this));
+        return getProvider(Book.class, Book::new, this);
     }
 
     public Bool bool() {
-        return getProvider(Bool.class, () -> new Bool(this));
+        return getProvider(Bool.class, Bool::new, this);
     }
 
     public BossaNova bossaNova() {
-        return getProvider(BossaNova.class, () -> new BossaNova(this));
+        return getProvider(BossaNova.class, BossaNova::new, this);
     }
 
     public BreakingBad breakingBad() {
-        return getProvider(BreakingBad.class, () -> new BreakingBad(this));
+        return getProvider(BreakingBad.class, BreakingBad::new, this);
     }
 
     public BrooklynNineNine brooklynNineNine() {
-        return getProvider(BrooklynNineNine.class, () -> new BrooklynNineNine(this));
+        return getProvider(BrooklynNineNine.class, BrooklynNineNine::new, this);
     }
 
     public Buffy buffy() {
-        return getProvider(Buffy.class, () -> new Buffy(this));
+        return getProvider(Buffy.class, Buffy::new, this);
     }
 
     public Business business() {
-        return getProvider(Business.class, () -> new Business(this));
+        return getProvider(Business.class, Business::new, this);
     }
 
     public Camera camera() {
-        return getProvider(Camera.class, () -> new Camera(this));
+        return getProvider(Camera.class, Camera::new, this);
     }
 
     public Cannabis cannabis() {
-        return getProvider(Cannabis.class, () -> new Cannabis(this));
+        return getProvider(Cannabis.class, Cannabis::new, this);
     }
 
     public Cat cat() {
-        return getProvider(Cat.class, () -> new Cat(this));
+        return getProvider(Cat.class, Cat::new, this);
     }
 
     public ChuckNorris chuckNorris() {
-        return getProvider(ChuckNorris.class, () -> new ChuckNorris(this));
+        return getProvider(ChuckNorris.class, ChuckNorris::new, this);
     }
 
     public ClashOfClans clashOfClans() {
-        return getProvider(ClashOfClans.class, () -> new ClashOfClans(this));
+        return getProvider(ClashOfClans.class, ClashOfClans::new, this);
     }
 
     public Chiquito chiquito() {
-        return getProvider(Chiquito.class, () -> new Chiquito(this));
+        return getProvider(Chiquito.class, Chiquito::new, this);
     }
 
     public CNPJ cnpj() {
-        return getProvider(CNPJ.class, () -> new CNPJ(this));
+        return getProvider(CNPJ.class, CNPJ::new, this);
     }
 
     public Code code() {
-        return getProvider(Code.class, () -> new Code(this));
+        return getProvider(Code.class, Code::new, this);
     }
 
     public Coffee coffee() {
-        return getProvider(Coffee.class, () -> new Coffee(this));
+        return getProvider(Coffee.class, Coffee::new, this);
     }
 
     public Coin coin() {
-        return getProvider(Coin.class, () -> new Coin(this));
+        return getProvider(Coin.class, Coin::new, this);
     }
 
     public Color color() {
-        return getProvider(Color.class, () -> new Color(this));
+        return getProvider(Color.class, Color::new, this);
     }
 
     public Commerce commerce() {
-        return getProvider(Commerce.class, () -> new Commerce(this));
+        return getProvider(Commerce.class, Commerce::new, this);
     }
 
     public Community community() {
-        return getProvider(Community.class, () -> new Community(this));
+        return getProvider(Community.class, Community::new, this);
     }
 
     public Company company() {
-        return getProvider(Company.class, () -> new Company(this));
+        return getProvider(Company.class, Company::new, this);
     }
 
     public Computer computer() {
-        return getProvider(Computer.class, () -> new Computer(this));
+        return getProvider(Computer.class, Computer::new, this);
     }
 
     public Construction construction() {
-        return getProvider(Construction.class, () -> new Construction(this));
+        return getProvider(Construction.class, Construction::new, this);
     }
 
     public Money money() {
-        return getProvider(Money.class, () -> new Money(this));
+        return getProvider(Money.class, Money::new, this);
     }
 
     public Country country() {
-        return getProvider(Country.class, () -> new Country(this));
+        return getProvider(Country.class, Country::new, this);
     }
 
     public CPF cpf() {
-        return getProvider(CPF.class, () -> new CPF(this));
+        return getProvider(CPF.class, CPF::new, this);
     }
 
     public Hashing hashing() {
-        return getProvider(Hashing.class, () -> new Hashing(this));
+        return getProvider(Hashing.class, Hashing::new, this);
     }
 
     public CryptoCoin cryptoCoin() {
-        return getProvider(CryptoCoin.class, () -> new CryptoCoin(this));
+        return getProvider(CryptoCoin.class, CryptoCoin::new, this);
     }
 
     public Currency currency() {
-        return getProvider(Currency.class, () -> new Currency(this));
+        return getProvider(Currency.class, Currency::new, this);
     }
 
     public DarkSoul darkSoul(){
-        return getProvider(DarkSoul.class, () -> new DarkSoul(this));
+        return getProvider(DarkSoul.class, DarkSoul::new, this);
     }
 
     public DateAndTime date() {
-        return getProvider(DateAndTime.class, () -> new DateAndTime(this));
+        return getProvider(DateAndTime.class, DateAndTime::new, this);
     }
 
     public Disease disease() {
-        return getProvider(Disease.class, () -> new Disease(this));
+        return getProvider(Disease.class, Disease::new, this);
     }
 
     public Demographic demographic() {
-        return getProvider(Demographic.class, () -> new Demographic(this));
+        return getProvider(Demographic.class, Demographic::new, this);
     }
 
     public DcComics dcComics () {
-        return getProvider(DcComics.class, () -> new DcComics(this));
+        return getProvider(DcComics.class, DcComics::new, this);
     }
 
     public Departed departed() {
-        return getProvider(Departed.class, () -> new Departed(this));
+        return getProvider(Departed.class, Departed::new, this);
     }
 
     public Dessert dessert() {
-        return getProvider(Dessert.class, () -> new Dessert(this));
+        return getProvider(Dessert.class, Dessert::new, this);
     }
 
     public Device device() {
-        return getProvider(Device.class, () -> new Device(this));
+        return getProvider(Device.class, Device::new, this);
     }
 
     public Dog dog() {
-        return getProvider(Dog.class, () -> new Dog(this));
+        return getProvider(Dog.class, Dog::new, this);
     }
 
     public Domain domain() {
-        return getProvider(Domain.class, () -> new Domain(this));
+        return getProvider(Domain.class, Domain::new, this);
     }
 
     public DragonBall dragonBall() {
-        return getProvider(DragonBall.class, () -> new DragonBall(this));
+        return getProvider(DragonBall.class, DragonBall::new, this);
     }
 
     public DrivingLicense drivingLicense() {
-        return getProvider(DrivingLicense.class, () -> new DrivingLicense(this));
+        return getProvider(DrivingLicense.class, DrivingLicense::new, this);
     }
 
     public DumbAndDumber dumbAndDumber() {
-        return getProvider(DumbAndDumber.class, () -> new DumbAndDumber(this));
+        return getProvider(DumbAndDumber.class, DumbAndDumber::new, this);
     }
 
     public Dune dune() {
-        return getProvider(Dune.class, () -> new Dune(this));
+        return getProvider(Dune.class, Dune::new, this);
     }
 
     public Educator educator() {
-        return getProvider(Educator.class, () -> new Educator(this));
+        return getProvider(Educator.class, Educator::new, this);
     }
 
     public EldenRing eldenRing() {
-        return getProvider(EldenRing.class, () -> new EldenRing(this));
+        return getProvider(EldenRing.class, EldenRing::new, this);
     }
 
     public ElderScrolls elderScrolls() {
-        return getProvider(ElderScrolls.class, () -> new ElderScrolls(this));
+        return getProvider(ElderScrolls.class, ElderScrolls::new, this);
     }
 
     public EnglandFootBall englandfootball() {
-        return getProvider(EnglandFootBall.class, () -> new EnglandFootBall(this));
+        return getProvider(EnglandFootBall.class, EnglandFootBall::new, this);
     }
 
     public ElectricalComponents electricalComponents() {
-        return getProvider(ElectricalComponents.class, () -> new ElectricalComponents(this));
+        return getProvider(ElectricalComponents.class, ElectricalComponents::new, this);
     }
 
     public Esports esports() {
-        return getProvider(Esports.class, () -> new Esports(this));
+        return getProvider(Esports.class, Esports::new, this);
     }
 
     public FakeDuration duration() {
-        return getProvider(FakeDuration.class, () -> new FakeDuration(this));
+        return getProvider(FakeDuration.class, FakeDuration::new, this);
     }
 
     public Fallout fallout() {
-        return getProvider(Fallout.class, () -> new Fallout(this));
+        return getProvider(Fallout.class, Fallout::new, this);
     }
 
     public FamousLastWords famousLastWords() {
-        return getProvider(FamousLastWords.class, () -> new FamousLastWords(this));
+        return getProvider(FamousLastWords.class, FamousLastWords::new, this);
     }
 
     public File file() {
-        return getProvider(File.class, () -> new File(this));
+        return getProvider(File.class, File::new, this);
     }
 
     public FinalSpace finalSpace() {
-        return getProvider(FinalSpace.class, () -> new FinalSpace(this));
+        return getProvider(FinalSpace.class, FinalSpace::new, this);
     }
 
     public Finance finance() {
-        return getProvider(Finance.class, () -> new Finance(this));
+        return getProvider(Finance.class, Finance::new, this);
     }
 
     public Food food() {
-        return getProvider(Food.class, () -> new Food(this));
+        return getProvider(Food.class, Food::new, this);
     }
 
     public Football football() {
-        return getProvider(Football.class, () -> new Football(this));
+        return getProvider(Football.class, Football::new, this);
     }
 
     public Formula1 formula1() {
-        return getProvider(Formula1.class, () -> new Formula1(this));
+        return getProvider(Formula1.class, Formula1::new, this);
     }
 
     public Friends friends() {
-        return getProvider(Friends.class, () -> new Friends(this));
+        return getProvider(Friends.class, Friends::new, this);
     }
 
     public FunnyName funnyName() {
-        return getProvider(FunnyName.class, () -> new FunnyName(this));
+        return getProvider(FunnyName.class, FunnyName::new, this);
     }
 
     public GameOfThrones gameOfThrones() {
-        return getProvider(GameOfThrones.class, () -> new GameOfThrones(this));
+        return getProvider(GameOfThrones.class, GameOfThrones::new, this);
     }
 
     public GarmentSize garmentSize() {
-      return getProvider(GarmentSize.class, () -> new GarmentSize(this));
+      return getProvider(GarmentSize.class, GarmentSize::new, this);
     }
 
     public Gender gender() {
-        return getProvider(Gender.class, () -> new Gender(this));
+        return getProvider(Gender.class, Gender::new, this);
     }
 
     public Ghostbusters ghostbusters() {
-        return getProvider(Ghostbusters.class, () -> new Ghostbusters(this));
+        return getProvider(Ghostbusters.class, Ghostbusters::new, this);
     }
 
     public GratefulDead gratefulDead() {
-        return getProvider(GratefulDead.class, () -> new GratefulDead(this));
+        return getProvider(GratefulDead.class, GratefulDead::new, this);
     }
 
     public GreekPhilosopher greekPhilosopher() {
-        return getProvider(GreekPhilosopher.class, () -> new GreekPhilosopher(this));
+        return getProvider(GreekPhilosopher.class, GreekPhilosopher::new, this);
     }
 
     public Hacker hacker() {
-        return getProvider(Hacker.class, () -> new Hacker(this));
+        return getProvider(Hacker.class, Hacker::new, this);
     }
 
     public HarryPotter harryPotter() {
-        return getProvider(HarryPotter.class, () -> new HarryPotter(this));
+        return getProvider(HarryPotter.class, HarryPotter::new, this);
     }
 
     public Hearthstone hearthstone() {
-        return getProvider(Hearthstone.class, () -> new Hearthstone(this));
+        return getProvider(Hearthstone.class, Hearthstone::new, this);
     }
 
     public HeyArnold heyArnold() {
-        return getProvider(HeyArnold.class, () -> new HeyArnold(this));
+        return getProvider(HeyArnold.class, HeyArnold::new, this);
     }
 
     public Hipster hipster() {
-        return getProvider(Hipster.class, () -> new Hipster(this));
+        return getProvider(Hipster.class, Hipster::new, this);
     }
 
     public HitchhikersGuideToTheGalaxy hitchhikersGuideToTheGalaxy() {
-        return getProvider(HitchhikersGuideToTheGalaxy.class, () -> new HitchhikersGuideToTheGalaxy(this));
+        return getProvider(HitchhikersGuideToTheGalaxy.class, HitchhikersGuideToTheGalaxy::new, this);
     }
 
     public Hobbit hobbit() {
-        return getProvider(Hobbit.class, () -> new Hobbit(this));
+        return getProvider(Hobbit.class, Hobbit::new, this);
     }
 
     public Hobby hobby() {
-        return getProvider(Hobby.class, () -> new Hobby(this));
+        return getProvider(Hobby.class, Hobby::new, this);
     }
 
     public Hololive hololive() {
-        return getProvider(Hololive.class, () -> new Hololive(this));
+        return getProvider(Hololive.class, Hololive::new, this);
     }
 
     public Horse horse() {
-        return getProvider(Horse.class, () -> new Horse(this));
+        return getProvider(Horse.class, Horse::new, this);
     }
 
     public House house() {
-        return getProvider(House.class, () -> new House(this));
+        return getProvider(House.class, House::new, this);
     }
 
     public HowIMetYourMother howIMetYourMother() {
-        return getProvider(HowIMetYourMother.class, () -> new HowIMetYourMother(this));
+        return getProvider(HowIMetYourMother.class, HowIMetYourMother::new, this);
     }
 
     public IdNumber idNumber() {
-        return getProvider(IdNumber.class, () -> new IdNumber(this));
+        return getProvider(IdNumber.class, IdNumber::new, this);
     }
 
     public IndustrySegments industrySegments() {
-        return getProvider(IndustrySegments.class, () -> new IndustrySegments(this));
+        return getProvider(IndustrySegments.class, IndustrySegments::new, this);
     }
 
     public Internet internet() {
-        return getProvider(Internet.class, () -> new Internet(this));
+        return getProvider(Internet.class, Internet::new, this);
     }
 
     public Job job() {
-        return getProvider(Job.class, () -> new Job(this));
+        return getProvider(Job.class, Job::new, this);
     }
 
     public Kaamelott kaamelott() {
-        return getProvider(Kaamelott.class, () -> new Kaamelott(this));
+        return getProvider(Kaamelott.class, Kaamelott::new, this);
     }
 
     public Kpop kpop() {
-        return getProvider(Kpop.class, () -> new Kpop(this));
+        return getProvider(Kpop.class, Kpop::new, this);
     }
 
     public Lebowski lebowski() {
-        return getProvider(Lebowski.class, () -> new Lebowski(this));
+        return getProvider(Lebowski.class, Lebowski::new, this);
     }
 
     public LeagueOfLegends leagueOfLegends() {
-        return getProvider(LeagueOfLegends.class, () -> new LeagueOfLegends(this));
+        return getProvider(LeagueOfLegends.class, LeagueOfLegends::new, this);
     }
 
     public LordOfTheRings lordOfTheRings() {
-        return getProvider(LordOfTheRings.class, () -> new LordOfTheRings(this));
+        return getProvider(LordOfTheRings.class, LordOfTheRings::new, this);
     }
 
     public Lorem lorem() {
-        return getProvider(Lorem.class, () -> new Lorem(this));
+        return getProvider(Lorem.class, Lorem::new, this);
     }
 
     public Marketing marketing() {
-        return getProvider(Marketing.class, () -> new Marketing(this));
+        return getProvider(Marketing.class, Marketing::new, this);
     }
 
     public MassEffect massEffect() {
-        return getProvider(MassEffect.class, () -> new MassEffect(this));
+        return getProvider(MassEffect.class, MassEffect::new, this);
     }
 
     public Matz matz() {
-        return getProvider(Matz.class, () -> new Matz(this));
+        return getProvider(Matz.class, Matz::new, this);
     }
 
-    public Mbti mbti() {return getProvider(Mbti.class, () -> new Mbti(this));}
+    public Mbti mbti() {return getProvider(Mbti.class, Mbti::new, this);}
 
     public Measurement measurement() {
-        return getProvider(Measurement.class, () -> new Measurement(this));
+        return getProvider(Measurement.class, Measurement::new, this);
     }
 
     public Medical medical() {
-        return getProvider(Medical.class, () -> new Medical(this));
+        return getProvider(Medical.class, Medical::new, this);
     }
 
     public Military military() {
-        return getProvider(Military.class, () -> new Military(this));
+        return getProvider(Military.class, Military::new, this);
     }
 
     public Minecraft minecraft() {
-        return getProvider(Minecraft.class, () -> new Minecraft(this));
+        return getProvider(Minecraft.class, Minecraft::new, this);
     }
 
     public Mood mood() {
-        return getProvider(Mood.class, () -> new Mood(this));
+        return getProvider(Mood.class, Mood::new, this);
     }
 
     public Mountain mountain() {
-        return getProvider(Mountain.class, () -> new Mountain(this));
+        return getProvider(Mountain.class, Mountain::new, this);
     }
 
     public Mountaineering mountaineering() {
-        return getProvider(Mountaineering.class, () -> new Mountaineering(this));
+        return getProvider(Mountaineering.class, Mountaineering::new, this);
     }
 
     public Movie movie() {
-        return getProvider(Movie.class, () -> new Movie(this));
+        return getProvider(Movie.class, Movie::new, this);
     }
 
     public Music music() {
-        return getProvider(Music.class, () -> new Music(this));
+        return getProvider(Music.class, Music::new, this);
     }
 
     public Name name() {
-        return getProvider(Name.class, () -> new Name(this));
+        return getProvider(Name.class, Name::new, this);
     }
 
     public Nation nation() {
-        return getProvider(Nation.class, () -> new Nation(this));
+        return getProvider(Nation.class, Nation::new, this);
     }
 
     public NatoPhoneticAlphabet natoPhoneticAlphabet() {
-        return getProvider(NatoPhoneticAlphabet.class, () -> new NatoPhoneticAlphabet(this));
+        return getProvider(NatoPhoneticAlphabet.class, NatoPhoneticAlphabet::new, this);
     }
 
     public Nigeria nigeria() {
-        return getProvider(Nigeria.class, () -> new Nigeria(this));
+        return getProvider(Nigeria.class, Nigeria::new, this);
     }
 
     public Number number() {
-        return getProvider(Number.class, () -> new Number(this));
+        return getProvider(Number.class, Number::new, this);
     }
 
     public Options options() {
-        return getProvider(Options.class, () -> new Options(this));
+        return getProvider(Options.class, Options::new, this);
     }
 
     public Overwatch overwatch() {
-        return getProvider(Overwatch.class, () -> new Overwatch(this));
+        return getProvider(Overwatch.class, Overwatch::new, this);
     }
 
-    public OscarMovie oscarMovie(){return getProvider(OscarMovie.class, () -> new OscarMovie(this));}
+    public OscarMovie oscarMovie(){return getProvider(OscarMovie.class, OscarMovie::new, this);}
 
     public Passport passport() {
-        return getProvider(Passport.class, () -> new Passport(this));
+        return getProvider(Passport.class, Passport::new, this);
     }
 
     public Password password() {
-        return getProvider(Password.class, () -> new Password(this));
+        return getProvider(Password.class, Password::new, this);
     }
 
     public PhoneNumber phoneNumber() {
-        return getProvider(PhoneNumber.class, () -> new PhoneNumber(this));
+        return getProvider(PhoneNumber.class, PhoneNumber::new, this);
     }
 
     public Photography photography() {
-        return getProvider(Photography.class, () -> new Photography(this));
+        return getProvider(Photography.class, Photography::new, this);
     }
 
     public Pokemon pokemon() {
-        return getProvider(Pokemon.class, () -> new Pokemon(this));
+        return getProvider(Pokemon.class, Pokemon::new, this);
     }
 
     public PrincessBride princessBride() {
-        return getProvider(PrincessBride.class, () -> new PrincessBride(this));
+        return getProvider(PrincessBride.class, PrincessBride::new, this);
     }
 
     public ProgrammingLanguage programmingLanguage() {
-        return getProvider(ProgrammingLanguage.class, () -> new ProgrammingLanguage(this));
+        return getProvider(ProgrammingLanguage.class, ProgrammingLanguage::new, this);
     }
 
     public Relationship relationships() {
-        return getProvider(Relationship.class, () -> new Relationship(this));
+        return getProvider(Relationship.class, Relationship::new, this);
     }
 
     public ResidentEvil residentEvil() {
-        return getProvider(ResidentEvil.class, () -> new ResidentEvil(this));
+        return getProvider(ResidentEvil.class, ResidentEvil::new, this);
     }
 
     public Restaurant restaurant() {
-        return getProvider(Restaurant.class, () -> new Restaurant(this));
+        return getProvider(Restaurant.class, Restaurant::new, this);
     }
 
     public RickAndMorty rickAndMorty() {
-        return getProvider(RickAndMorty.class, () -> new RickAndMorty(this));
+        return getProvider(RickAndMorty.class, RickAndMorty::new, this);
     }
 
     public Robin robin() {
-        return getProvider(Robin.class, () -> new Robin(this));
+        return getProvider(Robin.class, Robin::new, this);
     }
 
     public RockBand rockBand() {
-        return getProvider(RockBand.class, () -> new RockBand(this));
+        return getProvider(RockBand.class, RockBand::new, this);
     }
 
     public RuPaulDragRace ruPaulDragRace() {
-        return getProvider(RuPaulDragRace.class, () -> new RuPaulDragRace(this));
+        return getProvider(RuPaulDragRace.class, RuPaulDragRace::new, this);
     }
 
     public Science science() {
-        return getProvider(Science.class, () -> new Science(this));
+        return getProvider(Science.class, Science::new, this);
     }
 
     public Seinfeld seinfeld() {
-        return getProvider(Seinfeld.class, () -> new Seinfeld(this));
+        return getProvider(Seinfeld.class, Seinfeld::new, this);
     }
 
     public SlackEmoji slackEmoji() {
-        return getProvider(SlackEmoji.class, () -> new SlackEmoji(this));
+        return getProvider(SlackEmoji.class, SlackEmoji::new, this);
     }
 
     public Shakespeare shakespeare() {
-        return getProvider(Shakespeare.class, () -> new Shakespeare(this));
+        return getProvider(Shakespeare.class, Shakespeare::new, this);
     }
 
     public Sip sip() {
-        return getProvider(Sip.class, () -> new Sip(this));
+        return getProvider(Sip.class, Sip::new, this);
     }
 
     public Size size() {
-        return getProvider(Size.class, () -> new Size(this));
+        return getProvider(Size.class, Size::new, this);
     }
 
     public Simpsons simpsons() {
-        return getProvider(Simpsons.class, () -> new Simpsons(this));
+        return getProvider(Simpsons.class, Simpsons::new, this);
     }
 
     public SoulKnight soulKnight() {
-        return getProvider(SoulKnight.class, () -> new SoulKnight(this));
+        return getProvider(SoulKnight.class, SoulKnight::new, this);
     }
 
     public Space space() {
-        return getProvider(Space.class, () -> new Space(this));
+        return getProvider(Space.class, Space::new, this);
     }
 
     public StarCraft starCraft() {
-        return getProvider(StarCraft.class, () -> new StarCraft(this));
+        return getProvider(StarCraft.class, StarCraft::new, this);
     }
 
     public StarTrek starTrek() {
-        return getProvider(StarTrek.class, () -> new StarTrek(this));
+        return getProvider(StarTrek.class, StarTrek::new, this);
     }
     
     public StarWars starWars() { 
-        return getProvider(StarWars.class, () -> new StarWars(this)); 
+        return getProvider(StarWars.class, StarWars::new, this);
     }
 
     public Stock stock() {
-        return getProvider(Stock.class, () -> new Stock(this));
+        return getProvider(Stock.class, Stock::new, this);
     }
 
     public Subscription subscription() {
-        return getProvider(Subscription.class, () -> new Subscription(this));
+        return getProvider(Subscription.class, Subscription::new, this);
     }
 
     public Superhero superhero() {
-        return getProvider(Superhero.class, () -> new Superhero(this));
+        return getProvider(Superhero.class, Superhero::new, this);
     }
 
     public SuperMario superMario() {
-        return getProvider(SuperMario.class, () -> new SuperMario(this));
+        return getProvider(SuperMario.class, SuperMario::new, this);
     }
 
     public Tea tea() {
-        return getProvider(Tea.class, () -> new Tea(this));
+        return getProvider(Tea.class, Tea::new, this);
     }
 
     public Team team() {
-        return getProvider(Team.class, () -> new Team(this));
+        return getProvider(Team.class, Team::new, this);
     }
 
     public TheItCrowd theItCrowd() {
-        return getProvider(TheItCrowd.class, () -> new TheItCrowd(this));
+        return getProvider(TheItCrowd.class, TheItCrowd::new, this);
     }
 
     public Time time() {
-        return getProvider(Time.class, () -> new Time(this));
+        return getProvider(Time.class, Time::new, this);
     }
 
     public Touhou touhou() {
-        return getProvider(Touhou.class, () -> new Touhou(this));
+        return getProvider(Touhou.class, Touhou::new, this);
     }
 
     public Tron tron() {
-        return getProvider(Tron.class, () -> new Tron(this));
+        return getProvider(Tron.class, Tron::new, this);
     }
 
     public TwinPeaks twinPeaks() {
-        return getProvider(TwinPeaks.class, () -> new TwinPeaks(this));
+        return getProvider(TwinPeaks.class, TwinPeaks::new, this);
     }
 
     public Twitter twitter() {
-        return getProvider(Twitter.class, () -> new Twitter(this));
+        return getProvider(Twitter.class, Twitter::new, this);
     }
 
     public Unique unique() {
-        return getProvider(Unique.class, () -> new Unique(this));
+        return getProvider(Unique.class, Unique::new, this);
     }
 
     public University university() {
-        return getProvider(University.class, () -> new University(this));
+        return getProvider(University.class, University::new, this);
     }
 
     public Vehicle vehicle() {
-        return getProvider(Vehicle.class, () -> new Vehicle(this));
+        return getProvider(Vehicle.class, Vehicle::new, this);
     }
 
     public Verb verb() {
-        return getProvider(Verb.class, () -> new Verb(this));
+        return getProvider(Verb.class, Verb::new, this);
     }
 
     public Volleyball volleyball() {
-        return getProvider(Volleyball.class, () -> new Volleyball(this));
+        return getProvider(Volleyball.class, Volleyball::new, this);
     }
 
     public Weather weather() {
-        return getProvider(Weather.class, () -> new Weather(this));
+        return getProvider(Weather.class, Weather::new, this);
     }
 
     public Witcher witcher() {
-        return getProvider(Witcher.class, () -> new Witcher(this));
+        return getProvider(Witcher.class, Witcher::new, this);
     }
 
     public Yoda yoda() {
-        return getProvider(Yoda.class, () -> new Yoda(this));
+        return getProvider(Yoda.class, Yoda::new, this);
     }
 
     public Zelda zelda() {
-        return getProvider(Zelda.class, () -> new Zelda(this));
+        return getProvider(Zelda.class, Zelda::new, this);
     }
 
 
     public String resolve(String key) {
-        return this.fakeValuesService.resolve(key, this, this);
+        return this.fakeValuesService.resolve(key, this, this, context);
+    }
+
+    public String resolve(String key, Supplier<String> message) {
+        return this.fakeValuesService.resolve(key, this, this, message, context);
     }
 
     /**
@@ -1074,7 +1089,7 @@ public class Faker {
      * @throws RuntimeException if unable to evaluate the expression
      */
     public String expression(String expression) {
-        return this.fakeValuesService.expression(expression, this);
+        return this.fakeValuesService.expression(expression, this, getContext());
     }
 
 }

--- a/src/main/java/net/datafaker/Fallout.java
+++ b/src/main/java/net/datafaker/Fallout.java
@@ -12,18 +12,18 @@ public class Fallout extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("fallout.characters");
+        return resolve("fallout.characters");
     }
 
     public String faction() {
-        return faker.resolve("fallout.factions");
+        return resolve("fallout.factions");
     }
 
     public String location() {
-        return faker.resolve("fallout.locations");
+        return resolve("fallout.locations");
     }
 
     public String quote() {
-        return faker.resolve("fallout.quotes");
+        return resolve("fallout.quotes");
     }
 }

--- a/src/main/java/net/datafaker/FamousLastWords.java
+++ b/src/main/java/net/datafaker/FamousLastWords.java
@@ -15,6 +15,6 @@ public class FamousLastWords extends AbstractProvider {
      * @return a string of last words.
      */
     public String lastWords() {
-        return faker.fakeValuesService().resolve("famous_last_words.last_words", this);
+        return resolve("famous_last_words.last_words");
     }
 }

--- a/src/main/java/net/datafaker/File.java
+++ b/src/main/java/net/datafaker/File.java
@@ -10,11 +10,11 @@ public class File extends AbstractProvider {
     }
 
     public String extension() {
-        return faker.resolve("file.extension");
+        return resolve("file.extension");
     }
 
     public String mimeType() {
-        return faker.resolve("file.mime_type");
+        return resolve("file.mime_type");
     }
 
     public String fileName() {

--- a/src/main/java/net/datafaker/FinalSpace.java
+++ b/src/main/java/net/datafaker/FinalSpace.java
@@ -12,15 +12,15 @@ public class FinalSpace extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("final_space.characters");
+        return resolve("final_space.characters");
     }
 
     public String vehicle() {
-        return faker.resolve("final_space.vehicles");
+        return resolve("final_space.vehicles");
     }
 
     public String quote() {
-        return faker.resolve("final_space.quotes");
+        return resolve("final_space.quotes");
     }
 
 }

--- a/src/main/java/net/datafaker/Finance.java
+++ b/src/main/java/net/datafaker/Finance.java
@@ -16,15 +16,15 @@ public class Finance extends AbstractProvider {
     }
 
     public String nasdaqTicker() {
-        return faker.fakeValuesService().resolve("finance.ticker.nasdaq", this);
+        return resolve("finance.ticker.nasdaq");
     }
 
     public String nyseTicker() {
-        return faker.fakeValuesService().resolve("finance.ticker.nyse", this);
+        return resolve("finance.ticker.nyse");
     }
 
     public String stockMarket() {
-        return faker.fakeValuesService().resolve("finance.stock_market", this);
+        return resolve("finance.stock_market");
     }
 
     private static final Map<String, String> countryCodeToBasicBankAccountNumberPattern =
@@ -32,7 +32,7 @@ public class Finance extends AbstractProvider {
 
     public String creditCard(CreditCardType creditCardType) {
         final String key = String.format("finance.credit_card.%s", creditCardType.toString().toLowerCase(Locale.ROOT));
-        String value = faker.fakeValuesService().resolve(key, this);
+        String value = resolve(key);
         final String template = faker.numerify(value);
 
         String[] split = EMPTY_STRING.split(NUMBERS.matcher(template).replaceAll(""));

--- a/src/main/java/net/datafaker/Food.java
+++ b/src/main/java/net/datafaker/Food.java
@@ -10,31 +10,31 @@ public class Food extends AbstractProvider {
     }
 
     public String ingredient() {
-        return faker.fakeValuesService().resolve("food.ingredients", this);
+        return resolve("food.ingredients");
     }
 
     public String spice() {
-        return faker.fakeValuesService().resolve("food.spices", this);
+        return resolve("food.spices");
     }
 
     public String dish() {
-        return faker.fakeValuesService().resolve("food.dish", this);
+        return resolve("food.dish");
     }
 
     public String fruit() {
-        return faker.fakeValuesService().resolve("food.fruits", this);
+        return resolve("food.fruits");
     }
 
     public String vegetable() {
-        return faker.fakeValuesService().resolve("food.vegetables", this);
+        return resolve("food.vegetables");
     }
 
     public String sushi() {
-        return faker.fakeValuesService().resolve("food.sushi", this);
+        return resolve("food.sushi");
     }
 
     public String measurement() {
-        return faker.fakeValuesService().resolve("food.measurement_sizes", this) +
-            " " + faker.fakeValuesService().resolve("food.measurements", this);
+        return resolve("food.measurement_sizes") +
+            " " + resolve("food.measurements");
     }
 }

--- a/src/main/java/net/datafaker/Football.java
+++ b/src/main/java/net/datafaker/Football.java
@@ -10,23 +10,23 @@ public class Football extends AbstractProvider {
     }
 
     public String teams() {
-        return faker.fakeValuesService().resolve("football.teams", this);
+        return resolve("football.teams");
     }
 
     public String players() {
-        return faker.fakeValuesService().resolve("football.players", this);
+        return resolve("football.players");
     }
 
     public String coaches() {
-        return faker.fakeValuesService().resolve("football.coaches", this);
+        return resolve("football.coaches");
     }
 
     public String competitions() {
-        return faker.fakeValuesService().resolve("football.competitions", this);
+        return resolve("football.competitions");
     }
 
     public String positions() {
-        return faker.fakeValuesService().resolve("football.positions", this);
+        return resolve("football.positions");
     }
 
 }

--- a/src/main/java/net/datafaker/Formula1.java
+++ b/src/main/java/net/datafaker/Formula1.java
@@ -10,18 +10,18 @@ public class Formula1 extends AbstractProvider {
     }
 
     public String driver() {
-        return faker.fakeValuesService().resolve("formula1.driver", this);
+        return resolve("formula1.driver");
     }
 
     public String team() {
-        return faker.fakeValuesService().resolve("formula1.team", this);
+        return resolve("formula1.team");
     }
 
     public String circuit() {
-        return faker.fakeValuesService().resolve("formula1.circuit", this);
+        return resolve("formula1.circuit");
     }
 
     public String grandPrix() {
-        return faker.fakeValuesService().resolve("formula1.grand_prix", this);
+        return resolve("formula1.grand_prix");
     }
 }

--- a/src/main/java/net/datafaker/Friends.java
+++ b/src/main/java/net/datafaker/Friends.java
@@ -10,14 +10,14 @@ public class Friends extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("friends.characters");
+        return resolve("friends.characters");
     }
 
     public String location() {
-        return faker.resolve("friends.locations");
+        return resolve("friends.locations");
     }
 
     public String quote() {
-        return faker.resolve("friends.quotes");
+        return resolve("friends.quotes");
     }
 }

--- a/src/main/java/net/datafaker/FunnyName.java
+++ b/src/main/java/net/datafaker/FunnyName.java
@@ -10,6 +10,6 @@ public class FunnyName extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("funny_name.name", this);
+        return resolve("funny_name.name");
     }
 }

--- a/src/main/java/net/datafaker/GameOfThrones.java
+++ b/src/main/java/net/datafaker/GameOfThrones.java
@@ -10,22 +10,22 @@ public class GameOfThrones extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("game_of_thrones.characters");
+        return resolve("game_of_thrones.characters");
     }
 
     public String house() {
-        return faker.resolve("game_of_thrones.houses");
+        return resolve("game_of_thrones.houses");
     }
 
     public String city() {
-        return faker.resolve("game_of_thrones.cities");
+        return resolve("game_of_thrones.cities");
     }
 
     public String dragon() {
-        return faker.resolve("game_of_thrones.dragons");
+        return resolve("game_of_thrones.dragons");
     }
 
     public String quote() {
-        return faker.resolve("game_of_thrones.quotes");
+        return resolve("game_of_thrones.quotes");
     }
 }

--- a/src/main/java/net/datafaker/GarmentSize.java
+++ b/src/main/java/net/datafaker/GarmentSize.java
@@ -18,6 +18,6 @@ public class GarmentSize extends AbstractProvider {
    * @return a string of garment size
    */
   public String size() {
-    return faker.resolve("garments_sizes.sizes");
+    return resolve("garments_sizes.sizes");
   }
 }

--- a/src/main/java/net/datafaker/Gender.java
+++ b/src/main/java/net/datafaker/Gender.java
@@ -17,7 +17,7 @@ public class Gender extends AbstractProvider {
      * @return a string of gender type
      */
     public String types() {
-        return faker.fakeValuesService().fetchString("gender.types");
+        return resolve("gender.types");
     }
 
     /**
@@ -26,7 +26,7 @@ public class Gender extends AbstractProvider {
      * @return a string of binary gender type
      */
     public String binaryTypes() {
-        return faker.fakeValuesService().fetchString("gender.binary_types");
+        return resolve("gender.binary_types");
     }
 
     /**
@@ -35,6 +35,6 @@ public class Gender extends AbstractProvider {
      * @return a string of short binary gender type
      */
     public String shortBinaryTypes() {
-        return faker.fakeValuesService().fetchString("gender.short_binary_types");
+        return resolve("gender.short_binary_types");
     }
 }

--- a/src/main/java/net/datafaker/Ghostbusters.java
+++ b/src/main/java/net/datafaker/Ghostbusters.java
@@ -10,14 +10,14 @@ public class Ghostbusters extends AbstractProvider {
     }
 
     public String actor() {
-        return faker.resolve("ghostbusters.actors");
+        return resolve("ghostbusters.actors");
     }
 
     public String character() {
-        return faker.resolve("ghostbusters.characters");
+        return resolve("ghostbusters.characters");
     }
 
     public String quote() {
-        return faker.resolve("ghostbusters.quotes");
+        return resolve("ghostbusters.quotes");
     }
 }

--- a/src/main/java/net/datafaker/GratefulDead.java
+++ b/src/main/java/net/datafaker/GratefulDead.java
@@ -13,11 +13,11 @@ public class GratefulDead extends AbstractProvider {
     }
 
     public String players() {
-        return faker.fakeValuesService().resolve("grateful_dead.players", this);
+        return resolve("grateful_dead.players");
     }
 
     public String songs() {
-        return faker.fakeValuesService().resolve("grateful_dead.songs", this);
+        return resolve("grateful_dead.songs");
     }
 
 }

--- a/src/main/java/net/datafaker/GreekPhilosopher.java
+++ b/src/main/java/net/datafaker/GreekPhilosopher.java
@@ -15,7 +15,7 @@ public class GreekPhilosopher extends AbstractProvider {
      * @return a string of greek philosopher's name.
      */
     public String name() {
-        return faker.fakeValuesService().resolve("greek_philosophers.names", this);
+        return resolve("greek_philosophers.names");
     }
 
     /**
@@ -24,6 +24,6 @@ public class GreekPhilosopher extends AbstractProvider {
      * @return a string of greek philosopher's quote.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("greek_philosophers.quotes", this);
+        return resolve("greek_philosophers.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Hacker.java
+++ b/src/main/java/net/datafaker/Hacker.java
@@ -10,22 +10,22 @@ public class Hacker extends AbstractProvider {
     }
 
     public String abbreviation() {
-        return faker.fakeValuesService().resolve("hacker.abbreviation", this);
+        return resolve("hacker.abbreviation");
     }
 
     public String adjective() {
-        return faker.fakeValuesService().resolve("hacker.adjective", this);
+        return resolve("hacker.adjective");
     }
 
     public String noun() {
-        return faker.fakeValuesService().resolve("hacker.noun", this);
+        return resolve("hacker.noun");
     }
 
     public String verb() {
-        return faker.fakeValuesService().resolve("hacker.verb", this);
+        return resolve("hacker.verb");
     }
 
     public String ingverb() {
-        return faker.fakeValuesService().resolve("hacker.ingverb", this);
+        return resolve("hacker.ingverb");
     }
 }

--- a/src/main/java/net/datafaker/HarryPotter.java
+++ b/src/main/java/net/datafaker/HarryPotter.java
@@ -10,26 +10,26 @@ public class HarryPotter extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("harry_potter.characters");
+        return resolve("harry_potter.characters");
     }
 
     public String location() {
-        return faker.resolve("harry_potter.locations");
+        return resolve("harry_potter.locations");
     }
 
     public String quote() {
-        return faker.resolve("harry_potter.quotes");
+        return resolve("harry_potter.quotes");
     }
 
     public String book() {
-        return faker.resolve("harry_potter.books");
+        return resolve("harry_potter.books");
     }
 
     public String house() {
-        return faker.resolve("harry_potter.houses");
+        return resolve("harry_potter.houses");
     }
 
     public String spell() {
-        return faker.resolve("harry_potter.spells");
+        return resolve("harry_potter.spells");
     }
 }

--- a/src/main/java/net/datafaker/Hearthstone.java
+++ b/src/main/java/net/datafaker/Hearthstone.java
@@ -10,15 +10,15 @@ public class Hearthstone extends AbstractProvider {
     }
 
     public String mainProfession() {
-        return faker.resolve("games.hearthstone.professions");
+        return resolve("games.hearthstone.professions");
     }
 
     public String mainCharacter() {
-        return faker.fakeValuesService().resolve("games.hearthstone.characters", this);
+        return resolve("games.hearthstone.characters");
     }
 
     public String mainPattern() {
-        return faker.resolve("games.hearthstone.patterns");
+        return resolve("games.hearthstone.patterns");
     }
 
     public int battlegroundsScore() {
@@ -26,7 +26,7 @@ public class Hearthstone extends AbstractProvider {
     }
 
     public String standardRank() {
-        String rank = faker.resolve("games.hearthstone.rank");
+        String rank = resolve("games.hearthstone.rank");
         if (rank.equals("Legend")) {
             rank = rank + " " + faker.random().nextInt(1, 65000);
         } else {

--- a/src/main/java/net/datafaker/HeyArnold.java
+++ b/src/main/java/net/datafaker/HeyArnold.java
@@ -12,15 +12,15 @@ public class HeyArnold extends AbstractProvider {
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("hey_arnold.characters", this);
+        return resolve("hey_arnold.characters");
     }
 
     public String locations() {
-        return faker.fakeValuesService().resolve("hey_arnold.locations", this);
+        return resolve("hey_arnold.locations");
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("hey_arnold.quotes", this);
+        return resolve("hey_arnold.quotes");
     }
 
 }

--- a/src/main/java/net/datafaker/Hipster.java
+++ b/src/main/java/net/datafaker/Hipster.java
@@ -10,6 +10,6 @@ public class Hipster extends AbstractProvider {
     }
 
     public String word() {
-        return faker.resolve("hipster.words");
+        return resolve("hipster.words");
     }
 }

--- a/src/main/java/net/datafaker/HitchhikersGuideToTheGalaxy.java
+++ b/src/main/java/net/datafaker/HitchhikersGuideToTheGalaxy.java
@@ -10,30 +10,30 @@ public class HitchhikersGuideToTheGalaxy extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.characters", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.characters");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.locations", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.locations");
     }
 
     public String marvinQuote() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.marvin_quote", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.marvin_quote");
     }
 
     public String planet() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.planets", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.planets");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.quotes", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.quotes");
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.species", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.species");
     }
 
     public String starship() {
-        return faker.fakeValuesService().resolve("hitchhikers_guide_to_the_galaxy.starships", this);
+        return resolve("hitchhikers_guide_to_the_galaxy.starships");
     }
 }

--- a/src/main/java/net/datafaker/Hobbit.java
+++ b/src/main/java/net/datafaker/Hobbit.java
@@ -10,18 +10,18 @@ public class Hobbit extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("hobbit.character", this);
+        return resolve("hobbit.character");
     }
 
     public String thorinsCompany() {
-        return faker.fakeValuesService().resolve("hobbit.thorins_company", this);
+        return resolve("hobbit.thorins_company");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("hobbit.quote", this);
+        return resolve("hobbit.quote");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("hobbit.location", this);
+        return resolve("hobbit.location");
     }
 }

--- a/src/main/java/net/datafaker/Hobby.java
+++ b/src/main/java/net/datafaker/Hobby.java
@@ -10,7 +10,7 @@ public class Hobby extends AbstractProvider {
     }
 
     public String activity() {
-        return faker.fakeValuesService().resolve("hobby.activity", this);
+        return resolve("hobby.activity");
     }
 
 }

--- a/src/main/java/net/datafaker/Hololive.java
+++ b/src/main/java/net/datafaker/Hololive.java
@@ -10,6 +10,6 @@ public class Hololive extends AbstractProvider {
     }
 
     public String talent() {
-        return faker.resolve("hololive.talent");
+        return resolve("hololive.talent");
     }
 }

--- a/src/main/java/net/datafaker/Horse.java
+++ b/src/main/java/net/datafaker/Horse.java
@@ -10,11 +10,11 @@ public class Horse extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("creature.horse.name", this);
+        return resolve("creature.horse.name");
     }
 
     public String breed() {
-        return faker.fakeValuesService().resolve("creature.horse.breed", this);
+        return resolve("creature.horse.breed");
     }
 
 }

--- a/src/main/java/net/datafaker/House.java
+++ b/src/main/java/net/datafaker/House.java
@@ -15,7 +15,7 @@ public class House extends AbstractProvider {
      * @return a string of furniture.
      */
     public String furniture() {
-        return faker.fakeValuesService().resolve("house.furniture", this);
+        return resolve("house.furniture");
     }
 
     /**
@@ -24,6 +24,6 @@ public class House extends AbstractProvider {
      * @return a string of room.
      */
     public String room() {
-        return faker.fakeValuesService().resolve("house.rooms", this);
+        return resolve("house.rooms");
     }
 }

--- a/src/main/java/net/datafaker/HowIMetYourMother.java
+++ b/src/main/java/net/datafaker/HowIMetYourMother.java
@@ -10,18 +10,18 @@ public class HowIMetYourMother extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.character", this);
+        return resolve("how_i_met_your_mother.character");
     }
 
     public String catchPhrase() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.catch_phrase", this);
+        return resolve("how_i_met_your_mother.catch_phrase");
     }
 
     public String highFive() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.high_five", this);
+        return resolve("how_i_met_your_mother.high_five");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("how_i_met_your_mother.quote", this);
+        return resolve("how_i_met_your_mother.quote");
     }
 }

--- a/src/main/java/net/datafaker/IdNumber.java
+++ b/src/main/java/net/datafaker/IdNumber.java
@@ -24,11 +24,11 @@ public class IdNumber extends AbstractProvider {
     }
 
     public String valid() {
-        return faker.fakeValuesService().resolve("id_number.valid", this);
+        return resolve("id_number.valid");
     }
 
     public String invalid() {
-        return faker.numerify(faker.fakeValuesService().resolve("id_number.invalid", this));
+        return faker.numerify(faker.resolve("id_number.invalid"));
     }
 
     public String ssnValid() {

--- a/src/main/java/net/datafaker/IndustrySegments.java
+++ b/src/main/java/net/datafaker/IndustrySegments.java
@@ -10,19 +10,19 @@ public class IndustrySegments extends AbstractProvider {
     }
 
     public String industry() {
-        return faker.resolve("industry_segments.industry");
+        return resolve("industry_segments.industry");
     }
 
     public String superSector() {
-        return faker.resolve("industry_segments.super_sector");
+        return resolve("industry_segments.super_sector");
     }
 
     public String sector() {
-        return faker.resolve("industry_segments.sector");
+        return resolve("industry_segments.sector");
     }
 
     public String subSector() {
-        return faker.resolve("industry_segments.sub_sector");
+        return resolve("industry_segments.sub_sector");
     }
 
 }

--- a/src/main/java/net/datafaker/Internet.java
+++ b/src/main/java/net/datafaker/Internet.java
@@ -34,7 +34,7 @@ public class Internet extends AbstractProvider {
     }
 
     public String emailAddress(String localPart) {
-        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.free_email", this)));
+        return emailAddress(localPart, FakerIDN.toASCII(faker.resolve("internet.free_email")));
     }
 
     public String safeEmailAddress() {
@@ -42,7 +42,7 @@ public class Internet extends AbstractProvider {
     }
 
     public String safeEmailAddress(String localPart) {
-        return emailAddress(localPart, FakerIDN.toASCII(faker.fakeValuesService().resolve("internet.safe_email", this)));
+        return emailAddress(localPart, FakerIDN.toASCII(faker.resolve("internet.safe_email")));
     }
 
     private String emailAddress(String localPart, String domain) {
@@ -68,7 +68,7 @@ public class Internet extends AbstractProvider {
     }
 
     public String domainSuffix() {
-        return faker.fakeValuesService().resolve("internet.domain_suffix", this);
+        return resolve("internet.domain_suffix");
     }
 
     public String url() {
@@ -93,7 +93,7 @@ public class Internet extends AbstractProvider {
      * @see <a href="http://lorempixel.com/">lorempixel - Placeholder Images for every case</a>
      */
     public String image() {
-        String[] dimension = faker.fakeValuesService().resolve("internet.image_dimension", this).split("x");
+        String[] dimension = resolve("internet.image_dimension").split("x");
         if (dimension.length == 0) {
             return "";
         } else {
@@ -114,7 +114,7 @@ public class Internet extends AbstractProvider {
      */
     public String image(Integer width, Integer height, Boolean gray, String text) {
         return String.format("https://lorempixel.com/%s%s/%s/%s/%s",
-            gray ? "g/" : "", width, height, faker.fakeValuesService().resolve("internet.image_category", this),
+            gray ? "g/" : "", width, height, resolve("internet.image_category"),
             (text == null || text.length() == 0) ? "" : text);
     }
 
@@ -385,7 +385,7 @@ public class Internet extends AbstractProvider {
         }
 
         String userAgentKey = "internet.user_agent." + agent.toString();
-        return faker.fakeValuesService().resolve(userAgentKey, this);
+        return resolve(userAgentKey);
     }
 
     public String userAgentAny() {

--- a/src/main/java/net/datafaker/Job.java
+++ b/src/main/java/net/datafaker/Job.java
@@ -10,22 +10,22 @@ public class Job extends AbstractProvider {
     }
 
     public String field() {
-        return faker.fakeValuesService().resolve("job.field", this);
+        return resolve("job.field");
     }
 
     public String seniority() {
-        return faker.fakeValuesService().resolve("job.seniority", this);
+        return resolve("job.seniority");
     }
 
     public String position() {
-        return faker.fakeValuesService().resolve("job.position", this);
+        return resolve("job.position");
     }
 
     public String keySkills() {
-        return faker.fakeValuesService().resolve("job.key_skills", this);
+        return resolve("job.key_skills");
     }
 
     public String title() {
-        return faker.fakeValuesService().resolve("job.title", this);
+        return resolve("job.title");
     }
 }

--- a/src/main/java/net/datafaker/Kaamelott.java
+++ b/src/main/java/net/datafaker/Kaamelott.java
@@ -10,10 +10,10 @@ public class Kaamelott extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("kaamelott.characters", this);
+        return resolve("kaamelott.characters");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("kaamelott.quotes", this);
+        return resolve("kaamelott.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Kpop.java
+++ b/src/main/java/net/datafaker/Kpop.java
@@ -12,27 +12,27 @@ public class Kpop extends AbstractProvider {
     }
 
     public String iGroups() {
-        return faker.fakeValuesService().resolve("kpop.i_groups", this);
+        return resolve("kpop.i_groups");
     }
 
     public String iiGroups() {
-        return faker.fakeValuesService().resolve("kpop.ii_groups", this);
+        return resolve("kpop.ii_groups");
     }
 
     public String iiiGroups() {
-        return faker.fakeValuesService().resolve("kpop.iii_groups", this);
+        return resolve("kpop.iii_groups");
     }
 
     public String girlGroups() {
-        return faker.fakeValuesService().resolve("kpop.girl_groups", this);
+        return resolve("kpop.girl_groups");
     }
 
     public String boyBands() {
-        return faker.fakeValuesService().resolve("kpop.boy_bands", this);
+        return resolve("kpop.boy_bands");
     }
 
     public String solo() {
-        return faker.fakeValuesService().resolve("kpop.solo", this);
+        return resolve("kpop.solo");
     }
 
 }

--- a/src/main/java/net/datafaker/LeagueOfLegends.java
+++ b/src/main/java/net/datafaker/LeagueOfLegends.java
@@ -10,26 +10,26 @@ public class LeagueOfLegends extends AbstractProvider {
     }
 
     public String champion() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.champion", this);
+        return resolve("games.league_of_legends.champion");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.location", this);
+        return resolve("games.league_of_legends.location");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.quote", this);
+        return resolve("games.league_of_legends.quote");
     }
 
     public String summonerSpell() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.summoner_spell", this);
+        return resolve("games.league_of_legends.summoner_spell");
     }
 
     public String masteries() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.masteries", this);
+        return resolve("games.league_of_legends.masteries");
     }
 
     public String rank() {
-        return faker.fakeValuesService().resolve("games.league_of_legends.rank", this);
+        return resolve("games.league_of_legends.rank");
     }
 }

--- a/src/main/java/net/datafaker/Lebowski.java
+++ b/src/main/java/net/datafaker/Lebowski.java
@@ -10,14 +10,14 @@ public class Lebowski extends AbstractProvider {
     }
 
     public String actor() {
-        return faker.fakeValuesService().resolve("lebowski.actors", this);
+        return resolve("lebowski.actors");
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("lebowski.characters", this);
+        return resolve("lebowski.characters");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("lebowski.quotes", this);
+        return resolve("lebowski.quotes");
     }
 }

--- a/src/main/java/net/datafaker/LordOfTheRings.java
+++ b/src/main/java/net/datafaker/LordOfTheRings.java
@@ -10,10 +10,10 @@ public class LordOfTheRings extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("lord_of_the_rings.characters");
+        return resolve("lord_of_the_rings.characters");
     }
 
     public String location() {
-        return faker.resolve("lord_of_the_rings.locations");
+        return resolve("lord_of_the_rings.locations");
     }
 }

--- a/src/main/java/net/datafaker/Lorem.java
+++ b/src/main/java/net/datafaker/Lorem.java
@@ -77,7 +77,7 @@ public class Lorem extends AbstractProvider {
     }
 
     public String word() {
-        return faker.fakeValuesService().resolve("lorem.words", this);
+        return resolve("lorem.words");
     }
 
     /**

--- a/src/main/java/net/datafaker/Marketing.java
+++ b/src/main/java/net/datafaker/Marketing.java
@@ -12,6 +12,6 @@ public class Marketing extends AbstractProvider {
     }
 
     public String buzzwords() {
-        return faker.fakeValuesService().resolve("marketing.buzzwords", this);
+        return resolve("marketing.buzzwords");
     }
 }

--- a/src/main/java/net/datafaker/MassEffect.java
+++ b/src/main/java/net/datafaker/MassEffect.java
@@ -11,23 +11,23 @@ public class MassEffect extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("mass_effect.characters");
+        return resolve("mass_effect.characters");
     }
 
     public String specie() {
-        return faker.resolve("mass_effect.species");
+        return resolve("mass_effect.species");
     }
 
     public String cluster() {
-        return faker.resolve("mass_effect.cluster");
+        return resolve("mass_effect.cluster");
     }
 
     public String planet() {
-        return faker.resolve("mass_effect.planets");
+        return resolve("mass_effect.planets");
     }
 
     public String quote(){
-        return faker.resolve("mass_effect.quotes");
+        return resolve("mass_effect.quotes");
     }
 
 }

--- a/src/main/java/net/datafaker/Matz.java
+++ b/src/main/java/net/datafaker/Matz.java
@@ -10,6 +10,6 @@ public class Matz extends AbstractProvider {
     }
 
     public String quote() {
-        return faker.resolve("matz.quotes");
+        return resolve("matz.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Mbti.java
+++ b/src/main/java/net/datafaker/Mbti.java
@@ -15,24 +15,24 @@ public class Mbti extends AbstractProvider {
     }
 
     public String type() {
-        return faker.resolve("mbti.".concat(choice).concat(".type"));
+        return resolve("mbti.".concat(choice).concat(".type"));
     }
 
     public String name() {
-        return faker.resolve("mbti.".concat(choice).concat(".name"));
+        return resolve("mbti.".concat(choice).concat(".name"));
     }
 
     public String characteristic() {
-        return faker.resolve("mbti.".concat(choice).concat(".characteristic"));
+        return resolve("mbti.".concat(choice).concat(".characteristic"));
     }
 
     public String personage() {
-        return faker.resolve("mbti.".concat(choice).concat(".personage"));
+        return resolve("mbti.".concat(choice).concat(".personage"));
     }
 
-    public String merit(){return faker.resolve("mbti.".concat(choice).concat(".merit"));}
+    public String merit(){return resolve("mbti.".concat(choice).concat(".merit"));}
 
-    public String weakness(){return faker.resolve("mbti.".concat(choice).concat(".weakness"));}
+    public String weakness(){return resolve("mbti.".concat(choice).concat(".weakness"));}
 
 
 }

--- a/src/main/java/net/datafaker/Measurement.java
+++ b/src/main/java/net/datafaker/Measurement.java
@@ -15,7 +15,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of height measurement.
      */
     public String height() {
-        return faker.fakeValuesService().resolve("measurement.height", this);
+        return resolve("measurement.height");
     }
 
     /**
@@ -24,7 +24,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of length measurement.
      */
     public String length() {
-        return faker.fakeValuesService().resolve("measurement.length", this);
+        return resolve("measurement.length");
     }
 
     /**
@@ -33,7 +33,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of volume measurement.
      */
     public String volume() {
-        return faker.fakeValuesService().resolve("measurement.volume", this);
+        return resolve("measurement.volume");
     }
 
     /**
@@ -42,7 +42,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of weight measurement.
      */
     public String weight() {
-        return faker.fakeValuesService().resolve("measurement.weight", this);
+        return resolve("measurement.weight");
     }
 
     /**
@@ -51,7 +51,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of metric height measurement.
      */
     public String metricHeight() {
-        return faker.fakeValuesService().resolve("measurement.metric_height", this);
+        return resolve("measurement.metric_height");
     }
 
     /**
@@ -60,7 +60,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of metric length measurement.
      */
     public String metricLength() {
-        return faker.fakeValuesService().resolve("measurement.metric_length", this);
+        return resolve("measurement.metric_length");
     }
 
     /**
@@ -69,7 +69,7 @@ public class Measurement extends AbstractProvider {
      * @return a string of metric volume measurement.
      */
     public String metricVolume() {
-        return faker.fakeValuesService().resolve("measurement.metric_volume", this);
+        return resolve("measurement.metric_volume");
     }
 
     /**
@@ -78,6 +78,6 @@ public class Measurement extends AbstractProvider {
      * @return a string of metric weight measurement.
      */
     public String metricWeight() {
-        return faker.fakeValuesService().resolve("measurement.metric_weight", this);
+        return resolve("measurement.metric_weight");
     }
 }

--- a/src/main/java/net/datafaker/Medical.java
+++ b/src/main/java/net/datafaker/Medical.java
@@ -10,28 +10,28 @@ public class Medical extends AbstractProvider {
     }
 
     public String medicineName() {
-        return faker.fakeValuesService().resolve("medical.medicine_name", this);
+        return resolve("medical.medicine_name");
     }
 
     public String diseaseName() {
-        return faker.fakeValuesService().resolve("medical.disease_name", this);
+        return resolve("medical.disease_name");
     }
 
     public String hospitalName() {
-        return faker.fakeValuesService().resolve("medical.hospital_name", this);
+        return resolve("medical.hospital_name");
     }
 
     public String symptoms() {
-        return faker.fakeValuesService().resolve("medical.symptoms", this);
+        return resolve("medical.symptoms");
     }
 
     public String diagnosisCode() {
-        String regex = faker.fakeValuesService().resolve("medical.diagnosis_code.icd10", this);
+        String regex = resolve("medical.diagnosis_code.icd10");
         return faker.regexify(regex);
     }
 
     public String procedureCode() {
-        String regex = faker.fakeValuesService().resolve("medical.procedure_code.icd10", this);
+        String regex = resolve("medical.procedure_code.icd10");
         return faker.regexify(regex);
     }
 }

--- a/src/main/java/net/datafaker/Military.java
+++ b/src/main/java/net/datafaker/Military.java
@@ -12,23 +12,23 @@ public class Military extends AbstractProvider {
     }
 
     public String armyRank() {
-        return faker.fakeValuesService().resolve("military.army_rank", this);
+        return resolve("military.army_rank");
     }
 
     public String marinesRank() {
-        return faker.fakeValuesService().resolve("military.marines_rank", this);
+        return resolve("military.marines_rank");
     }
 
     public String navyRank() {
-        return faker.fakeValuesService().resolve("military.navy_rank", this);
+        return resolve("military.navy_rank");
     }
 
     public String airForceRank() {
-        return faker.fakeValuesService().resolve("military.air_force_rank", this);
+        return resolve("military.air_force_rank");
     }
 
     public String dodPaygrade() {
-        return faker.fakeValuesService().resolve("military.dod_paygrade", this);
+        return resolve("military.dod_paygrade");
     }
 
 }

--- a/src/main/java/net/datafaker/Minecraft.java
+++ b/src/main/java/net/datafaker/Minecraft.java
@@ -10,23 +10,23 @@ public class Minecraft extends AbstractProvider {
     }
 
     public String itemName() {
-        return faker.fakeValuesService().resolve("minecraft.item_name", this);
+        return resolve("minecraft.item_name");
     }
 
     public String tileName() {
-        return faker.fakeValuesService().resolve("minecraft.tile_name", this);
+        return resolve("minecraft.tile_name");
     }
 
     public String entityName() {
-        return faker.fakeValuesService().resolve("minecraft.entity_name", this);
+        return resolve("minecraft.entity_name");
     }
 
     public String monsterName() {
-        return faker.fakeValuesService().resolve("minecraft.monster_name", this);
+        return resolve("minecraft.monster_name");
     }
 
     public String animalName() {
-        return faker.fakeValuesService().resolve("minecraft.animal_name", this);
+        return resolve("minecraft.animal_name");
     }
 
     public String tileItemName() {

--- a/src/main/java/net/datafaker/Money.java
+++ b/src/main/java/net/datafaker/Money.java
@@ -17,7 +17,7 @@ public class Money extends AbstractProvider {
      * @return detailed currency value.
      */
     public String currency() {
-        return faker.fakeValuesService().resolve("money.currency", this);
+        return resolve("money.currency");
     }
 
     /**
@@ -26,6 +26,6 @@ public class Money extends AbstractProvider {
      * @return currency code.
      */
     public String currencyCode() {
-        return faker.fakeValuesService().resolve("money.code", this);
+        return resolve("money.code");
     }
 }

--- a/src/main/java/net/datafaker/Mood.java
+++ b/src/main/java/net/datafaker/Mood.java
@@ -10,15 +10,15 @@ public class Mood extends AbstractProvider {
     }
 
     public String feeling() {
-        return faker.fakeValuesService().resolve("mood.feeling", this);
+        return resolve("mood.feeling");
     }
 
     public String emotion() {
-        return faker.fakeValuesService().resolve("mood.emotion", this);
+        return resolve("mood.emotion");
     }
 
     public String tone() {
-        return faker.fakeValuesService().resolve("mood.tone", this);
+        return resolve("mood.tone");
     }
 
 }

--- a/src/main/java/net/datafaker/Mountain.java
+++ b/src/main/java/net/datafaker/Mountain.java
@@ -12,10 +12,10 @@ public class Mountain extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("mountain.name", this);
+        return resolve("mountain.name");
     }
 
     public String range() {
-        return faker.fakeValuesService().resolve("mountain.range", this);
+        return resolve("mountain.range");
     }
 }

--- a/src/main/java/net/datafaker/Mountaineering.java
+++ b/src/main/java/net/datafaker/Mountaineering.java
@@ -12,7 +12,7 @@ public class Mountaineering extends AbstractProvider {
     }
 
     public String mountaineer() {
-        return faker.fakeValuesService().resolve("mountaineering.mountaineer", this);
+        return resolve("mountaineering.mountaineer");
     }
 
 }

--- a/src/main/java/net/datafaker/Movie.java
+++ b/src/main/java/net/datafaker/Movie.java
@@ -15,6 +15,6 @@ public class Movie extends AbstractProvider {
      * @return a string of quote from a movie.
      */
     public String quote() {
-        return faker.fakeValuesService().resolve("movie.quote", this);
+        return resolve("movie.quote");
     }
 }

--- a/src/main/java/net/datafaker/Music.java
+++ b/src/main/java/net/datafaker/Music.java
@@ -14,7 +14,7 @@ public class Music extends AbstractProvider {
     }
 
     public String instrument() {
-        return faker.resolve("music.instruments");
+        return resolve("music.instruments");
     }
 
     public String key() {
@@ -26,6 +26,6 @@ public class Music extends AbstractProvider {
     }
 
     public String genre() {
-        return faker.resolve("music.genres");
+        return resolve("music.genres");
     }
 }

--- a/src/main/java/net/datafaker/Name.java
+++ b/src/main/java/net/datafaker/Name.java
@@ -24,7 +24,7 @@ public class Name extends AbstractProvider {
      * @return a random name with given and family names and an optional suffix.
      */
     public String name() {
-        return faker.fakeValuesService().resolve("name.name", this);
+        return resolve("name.name");
     }
 
     /**
@@ -40,7 +40,7 @@ public class Name extends AbstractProvider {
      * @return a random name with a middle name component with optional prefix and suffix
      */
     public String nameWithMiddle() {
-        return faker.fakeValuesService().resolve("name.name_with_middle", this);
+        return resolve("name.name_with_middle");
     }
 
     /**
@@ -58,7 +58,7 @@ public class Name extends AbstractProvider {
      * @return a 'given' name such as Aaliyah, Aaron, Abagail or Abbey
      */
     public String firstName() {
-        return faker.fakeValuesService().resolve("name.first_name", this);
+        return resolve("name.first_name");
     }
 
     /**
@@ -67,7 +67,7 @@ public class Name extends AbstractProvider {
      * @return a random last name such as Smith, Jones or Baldwin
      */
     public String lastName() {
-        return faker.fakeValuesService().resolve("name.last_name", this);
+        return resolve("name.last_name");
     }
 
     /**
@@ -76,7 +76,7 @@ public class Name extends AbstractProvider {
      * @return a name prefix such as Mr., Mrs., Ms., Miss, or Dr.
      */
     public String prefix() {
-        return faker.fakeValuesService().resolve("name.prefix", this);
+        return resolve("name.prefix");
     }
 
     /**
@@ -85,7 +85,7 @@ public class Name extends AbstractProvider {
      * @return a name suffix such as Jr., Sr., I, II, III, IV, V, MD, DDS, PhD or DVM
      */
     public String suffix() {
-        return faker.fakeValuesService().resolve("name.suffix", this);
+        return resolve("name.suffix");
     }
 
     /**
@@ -101,9 +101,9 @@ public class Name extends AbstractProvider {
      */
     public String title() {
         return String.join(" ",
-            faker.fakeValuesService().resolve("name.title.descriptor", this),
-            faker.fakeValuesService().resolve("name.title.level", this),
-            faker.fakeValuesService().resolve("name.title.job", this)
+            resolve("name.title.descriptor"),
+            resolve("name.title.level"),
+            resolve("name.title.job")
         );
     }
 

--- a/src/main/java/net/datafaker/Nation.java
+++ b/src/main/java/net/datafaker/Nation.java
@@ -19,20 +19,20 @@ public class Nation extends AbstractProvider {
     }
 
     public String nationality() {
-        return faker.fakeValuesService().resolve("nation.nationality", this);
+        return resolve("nation.nationality");
     }
 
     public String language() {
-        return faker.fakeValuesService().resolve("nation.language", this);
+        return resolve("nation.language");
     }
 
     public String capitalCity() {
-        return faker.fakeValuesService().resolve("nation.capital_city", this);
+        return resolve("nation.capital_city");
     }
 
     public String flag() {
         @SuppressWarnings("unchecked")
-        List<Integer> flagInts = (List<Integer>) faker.fakeValuesService().fetch("nation.flag");
+        List<Integer> flagInts = (List<Integer>) faker.fakeValuesService().fetch("nation.flag", faker.getContext());
 
         ByteBuffer byteBuffer = MappedByteBuffer.allocate(flagInts.size());
 

--- a/src/main/java/net/datafaker/NatoPhoneticAlphabet.java
+++ b/src/main/java/net/datafaker/NatoPhoneticAlphabet.java
@@ -12,7 +12,7 @@ public class NatoPhoneticAlphabet extends AbstractProvider {
     }
 
     public String codeWord() {
-        return faker.fakeValuesService().resolve("nato_phonetic_alphabet.code_word", this);
+        return resolve("nato_phonetic_alphabet.code_word");
     }
 
 }

--- a/src/main/java/net/datafaker/Nigeria.java
+++ b/src/main/java/net/datafaker/Nigeria.java
@@ -13,23 +13,23 @@ public class Nigeria extends AbstractProvider {
     }
 
     public String places() {
-        return faker.fakeValuesService().resolve(KEY + ".places", this);
+        return resolve(KEY + ".places");
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve(KEY + ".name", this);
+        return resolve(KEY + ".name");
     }
 
     public String food() {
-        return faker.fakeValuesService().resolve(KEY + ".food", this);
+        return resolve(KEY + ".food");
     }
 
     public String schools() {
-        return faker.fakeValuesService().resolve(KEY + ".schools", this);
+        return resolve(KEY + ".schools");
     }
 
     public String celebrities() {
-        return faker.fakeValuesService().resolve(KEY + ".celebrities", this);
+        return resolve(KEY + ".celebrities");
     }
 }
 

--- a/src/main/java/net/datafaker/OscarMovie.java
+++ b/src/main/java/net/datafaker/OscarMovie.java
@@ -46,7 +46,7 @@ public class OscarMovie extends AbstractProvider {
      * @return random actor
      */
     public String actor() {
-        return faker.resolve(str.concat(".actor"));
+        return resolve(str.concat(".actor"));
     }
 
     /**
@@ -55,7 +55,7 @@ public class OscarMovie extends AbstractProvider {
      * @return random movieName
      */
     public String movieName() {
-        return faker.resolve(str.concat(".movieName"));
+        return resolve(str.concat(".movieName"));
     }
 
     /**
@@ -64,7 +64,7 @@ public class OscarMovie extends AbstractProvider {
      * @return random quote
      */
     public String quote() {
-        return faker.resolve(str.concat(".quote"));
+        return resolve(str.concat(".quote"));
     }
 
     /**
@@ -73,7 +73,7 @@ public class OscarMovie extends AbstractProvider {
      * @return random character
      */
     public String character() {
-        return faker.resolve(str.concat(".character"));
+        return resolve(str.concat(".character"));
     }
 
     /**
@@ -82,6 +82,6 @@ public class OscarMovie extends AbstractProvider {
      * @return random releaseDate
      */
     public String releaseDate() {
-        return faker.resolve(str.concat(".releaseDate"));
+        return resolve(str.concat(".releaseDate"));
     }
 }

--- a/src/main/java/net/datafaker/Overwatch.java
+++ b/src/main/java/net/datafaker/Overwatch.java
@@ -10,14 +10,14 @@ public class Overwatch extends AbstractProvider {
     }
 
     public String hero() {
-        return faker.fakeValuesService().resolve("games.overwatch.heroes", this);
+        return resolve("games.overwatch.heroes");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("games.overwatch.locations", this);
+        return resolve("games.overwatch.locations");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.overwatch.quotes", this);
+        return resolve("games.overwatch.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Passport.java
+++ b/src/main/java/net/datafaker/Passport.java
@@ -10,6 +10,6 @@ public class Passport extends AbstractProvider {
     }
 
     public String valid() {
-        return faker.regexify(faker.fakeValuesService().resolve("passport.valid", this));
+        return faker.regexify(faker.resolve("passport.valid"));
     }
 }

--- a/src/main/java/net/datafaker/PhoneNumber.java
+++ b/src/main/java/net/datafaker/PhoneNumber.java
@@ -10,11 +10,11 @@ public class PhoneNumber extends AbstractProvider {
     }
 
     public String cellPhone() {
-        return faker.numerify(faker.fakeValuesService().resolve("cell_phone.formats", this));
+        return faker.numerify(resolve("cell_phone.formats"));
     }
 
     public String phoneNumber() {
-        return faker.numerify(faker.fakeValuesService().resolve("phone_number.formats", this));
+        return faker.numerify(resolve("phone_number.formats"));
     }
 
     public String extension() {

--- a/src/main/java/net/datafaker/Photography.java
+++ b/src/main/java/net/datafaker/Photography.java
@@ -15,62 +15,62 @@ public class Photography extends AbstractProvider {
      * @return a photography term.
      */
     public String term() {
-        return faker.fakeValuesService().fetchString("photography.term");
+        return resolve("photography.term");
     }
 
     /**
      * @return a photography brand.
      */
     public String brand() {
-        return faker.fakeValuesService().fetchString("photography.brand");
+        return resolve("photography.brand");
     }
 
     /**
      * @return a name of camera model/make.
      */
     public String camera() {
-        return faker.fakeValuesService().fetchString("photography.camera");
+        return resolve("photography.camera");
     }
 
     /**
      * @return some lens description like 500mm/8.
      */
     public String lens() {
-        return faker.fakeValuesService().fetchString("photography.lens");
+        return resolve("photography.lens");
     }
 
     /**
      * @return a photography genre.
      */
     public String genre() {
-        return faker.fakeValuesService().fetchString("photography.genre");
+        return resolve("photography.genre");
     }
 
     /**
      * @return some string to tag an image.
      */
     public String imageTag() {
-        return faker.fakeValuesService().fetchString("photography.imagetag");
+        return resolve("photography.imagetag");
     }
 
     /**
      * @return some aperture description like f/1.4 .
      */
     public String aperture() {
-        return faker.fakeValuesService().fetchString("photography.aperture");
+        return resolve("photography.aperture");
     }
 
     /**
      * @return some shutter description like 1/25 .
      */
     public String shutter() {
-        return faker.fakeValuesService().fetchString("photography.shutter");
+        return resolve("photography.shutter");
     }
 
     /**
      * @return some ISO value like 3200.
      */
     public String iso() {
-        return faker.fakeValuesService().fetchString("photography.iso");
+        return resolve("photography.iso");
     }
 }

--- a/src/main/java/net/datafaker/Pokemon.java
+++ b/src/main/java/net/datafaker/Pokemon.java
@@ -10,10 +10,10 @@ public class Pokemon extends AbstractProvider {
     }
 
     public String name() {
-        return faker.resolve("games.pokemon.names");
+        return resolve("games.pokemon.names");
     }
 
     public String location() {
-        return faker.resolve("games.pokemon.locations");
+        return resolve("games.pokemon.locations");
     }
 }

--- a/src/main/java/net/datafaker/PrincessBride.java
+++ b/src/main/java/net/datafaker/PrincessBride.java
@@ -10,10 +10,10 @@ public class PrincessBride extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("princess_bride.characters");
+        return resolve("princess_bride.characters");
     }
 
     public String quote() {
-        return faker.resolve("princess_bride.quotes");
+        return resolve("princess_bride.quotes");
     }
 }

--- a/src/main/java/net/datafaker/ProgrammingLanguage.java
+++ b/src/main/java/net/datafaker/ProgrammingLanguage.java
@@ -10,11 +10,11 @@ public class ProgrammingLanguage extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("programming_language.name", this);
+        return resolve("programming_language.name");
     }
 
     public String creator() {
-        return faker.fakeValuesService().resolve("programming_language.creator", this);
+        return resolve("programming_language.creator");
     }
 
 }

--- a/src/main/java/net/datafaker/Relationship.java
+++ b/src/main/java/net/datafaker/Relationship.java
@@ -15,27 +15,27 @@ public class Relationship extends AbstractProvider {
     }
 
     public String direct() {
-        return faker.resolve("relationship.familial.direct");
+        return resolve("relationship.familial.direct");
     }
 
     public String extended() {
-        return faker.resolve("relationship.familial.extended");
+        return resolve("relationship.familial.extended");
     }
 
     public String inLaw() {
-        return faker.resolve("relationship.in_law");
+        return resolve("relationship.in_law");
     }
 
     public String spouse() {
-        return faker.resolve("relationship.spouse");
+        return resolve("relationship.spouse");
     }
 
     public String parent() {
-        return faker.resolve("relationship.parent");
+        return resolve("relationship.parent");
     }
 
     public String sibling() {
-        return faker.resolve("relationship.sibling");
+        return resolve("relationship.sibling");
     }
 
     public String any() {

--- a/src/main/java/net/datafaker/ResidentEvil.java
+++ b/src/main/java/net/datafaker/ResidentEvil.java
@@ -15,34 +15,34 @@ public class ResidentEvil extends AbstractProvider {
      * @return A random character string (like leon kennedy) of ResidentEvil series.
      */
     public String character() {
-        return faker.fakeValuesService().resolve("games.resident_evil.characters", this);
+        return resolve("games.resident_evil.characters");
     }
 
     /**
      * @return A random biologicalAgent string of ResidentEvil series. This string may contains special characters.
      */
     public String biologicalAgent() {
-        return faker.fakeValuesService().resolve("games.resident_evil.biological-agents", this);
+        return resolve("games.resident_evil.biological-agents");
     }
 
     /**
      * @return A random equipment string of ResidentEvil series, which includes weapons and other items.
      */
     public String equipment() {
-        return faker.fakeValuesService().resolve("games.resident_evil.equipments", this);
+        return resolve("games.resident_evil.equipments");
     }
 
     /**
      * @return A random location string of ResidentEvil series.
      */
     public String location() {
-        return faker.fakeValuesService().resolve("games.resident_evil.locations", this);
+        return resolve("games.resident_evil.locations");
     }
 
     /**
      * @return A random creature string of ResidentEvil series.
      */
     public String creature() {
-        return faker.fakeValuesService().resolve("games.resident_evil.creatures", this);
+        return resolve("games.resident_evil.creatures");
     }
 }

--- a/src/main/java/net/datafaker/Restaurant.java
+++ b/src/main/java/net/datafaker/Restaurant.java
@@ -10,27 +10,27 @@ public class Restaurant extends AbstractProvider {
     }
 
     public String namePrefix() {
-        return faker.fakeValuesService().resolve("restaurant.name_prefix", this);
+        return resolve("restaurant.name_prefix");
     }
 
     public String nameSuffix() {
-        return faker.fakeValuesService().resolve("restaurant.name_suffix", this);
+        return resolve("restaurant.name_suffix");
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("restaurant.name", this);
+        return resolve("restaurant.name");
     }
 
     public String type() {
-        return faker.fakeValuesService().resolve("restaurant.type", this);
+        return resolve("restaurant.type");
     }
 
     public String description() {
-        return faker.fakeValuesService().resolve("restaurant.description", this);
+        return resolve("restaurant.description");
     }
 
     public String review() {
-        return faker.fakeValuesService().resolve("restaurant.review", this);
+        return resolve("restaurant.review");
     }
 
 }

--- a/src/main/java/net/datafaker/RickAndMorty.java
+++ b/src/main/java/net/datafaker/RickAndMorty.java
@@ -10,14 +10,14 @@ public class RickAndMorty extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("rick_and_morty.characters");
+        return resolve("rick_and_morty.characters");
     }
 
     public String location() {
-        return faker.resolve("rick_and_morty.locations");
+        return resolve("rick_and_morty.locations");
     }
 
     public String quote() {
-        return faker.resolve("rick_and_morty.quotes");
+        return resolve("rick_and_morty.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Robin.java
+++ b/src/main/java/net/datafaker/Robin.java
@@ -10,6 +10,6 @@ public class Robin extends AbstractProvider {
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("robin.quotes", this);
+        return resolve("robin.quotes");
     }
 }

--- a/src/main/java/net/datafaker/RockBand.java
+++ b/src/main/java/net/datafaker/RockBand.java
@@ -10,6 +10,6 @@ public class RockBand extends AbstractProvider {
     }
 
     public String name() {
-        return faker.resolve("rock_band.name");
+        return resolve("rock_band.name");
     }
 }

--- a/src/main/java/net/datafaker/RuPaulDragRace.java
+++ b/src/main/java/net/datafaker/RuPaulDragRace.java
@@ -12,10 +12,10 @@ public class RuPaulDragRace extends AbstractProvider {
     }
 
     public String queen() {
-        return faker.resolve("rupaul.queens");
+        return resolve("rupaul.queens");
     }
 
     public String quote() {
-        return faker.resolve("rupaul.quotes");
+        return resolve("rupaul.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Science.java
+++ b/src/main/java/net/datafaker/Science.java
@@ -10,31 +10,31 @@ public class Science extends AbstractProvider {
     }
 
     public String element() {
-        return faker.fakeValuesService().resolve("science.element", this);
+        return resolve("science.element");
     }
 
     public String elementSymbol() {
-        return faker.fakeValuesService().resolve("science.element_symbol", this);
+        return resolve("science.element_symbol");
     }
 
     public String scientist() {
-        return faker.fakeValuesService().resolve("science.scientist", this);
+        return resolve("science.scientist");
     }
 
     public String tool() {
-        return faker.fakeValuesService().resolve("science.tool", this);
+        return resolve("science.tool");
     }
 
     public String quark() {
-        return faker.fakeValuesService().resolve("science.particles.quarks", this);
+        return resolve("science.particles.quarks");
     }
 
     public String leptons() {
-        return faker.fakeValuesService().resolve("science.particles.leptons", this);
+        return resolve("science.particles.leptons");
     }
 
     public String bosons() {
-        return faker.fakeValuesService().resolve("science.particles.bosons", this);
+        return resolve("science.particles.bosons");
     }
 
 }

--- a/src/main/java/net/datafaker/Seinfeld.java
+++ b/src/main/java/net/datafaker/Seinfeld.java
@@ -12,15 +12,15 @@ public class Seinfeld extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("seinfeld.character", this);
+        return resolve("seinfeld.character");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("seinfeld.quote", this);
+        return resolve("seinfeld.quote");
     }
 
     public String business() {
-        return faker.fakeValuesService().resolve("seinfeld.business", this);
+        return resolve("seinfeld.business");
     }
 
 }

--- a/src/main/java/net/datafaker/Simpsons.java
+++ b/src/main/java/net/datafaker/Simpsons.java
@@ -10,14 +10,14 @@ public class Simpsons extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("simpsons.characters");
+        return resolve("simpsons.characters");
     }
 
     public String location() {
-        return faker.resolve("simpsons.locations");
+        return resolve("simpsons.locations");
     }
 
     public String quote() {
-        return faker.resolve("simpsons.quotes");
+        return resolve("simpsons.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Sip.java
+++ b/src/main/java/net/datafaker/Sip.java
@@ -25,7 +25,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP method String, e.g. {@code INVITE}.
      */
     public String method() {
-        return faker.resolve("sip.methods");
+        return resolve("sip.methods");
     }
 
     /**
@@ -35,7 +35,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP content-type declaration String, e.g. {@code application/sdp}
      */
     public String contentType() {
-        return faker.resolve("sip.content.types");
+        return resolve("sip.content.types");
     }
 
     /**
@@ -123,7 +123,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP provisional response phrase String, e.g. {@code Ringing}.
      */
     public String provisionalResponsePhrase() {
-        return faker.resolve("sip.response.phrases.provisional");
+        return resolve("sip.response.phrases.provisional");
     }
 
     /**
@@ -133,7 +133,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP success response phrase String, e.g. {@code OK}.
      */
     public String successResponsePhrase() {
-        return faker.resolve("sip.response.phrases.success");
+        return resolve("sip.response.phrases.success");
     }
 
     /**
@@ -143,7 +143,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP redirection response phrase String, e.g. {@code Moved Permanently}.
      */
     public String redirectResponsePhrase() {
-        return faker.resolve("sip.response.phrases.redirection");
+        return resolve("sip.response.phrases.redirection");
     }
 
     /**
@@ -153,7 +153,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP client error response phrase String, e.g. {@code Busy Here}.
      */
     public String clientErrorResponsePhrase() {
-        return faker.resolve("sip.response.phrases.clientError");
+        return resolve("sip.response.phrases.clientError");
     }
 
     /**
@@ -163,7 +163,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP server error response phrase String, e.g. {@code Service Unavailable}.
      */
     public String serverErrorResponsePhrase() {
-        return faker.resolve("sip.response.phrases.serverError");
+        return resolve("sip.response.phrases.serverError");
     }
 
     /**
@@ -173,7 +173,7 @@ public class Sip extends AbstractProvider {
      * @return a SIP global error response phrase String, e.g. {@code Rejected}.
      */
     public String globalErrorResponsePhrase() {
-        return faker.resolve("sip.response.phrases.globalError");
+        return resolve("sip.response.phrases.globalError");
     }
 
     /**

--- a/src/main/java/net/datafaker/Size.java
+++ b/src/main/java/net/datafaker/Size.java
@@ -10,7 +10,7 @@ public class Size extends AbstractProvider {
     }
 
     public String adjective() {
-        return faker.fakeValuesService().resolve("size.adjective", this);
+        return resolve("size.adjective");
     }
 
 }

--- a/src/main/java/net/datafaker/SlackEmoji.java
+++ b/src/main/java/net/datafaker/SlackEmoji.java
@@ -10,38 +10,38 @@ public class SlackEmoji extends AbstractProvider {
     }
 
     public String people() {
-        return faker.resolve("slack_emoji.people");
+        return resolve("slack_emoji.people");
     }
 
     public String nature() {
-        return faker.resolve("slack_emoji.nature");
+        return resolve("slack_emoji.nature");
     }
 
     public String foodAndDrink() {
-        return faker.resolve("slack_emoji.food_and_drink");
+        return resolve("slack_emoji.food_and_drink");
     }
 
     public String celebration() {
-        return faker.resolve("slack_emoji.celebration");
+        return resolve("slack_emoji.celebration");
     }
 
     public String activity() {
-        return faker.resolve("slack_emoji.activity");
+        return resolve("slack_emoji.activity");
     }
 
     public String travelAndPlaces() {
-        return faker.resolve("slack_emoji.travel_and_places");
+        return resolve("slack_emoji.travel_and_places");
     }
 
     public String objectsAndSymbols() {
-        return faker.resolve("slack_emoji.objects_and_symbols");
+        return resolve("slack_emoji.objects_and_symbols");
     }
 
     public String custom() {
-        return faker.resolve("slack_emoji.custom");
+        return resolve("slack_emoji.custom");
     }
 
     public String emoji() {
-        return faker.fakeValuesService().resolve("slack_emoji.emoji", this);
+        return resolve("slack_emoji.emoji");
     }
 }

--- a/src/main/java/net/datafaker/SoulKnight.java
+++ b/src/main/java/net/datafaker/SoulKnight.java
@@ -17,42 +17,42 @@ public class SoulKnight extends AbstractProvider {
      * @return a random value of characters
      */
     public String characters() {
-        return faker.resolve("soul_knight.characters");
+        return resolve("soul_knight.characters");
     }
 
     /**
      * @return a random value of buffs
      */
     public String buffs() {
-        return faker.resolve("soul_knight.buffs");
+        return resolve("soul_knight.buffs");
     }
 
     /**
      * @return a random value of statues
      */
     public String statues() {
-        return faker.resolve("soul_knight.statues");
+        return resolve("soul_knight.statues");
     }
 
     /**
      * @return a random value of weapons
      */
     public String weapons() {
-        return faker.resolve("soul_knight.weapons");
+        return resolve("soul_knight.weapons");
     }
 
     /**
      * @return a random value of bosses
      */
     public String bosses() {
-        return faker.resolve("soul_knight.bosses");
+        return resolve("soul_knight.bosses");
     }
 
     /**
      * @return a random value of enemies
      */
     public String enemies() {
-        return faker.resolve("soul_knight.enemies");
+        return resolve("soul_knight.enemies");
     }
 
 }

--- a/src/main/java/net/datafaker/Space.java
+++ b/src/main/java/net/datafaker/Space.java
@@ -10,54 +10,54 @@ public class Space extends AbstractProvider {
     }
 
     public String planet() {
-        return faker.resolve("space.planet");
+        return resolve("space.planet");
     }
 
     public String moon() {
-        return faker.resolve("space.moon");
+        return resolve("space.moon");
     }
 
     public String galaxy() {
-        return faker.resolve("space.galaxy");
+        return resolve("space.galaxy");
     }
 
     public String nebula() {
-        return faker.resolve("space.nebula");
+        return resolve("space.nebula");
     }
 
     public String starCluster() {
-        return faker.resolve("space.star_cluster");
+        return resolve("space.star_cluster");
     }
 
     public String constellation() {
-        return faker.resolve("space.constellation");
+        return resolve("space.constellation");
     }
 
     public String star() {
-        return faker.resolve("space.star");
+        return resolve("space.star");
     }
 
     public String agency() {
-        return faker.resolve("space.agency");
+        return resolve("space.agency");
     }
 
     public String agencyAbbreviation() {
-        return faker.resolve("space.agency_abv");
+        return resolve("space.agency_abv");
     }
 
     public String nasaSpaceCraft() {
-        return faker.resolve("space.nasa_space_craft");
+        return resolve("space.nasa_space_craft");
     }
 
     public String company() {
-        return faker.resolve("space.company");
+        return resolve("space.company");
     }
 
     public String distanceMeasurement() {
-        return faker.number().numberBetween(10, 100) + ' ' + faker.resolve("space.distance_measurement");
+        return faker.number().numberBetween(10, 100) + ' ' + resolve("space.distance_measurement");
     }
 
     public String meteorite() {
-        return faker.resolve("space.meteorite");
+        return resolve("space.meteorite");
     }
 }

--- a/src/main/java/net/datafaker/StarCraft.java
+++ b/src/main/java/net/datafaker/StarCraft.java
@@ -10,19 +10,19 @@ public class StarCraft extends AbstractProvider {
     }
 
     public String unit() {
-        return faker.fakeValuesService().resolve("starcraft.units", this);
+        return resolve("starcraft.units");
     }
 
     public String building() {
-        return faker.fakeValuesService().resolve("starcraft.buildings", this);
+        return resolve("starcraft.buildings");
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("starcraft.characters", this);
+        return resolve("starcraft.characters");
     }
 
     public String planet() {
-        return faker.fakeValuesService().resolve("starcraft.planets", this);
+        return resolve("starcraft.planets");
     }
 
 }

--- a/src/main/java/net/datafaker/StarTrek.java
+++ b/src/main/java/net/datafaker/StarTrek.java
@@ -10,22 +10,22 @@ public class StarTrek extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("star_trek.character", this);
+        return resolve("star_trek.character");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("star_trek.location", this);
+        return resolve("star_trek.location");
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("star_trek.species", this);
+        return resolve("star_trek.species");
     }
 
     public String villain() {
-        return faker.fakeValuesService().resolve("star_trek.villain", this);
+        return resolve("star_trek.villain");
     }
 
     public String klingon() {
-        return faker.fakeValuesService().resolve("star_trek.klingon", this);
+        return resolve("star_trek.klingon");
     }
 }

--- a/src/main/java/net/datafaker/StarWars.java
+++ b/src/main/java/net/datafaker/StarWars.java
@@ -16,37 +16,37 @@ public class StarWars extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("star_wars.characters", this, faker);
+        return resolve("star_wars.characters");
     }
 
     public String callSign() {
-        return faker.numerify(faker.fakeValuesService().resolve("star_wars.call_sign", this, faker));
+        return faker.numerify(resolve("star_wars.call_sign"));
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("star_wars.quotes." + CHARACTERS[faker.random().nextInt(CHARACTERS.length)], this, faker);
+        return resolve("star_wars.quotes." + CHARACTERS[faker.random().nextInt(CHARACTERS.length)]);
     }
     public String vehicles() {
-        return faker.fakeValuesService().resolve("star_wars.vehicles", this, faker);
+        return resolve("star_wars.vehicles");
     }
 
     public String droids() {
-        return faker.fakeValuesService().resolve("star_wars.droids", this, faker);
+        return resolve("star_wars.droids");
     }
 
     public String planets() {
-        return faker.fakeValuesService().resolve("star_wars.planets", this, faker);
+        return resolve("star_wars.planets");
     }
 
     public String species() {
-        return faker.fakeValuesService().resolve("star_wars.species", this, faker);
+        return resolve("star_wars.species");
     }
 
     public String wookieWords() {
-        return faker.fakeValuesService().resolve("star_wars.wookiee_words", this, faker);
+        return resolve("star_wars.wookiee_words");
     }
 
     public String alternateCharacterSpelling() {
-        return faker.fakeValuesService().resolve("star_wars.alternate_character_spellings." + CHARACTERS[faker.random().nextInt(CHARACTERS.length)], this, faker);
+        return resolve("star_wars.alternate_character_spellings." + CHARACTERS[faker.random().nextInt(CHARACTERS.length)]);
     }
 }

--- a/src/main/java/net/datafaker/Stock.java
+++ b/src/main/java/net/datafaker/Stock.java
@@ -10,11 +10,11 @@ public class Stock extends AbstractProvider {
     }
 
     public String nsdqSymbol() {
-        return faker.fakeValuesService().resolve("stock.symbol_nsdq", this);
+        return resolve("stock.symbol_nsdq");
     }
 
     public String nyseSymbol() {
-        return faker.fakeValuesService().resolve("stock.symbol_nyse", this);
+        return resolve("stock.symbol_nyse");
     }
 
 }

--- a/src/main/java/net/datafaker/Subscription.java
+++ b/src/main/java/net/datafaker/Subscription.java
@@ -10,23 +10,23 @@ public class Subscription extends AbstractProvider {
     }
 
     public String plans() {
-        return faker.fakeValuesService().resolve("subscription.plans", this);
+        return resolve("subscription.plans");
     }
 
     public String statuses() {
-        return faker.fakeValuesService().resolve("subscription.statuses", this);
+        return resolve("subscription.statuses");
     }
 
     public String paymentMethods() {
-        return faker.fakeValuesService().resolve("subscription.payment_methods", this);
+        return resolve("subscription.payment_methods");
     }
 
     public String subscriptionTerms() {
-        return faker.fakeValuesService().resolve("subscription.subscription_terms", this);
+        return resolve("subscription.subscription_terms");
     }
 
     public String paymentTerms() {
-        return faker.fakeValuesService().resolve("subscription.payment_terms", this);
+        return resolve("subscription.payment_terms");
     }
 
 }

--- a/src/main/java/net/datafaker/SuperMario.java
+++ b/src/main/java/net/datafaker/SuperMario.java
@@ -10,15 +10,15 @@ public class SuperMario extends AbstractProvider {
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("games.super_mario.characters", this);
+        return resolve("games.super_mario.characters");
     }
 
     public String games() {
-        return faker.fakeValuesService().resolve("games.super_mario.games", this);
+        return resolve("games.super_mario.games");
     }
 
     public String locations() {
-        return faker.fakeValuesService().resolve("games.super_mario.locations", this);
+        return resolve("games.super_mario.locations");
     }
 
 }

--- a/src/main/java/net/datafaker/Superhero.java
+++ b/src/main/java/net/datafaker/Superhero.java
@@ -10,22 +10,22 @@ public class Superhero extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("superhero.name", this);
+        return resolve("superhero.name");
     }
 
     public String prefix() {
-        return faker.fakeValuesService().resolve("superhero.prefix", this);
+        return resolve("superhero.prefix");
     }
 
     public String suffix() {
-        return faker.fakeValuesService().resolve("superhero.suffix", this);
+        return resolve("superhero.suffix");
     }
 
     public String power() {
-        return faker.fakeValuesService().resolve("superhero.power", this);
+        return resolve("superhero.power");
     }
 
     public String descriptor() {
-        return faker.fakeValuesService().resolve("superhero.descriptor", this);
+        return resolve("superhero.descriptor");
     }
 }

--- a/src/main/java/net/datafaker/Tea.java
+++ b/src/main/java/net/datafaker/Tea.java
@@ -15,7 +15,7 @@ public class Tea extends AbstractProvider {
      * @return a string of tea variety.
      */
     public String variety() {
-        return faker.fakeValuesService().resolve("tea.variety." + type().toLowerCase(), this);
+        return resolve("tea.variety." + type().toLowerCase());
     }
 
     /**
@@ -24,6 +24,6 @@ public class Tea extends AbstractProvider {
      * @return a string of tea type.
      */
     public String type() {
-        return faker.fakeValuesService().resolve("tea.type", this);
+        return resolve("tea.type");
     }
 }

--- a/src/main/java/net/datafaker/Team.java
+++ b/src/main/java/net/datafaker/Team.java
@@ -10,18 +10,18 @@ public class Team extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("team.name", this);
+        return resolve("team.name");
     }
 
     public String creature() {
-        return faker.fakeValuesService().resolve("team.creature", this);
+        return resolve("team.creature");
     }
 
     public String state() {
-        return faker.fakeValuesService().resolve("address.state", this);
+        return resolve("address.state");
     }
 
     public String sport() {
-        return faker.fakeValuesService().resolve("team.sport", this);
+        return resolve("team.sport");
     }
 }

--- a/src/main/java/net/datafaker/TheItCrowd.java
+++ b/src/main/java/net/datafaker/TheItCrowd.java
@@ -10,19 +10,19 @@ public class TheItCrowd extends AbstractProvider {
     }
 
     public String actors() {
-        return faker.fakeValuesService().resolve("the_it_crowd.actors", this);
+        return resolve("the_it_crowd.actors");
     }
 
     public String characters() {
-        return faker.fakeValuesService().resolve("the_it_crowd.characters", this);
+        return resolve("the_it_crowd.characters");
     }
 
     public String emails() {
-        return faker.fakeValuesService().resolve("the_it_crowd.emails", this);
+        return resolve("the_it_crowd.emails");
     }
 
     public String quotes() {
-        return faker.fakeValuesService().resolve("the_it_crowd.quotes", this);
+        return resolve("the_it_crowd.quotes");
     }
 
 }

--- a/src/main/java/net/datafaker/Touhou.java
+++ b/src/main/java/net/datafaker/Touhou.java
@@ -10,22 +10,22 @@ public class Touhou extends AbstractProvider {
     }
 
     public String characterName() {
-        return faker.fakeValuesService().resolve("touhou.full_name", this);
+        return resolve("touhou.full_name");
     }
 
     public String characterFirstName() {
-        return faker.fakeValuesService().resolve("touhou.first_name", this);
+        return resolve("touhou.first_name");
     }
 
     public String characterLastName() {
-        return faker.fakeValuesService().resolve("touhou.last_name", this);
+        return resolve("touhou.last_name");
     }
 
     public String trackName() {
-        return faker.fakeValuesService().resolve("touhou.track_name", this);
+        return resolve("touhou.track_name");
     }
 
     public String gameName() {
-        return faker.fakeValuesService().resolve("touhou.game_name", this);
+        return resolve("touhou.game_name");
     }
 }

--- a/src/main/java/net/datafaker/Tron.java
+++ b/src/main/java/net/datafaker/Tron.java
@@ -16,15 +16,15 @@ public class Tron extends AbstractProvider {
     }
 
     public String character(Character character) {
-        return faker.fakeValuesService().resolve("tron.characters." + character.yamlKey, this);
+        return resolve("tron.characters." + character.yamlKey);
     }
 
     public String game() {
-        return faker.fakeValuesService().resolve("tron.games", this);
+        return resolve("tron.games");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("tron.locations", this);
+        return resolve("tron.locations");
     }
 
     public String quote() {
@@ -32,15 +32,15 @@ public class Tron extends AbstractProvider {
     }
 
     public String quote(Tron.Quote quote) {
-        return faker.fakeValuesService().resolve("tron.quotes." + quote.yamlKey, this);
+        return resolve("tron.quotes." + quote.yamlKey);
     }
 
     public String tagline() {
-        return faker.fakeValuesService().resolve("tron.taglines", this);
+        return resolve("tron.taglines");
     }
 
     public String vehicle() {
-        return faker.fakeValuesService().resolve("tron.vehicles", this);
+        return resolve("tron.vehicles");
     }
 
     public String alternateCharacterSpelling() {
@@ -48,7 +48,7 @@ public class Tron extends AbstractProvider {
     }
 
     public String alternateCharacterSpelling(AlternateCharacterSpelling alternateCharacterSpelling) {
-        return faker.fakeValuesService().resolve("tron.alternate_character_spellings." + alternateCharacterSpelling.yamlKey, this);
+        return resolve("tron.alternate_character_spellings." + alternateCharacterSpelling.yamlKey);
     }
 
     public enum AlternateCharacterSpelling {

--- a/src/main/java/net/datafaker/TwinPeaks.java
+++ b/src/main/java/net/datafaker/TwinPeaks.java
@@ -10,14 +10,14 @@ public class TwinPeaks extends AbstractProvider {
     }
 
     public String character() {
-        return faker.resolve("twin_peaks.characters");
+        return resolve("twin_peaks.characters");
     }
 
     public String location() {
-        return faker.resolve("twin_peaks.locations");
+        return resolve("twin_peaks.locations");
     }
 
     public String quote() {
-        return faker.resolve("twin_peaks.quotes");
+        return resolve("twin_peaks.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Twitter.java
+++ b/src/main/java/net/datafaker/Twitter.java
@@ -128,14 +128,14 @@ public class Twitter extends AbstractProvider {
      * @return Return a user name using the twitter.user_name.
      */
     public String userName() {
-        return faker.fakeValuesService().resolve("twitter.user_name", this);
+        return resolve("twitter.user_name");
     }
 
     /**
      * @return Return a user id using the twitter.user_name.
      */
     public String userId() {
-        return faker.fakeValuesService().resolve("twitter.user_id", this);
+        return resolve("twitter.user_id");
     }
 
     /**

--- a/src/main/java/net/datafaker/Unique.java
+++ b/src/main/java/net/datafaker/Unique.java
@@ -65,7 +65,7 @@ public class Unique extends AbstractProvider {
     }
 
     private List<String> fetchValues(String key) {
-        Object object = faker.fakeValuesService().fetchObject(key);
+        Object object = faker.fakeValuesService().fetchObject(key, faker.getContext());
 
         if (!(object instanceof List)) {
             throw noValuesFoundException(key);

--- a/src/main/java/net/datafaker/University.java
+++ b/src/main/java/net/datafaker/University.java
@@ -10,14 +10,14 @@ public class University extends AbstractProvider {
     }
 
     public String name() {
-        return faker.fakeValuesService().resolve("university.name", this);
+        return resolve("university.name");
     }
 
     public String prefix() {
-        return faker.fakeValuesService().resolve("university.prefix", this);
+        return resolve("university.prefix");
     }
 
     public String suffix() {
-        return faker.fakeValuesService().resolve("university.suffix", this);
+        return resolve("university.suffix");
     }
 }

--- a/src/main/java/net/datafaker/Vehicle.java
+++ b/src/main/java/net/datafaker/Vehicle.java
@@ -17,15 +17,15 @@ public class Vehicle extends AbstractProvider {
     }
 
     public String vin() {
-        return faker.fakeValuesService().regexify(VIN_REGEX);
+        return faker.regexify(VIN_REGEX);
     }
 
     public String manufacturer() {
-        return faker.resolve("vehicle.manufacture");
+        return resolve("vehicle.manufacture");
     }
 
     public String make() {
-        return faker.resolve("vehicle.makes");
+        return resolve("vehicle.makes");
     }
 
     public String model() {
@@ -33,7 +33,7 @@ public class Vehicle extends AbstractProvider {
     }
 
     public String model(String make) {
-        return faker.resolve("vehicle.models_by_make." + make);
+        return resolve("vehicle.models_by_make." + make);
     }
 
     public String makeAndModel() {
@@ -42,45 +42,45 @@ public class Vehicle extends AbstractProvider {
     }
 
     public String style() {
-        return faker.resolve("vehicle.styles");
+        return resolve("vehicle.styles");
     }
 
     public String color() {
-        return faker.resolve("vehicle.colors");
+        return resolve("vehicle.colors");
     }
 
     public String upholsteryColor() {
-        return faker.resolve("vehicle.upholstery_colors");
+        return resolve("vehicle.upholstery_colors");
     }
 
     public String upholsteryFabric() {
-        return faker.resolve("vehicle.upholstery_fabrics");
+        return resolve("vehicle.upholstery_fabrics");
     }
 
     public String upholstery() {
-        return faker.resolve("vehicle.upholsteries");
+        return resolve("vehicle.upholsteries");
     }
 
     public String transmission() {
-        return faker.resolve("vehicle.transmissions");
+        return resolve("vehicle.transmissions");
     }
 
     public String driveType() {
-        return faker.resolve("vehicle.drive_types");
+        return resolve("vehicle.drive_types");
     }
 
     public String fuelType() {
-        return faker.resolve("vehicle.fuel_types");
+        return resolve("vehicle.fuel_types");
     }
 
     public String carType() {
-        return faker.resolve("vehicle.car_types");
+        return resolve("vehicle.car_types");
     }
 
     public String engine() {
-        return faker.resolve("vehicle.engine_sizes")
+        return resolve("vehicle.engine_sizes")
             + " "
-            + faker.resolve("vehicle.cylinder_engine");
+            + resolve("vehicle.cylinder_engine");
     }
 
     public List<String> carOptions() {
@@ -112,7 +112,7 @@ public class Vehicle extends AbstractProvider {
     }
 
     public String doors() {
-        return faker.resolve("vehicle.doors");
+        return resolve("vehicle.doors");
     }
 
     public String licensePlate() {
@@ -125,7 +125,7 @@ public class Vehicle extends AbstractProvider {
             return null;
         }
 
-        String licensePlatesByState = faker.fakeValuesService().resolve("vehicle.license_plate_by_state." + stateAbbreviation, this);
+        String licensePlatesByState = resolve("vehicle.license_plate_by_state." + stateAbbreviation);
         return licensePlatesByState == null ? null : faker.regexify(faker.bothify(licensePlatesByState)).toUpperCase(Locale.ROOT);
     }
 }

--- a/src/main/java/net/datafaker/Verb.java
+++ b/src/main/java/net/datafaker/Verb.java
@@ -15,7 +15,7 @@ public class Verb extends AbstractProvider {
      * @return a string of base form of a verb.
      */
     public String base() {
-        return faker.fakeValuesService().resolve("verbs.base", this);
+        return resolve("verbs.base");
     }
 
     /**
@@ -24,7 +24,7 @@ public class Verb extends AbstractProvider {
      * @return a string of verb in past tense.
      */
     public String past() {
-        return faker.fakeValuesService().resolve("verbs.past", this);
+        return resolve("verbs.past");
     }
 
     /**
@@ -33,7 +33,7 @@ public class Verb extends AbstractProvider {
      * @return a string of verb in past participle tense.
      */
     public String pastParticiple() {
-        return faker.fakeValuesService().resolve("verbs.past_participle", this);
+        return resolve("verbs.past_participle");
     }
 
     /**
@@ -42,7 +42,7 @@ public class Verb extends AbstractProvider {
      * @return a string of verb in simple present tense.
      */
     public String simplePresent() {
-        return faker.fakeValuesService().resolve("verbs.simple_present", this);
+        return resolve("verbs.simple_present");
     }
 
     /**
@@ -51,6 +51,6 @@ public class Verb extends AbstractProvider {
      * @return a string of verb in -ing form.
      */
     public String ingForm() {
-        return faker.fakeValuesService().resolve("verbs.ing_form", this);
+        return resolve("verbs.ing_form");
     }
 }

--- a/src/main/java/net/datafaker/Volleyball.java
+++ b/src/main/java/net/datafaker/Volleyball.java
@@ -10,23 +10,23 @@ public class Volleyball extends AbstractProvider {
     }
 
     public String team() {
-        return faker.fakeValuesService().resolve("volleyball.team", this);
+        return resolve("volleyball.team");
     }
 
     public String player() {
-        return faker.fakeValuesService().resolve("volleyball.player", this);
+        return resolve("volleyball.player");
     }
 
     public String coach() {
-        return faker.fakeValuesService().resolve("volleyball.coach", this);
+        return resolve("volleyball.coach");
     }
 
     public String position() {
-        return faker.fakeValuesService().resolve("volleyball.position", this);
+        return resolve("volleyball.position");
     }
 
     public String formation() {
-        return faker.fakeValuesService().resolve("volleyball.formation", this);
+        return resolve("volleyball.formation");
     }
 
 }

--- a/src/main/java/net/datafaker/Weather.java
+++ b/src/main/java/net/datafaker/Weather.java
@@ -20,7 +20,7 @@ public class Weather extends AbstractProvider {
      * Generates a short weather description.
      */
     public String description() {
-        return faker.resolve("weather.description");
+        return resolve("weather.description");
     }
 
     /**
@@ -64,6 +64,6 @@ public class Weather extends AbstractProvider {
     }
 
     private String temperature(int minTemperature, int maxTemperature, String degreeKey) {
-        return faker.random().nextInt(minTemperature, maxTemperature) + faker.resolve(degreeKey);
+        return faker.random().nextInt(minTemperature, maxTemperature) + resolve(degreeKey);
     }
 }

--- a/src/main/java/net/datafaker/Witcher.java
+++ b/src/main/java/net/datafaker/Witcher.java
@@ -10,37 +10,37 @@ public class Witcher extends AbstractProvider {
     }
 
     public String character() {
-        return faker.fakeValuesService().resolve("games.witcher.characters", this);
+        return resolve("games.witcher.characters");
     }
 
     public String witcher() {
-        return faker.fakeValuesService().resolve("games.witcher.witchers", this);
+        return resolve("games.witcher.witchers");
     }
 
     public String school() {
-        return faker.fakeValuesService().resolve("games.witcher.schools", this);
+        return resolve("games.witcher.schools");
     }
 
     public String location() {
-        return faker.fakeValuesService().resolve("games.witcher.locations", this);
+        return resolve("games.witcher.locations");
     }
 
     public String quote() {
-        return faker.fakeValuesService().resolve("games.witcher.quotes", this);
+        return resolve("games.witcher.quotes");
     }
 
     public String monster() {
-        return faker.fakeValuesService().resolve("games.witcher.monsters", this);
+        return resolve("games.witcher.monsters");
     }
     public String sign() {
-        return faker.fakeValuesService().resolve("games.witcher.signs", this);
+        return resolve("games.witcher.signs");
     }
 
     public String potion() {
-        return faker.fakeValuesService().resolve("games.witcher.potions", this);
+        return resolve("games.witcher.potions");
     }
 
     public String book() {
-        return faker.fakeValuesService().resolve("games.witcher.books", this);
+        return resolve("games.witcher.books");
     }
 }

--- a/src/main/java/net/datafaker/Yoda.java
+++ b/src/main/java/net/datafaker/Yoda.java
@@ -10,6 +10,6 @@ public class Yoda extends AbstractProvider {
     }
 
     public String quote() {
-        return faker.resolve("yoda.quotes");
+        return resolve("yoda.quotes");
     }
 }

--- a/src/main/java/net/datafaker/Zelda.java
+++ b/src/main/java/net/datafaker/Zelda.java
@@ -10,10 +10,10 @@ public class Zelda extends AbstractProvider {
     }
 
     public String game() {
-        return faker.resolve("games.zelda.games");
+        return resolve("games.zelda.games");
     }
 
     public String character() {
-        return faker.resolve("games.zelda.characters");
+        return resolve("games.zelda.characters");
     }
 }

--- a/src/main/java/net/datafaker/service/FakerContext.java
+++ b/src/main/java/net/datafaker/service/FakerContext.java
@@ -1,0 +1,125 @@
+package net.datafaker.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static net.datafaker.service.FakeValuesService.DEFAULT_LOCALE;
+
+/**
+ * Contains the changeable Faker's part which currently contains {@link Locale} and {@link RandomService}.
+ */
+public class FakerContext {
+    private static final Pattern LOCALE = Pattern.compile("[-_]");
+    private final Map<Locale, List<Locale>> locale2localesChain = new HashMap<>();
+    private Locale locale;
+    private RandomService randomService;
+
+
+    /**
+     * Resolves YAML file using the most specific path first based on language and country code.
+     * 'en_US' would resolve in the following order:
+     * <ol>
+     * <li>/en-US.yml</li>
+     * <li>/en.yml</li>
+     * </ol>
+     * The search is case-insensitive, so the following will all resolve correctly.  Also, either a hyphen or
+     * an underscore can be used when constructing a {@link Locale} instance.  This is legacy behavior and not
+     * condoned, but it will work.
+     * <ul>
+     * <li>EN_US</li>
+     * <li>En-Us</li>
+     * <li>eN_uS</li>
+     * </ul>
+     */
+    public FakerContext(Locale locale, RandomService randomService) {
+        this.locale = locale;
+        this.randomService = randomService;
+        setCurrentLocale(locale);
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    public void setRandomService(RandomService randomService) {
+        this.randomService = randomService;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public RandomService getRandomService() {
+        return randomService;
+    }
+
+    public List<Locale> getLocaleChain() {
+        return locale2localesChain.get(locale);
+    }
+
+    /**
+     * @return a proper {@link Locale} instance with language and country code set regardless of how
+     * it was instantiated.  new Locale("pt-br") will be normalized to a locale constructed
+     * with new Locale("pt","BR").
+     */
+    private Locale normalizeLocale(Locale locale) {
+        final String[] parts = LOCALE.split(locale.toString());
+
+        if (parts.length == 1) {
+            return new Locale(parts[0]);
+        } else {
+            return new Locale(parts[0], parts[1]);
+        }
+    }
+
+    public void setCurrentLocale(Locale locale) {
+        Objects.requireNonNull(locale);
+        this.locale = normalizeLocale(locale);
+        if (locale2localesChain.containsKey(getLocale())) {
+            return;
+        }
+        locale2localesChain.put(getLocale(), localeChain(getLocale()));
+    }
+
+    /**
+     * Convert the specified locale into a chain of locales used for message resolution. For example:
+     * <p>
+     * {@link Locale#FRANCE} (fr_FR) to [ fr_FR, anotherTest, en ]
+     *
+     * @return a list of {@link Locale} instances
+     */
+    protected List<Locale> localeChain(Locale from) {
+        if (DEFAULT_LOCALE.equals(from)) {
+            return Collections.singletonList(DEFAULT_LOCALE);
+        }
+
+        final Locale normalized = normalizeLocale(from);
+
+        final List<Locale> chain = new ArrayList<>(3);
+        chain.add(normalized);
+        if (!"".equals(normalized.getCountry()) && !DEFAULT_LOCALE.getLanguage().equals(normalized.getLanguage())) {
+            chain.add(new Locale(normalized.getLanguage()));
+        }
+        chain.add(DEFAULT_LOCALE); // default
+        return chain;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FakerContext that = (FakerContext) o;
+        return Objects.equals(locale, that.locale) && Objects.equals(randomService, that.randomService);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(locale, randomService);
+    }
+}

--- a/src/test/java/net/datafaker/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/CustomFakerTest.java
@@ -15,11 +15,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class CustomFakerTest {
     public static class MyCustomFaker extends Faker {
         public Insect insect() {
-            return getProvider(Insect.class, () -> new Insect(this));
+            return getProvider(Insect.class, Insect::new, this);
         }
 
         public InsectFromFile insectFromFile() {
-            return getProvider(InsectFromFile.class, () -> new InsectFromFile(this));
+            return getProvider(InsectFromFile.class, InsectFromFile::new, this);
         }
     }
 
@@ -45,11 +45,11 @@ class CustomFakerTest {
         }
 
         public String ant() {
-            return faker.fakeValuesService().resolve(KEY + ".ants", null, faker);
+            return resolve(KEY + ".ants");
         }
 
         public String bee() {
-            return faker.fakeValuesService().resolve(KEY + ".bees", null, faker);
+            return resolve(KEY + ".bees");
         }
     }
 
@@ -92,12 +92,12 @@ class CustomFakerTest {
     @Test
     void insectBeeTestExpressionFromFileWithoutExtraFaker() {
         Faker faker = new Faker();
-        assertThat(faker.getProvider(InsectFromFile.class, () -> new InsectFromFile(faker)).bee()).endsWith("bee");
+        assertThat(faker.getProvider(InsectFromFile. class, f -> new InsectFromFile(f), faker).bee()).endsWith("bee");
     }
 
     @Test
     void insectTestWithoutExtraFaker() {
         Faker faker = new Faker();
-        assertThat(faker.getProvider(Insect.class, () -> new Insect(faker)).nextInsectName()).matches("[A-Za-z ]+");
+        assertThat(faker.getProvider(Insect. class, f -> new Insect(f), faker).nextInsectName()).matches("[A-Za-z ]+");
     }
 }

--- a/src/test/java/net/datafaker/UniqueTest.java
+++ b/src/test/java/net/datafaker/UniqueTest.java
@@ -70,7 +70,7 @@ class UniqueTest {
 
         assertThat(faker.unique().fetchFromYaml(firstKey)).isEqualTo(expectedValue);
         assertThat(faker.unique().fetchFromYaml(secondKey)).isEqualTo(expectedValue);
-        faker.fakeValuesService().setCurrentLocale(new Locale("test_otherlocale"));
+        faker.getContext().setCurrentLocale(new Locale("test_otherlocale"));
         assertThat(faker.unique().fetchFromYaml(firstKey)).isEqualTo(expectedValue);
         assertThat(faker.unique().fetchFromYaml(secondKey)).isEqualTo(expectedValue);
     }
@@ -101,7 +101,7 @@ class UniqueTest {
             faker.unique().fetchFromYaml(key);
         }
 
-        String result = faker.fakeValuesService().fetchString(key);
+        String result = faker.unique().resolve(key);
 
         assertThat(defaultValues).contains(result);
     }

--- a/src/test/java/net/datafaker/integration/MostSpecificLocaleTest.java
+++ b/src/test/java/net/datafaker/integration/MostSpecificLocaleTest.java
@@ -1,6 +1,7 @@
 package net.datafaker.integration;
 
 import net.datafaker.service.FakeValuesService;
+import net.datafaker.service.FakerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,20 +17,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class MostSpecificLocaleTest {
 
-    private FakeValuesService en;
-    private FakeValuesService en_US;
+    private FakerContext en;
+    private FakerContext en_US;
 
     @BeforeEach
     void setupFakers() {
-        en = new FakeValuesService(new Locale("en"), null);
-        en_US = new FakeValuesService(new Locale("en", "US"), null);
+        en = new FakerContext(new Locale("en"), null);
+        en_US = new FakerContext(new Locale("en", "US"), null);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void resolvesTheMostSpecificLocale() {
-        final List<String> enDefaultCountries = (List<String>) en.fetchObject("address.default_country");
-        final List<String> enUsDefaultCountries = (List<String>) en_US.fetchObject("address.default_country");
+        FakeValuesService fakeValuesService = new FakeValuesService();
+        fakeValuesService.updateFakeValuesInterfaceMap(en.getLocaleChain());
+        final List<String> enDefaultCountries = (List<String>) fakeValuesService.fetchObject("address.default_country", en);
+        fakeValuesService = new FakeValuesService();
+        fakeValuesService.updateFakeValuesInterfaceMap(en_US.getLocaleChain());
+        final List<String> enUsDefaultCountries = (List<String>) fakeValuesService.fetchObject("address.default_country", en_US);
 
         assertThat(enDefaultCountries).hasSize(1);
         assertThat(enUsDefaultCountries).hasSize(3);

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -73,7 +73,7 @@ class ProviderGenerator {
             String methodName = StringUtils.uncapitalize(toJavaConvention(string));
 
             System.out.println("    public String " + methodName + "() {\n" +
-                "        return faker.fakeValuesService().resolve(\"" + key + "." + string + "\", this);\n" +
+                "        return resolve(\"" + key + "." + string + "\", this);\n" +
                 "    }");
             System.out.println();
         }


### PR DESCRIPTION
The main issue this PR is trying to solve is that so far `net.datafaker.Faker#providersMap` contains `AbstractProvider` as value and `AbstractProvider` itself contains link to `Faker` which contains information about `Locale` and `RandomService`.
The problem is that in that map there is one `AbstractProvider` per class and this is the main blocker before movement this map to static. To see issues just switch it to static and run tests.
Another issue is that RandomService is containing in 2 classes: `Faker` and `FakeValuesService`. The PR makes is located only on Faker's level by removal from `FakeValuesService`.

The PR introduces `FakerContext` containing `Locale` and `RandomService` and it allows to satisfy all the cases we have in tests