### PR TITLE
Introduce transformation schemas

### DIFF
--- a/src/main/java/net/datafaker/transformations/CompositeField.java
+++ b/src/main/java/net/datafaker/transformations/CompositeField.java
@@ -1,0 +1,22 @@
+package net.datafaker.transformations;
+
+import net.datafaker.providers.base.AbstractProvider;
+
+public class CompositeField<MyObject extends AbstractProvider<?>, MyType> extends Schema<MyObject, MyType> implements Field<MyObject, MyType> {
+    private final String name;
+
+    public CompositeField(String name, Field<MyObject, MyType>[] fields) {
+        super(fields);
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public MyType transform(MyObject input) {
+        return null;
+    }
+}

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -1,0 +1,113 @@
+package net.datafaker.transformations;
+
+import net.datafaker.providers.base.AbstractProvider;
+
+import java.util.List;
+
+public class CsvTransformer<IN extends AbstractProvider<?>>
+    implements Transformer<IN, CharSequence> {
+  private static final String DEFAULT_SEPARATOR = ";";
+  public static final char DEFAULT_QUOTE = '"';
+
+  private final String separator;
+  private final char quote;
+  private final boolean withHeader;
+
+  private CsvTransformer(String separator, char quote, boolean withHeader) {
+    this.separator = separator;
+    this.quote = quote;
+    this.withHeader = withHeader;
+  }
+
+  @Override
+  public CharSequence apply(Object input, Schema<?, ? extends CharSequence> schema) {
+    Field<? extends Object, ? extends CharSequence>[] fields = schema.getFields();
+    if (fields.length == 0) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < fields.length; i++) {
+      SimpleField<Object, ? extends CharSequence> f =
+          (SimpleField<Object, ? extends CharSequence>) fields[i];
+      addLine(sb, f.transform(input));
+      if (i < fields.length - 1) {
+        sb.append(separator);
+      }
+    }
+    return sb.toString();
+  }
+
+  private void addLine(StringBuilder sb, CharSequence apply) {
+    sb.append(quote);
+    for (int j = 0; j < apply.length(); j++) {
+      if (apply.charAt(j) == quote) {
+        sb.append(quote);
+      }
+      sb.append(apply.charAt(j));
+    }
+    sb.append(quote);
+  }
+
+  @Override
+  public String generate(List<IN> input, Schema<IN, ? extends CharSequence> schema) {
+    StringBuilder sb = new StringBuilder();
+    generateHeader(schema, sb);
+    for (int i = 0; i < input.size(); i++) {
+      sb.append(apply(input.get(i), schema));
+      if (i < input.size() - 1) {
+        sb.append(System.lineSeparator());
+      }
+    }
+    return sb.toString();
+  }
+
+  private void generateHeader(Schema<?, ? extends CharSequence> schema, StringBuilder sb) {
+    if (withHeader) {
+      for (int i = 0; i < schema.getFields().length; i++) {
+        addLine(sb, schema.getFields()[i].getName());
+        if (i < schema.getFields().length - 1) {
+          sb.append(separator);
+        }
+      }
+      sb.append(System.lineSeparator());
+    }
+  }
+
+  @Override
+  public String generate(Schema<?, ? extends CharSequence> schema, int limit) {
+    StringBuilder sb = new StringBuilder();
+    generateHeader(schema, sb);
+    for (int i = 0; i < limit; i++) {
+      sb.append(apply(null, schema));
+      if (i < limit - 1) {
+        sb.append(System.lineSeparator());
+      }
+    }
+    return sb.toString();
+  }
+
+  public static class CsvTransformerBuilder<IN extends AbstractProvider<?>> {
+    private String separator = DEFAULT_SEPARATOR;
+    private char quote = DEFAULT_QUOTE;
+    private boolean withHeader = true;
+
+    public CsvTransformerBuilder<IN> quote(char quote) {
+      this.quote = quote;
+      return this;
+    }
+
+    public CsvTransformerBuilder<IN> separator(String separator) {
+      this.separator = separator;
+      return this;
+    }
+
+    public CsvTransformerBuilder<IN> header(boolean header) {
+      this.withHeader = header;
+      return this;
+    }
+
+    public CsvTransformer<IN> build() {
+      return new CsvTransformer<>(separator, quote, withHeader);
+    }
+  }
+}

--- a/src/main/java/net/datafaker/transformations/Field.java
+++ b/src/main/java/net/datafaker/transformations/Field.java
@@ -1,0 +1,28 @@
+package net.datafaker.transformations;
+
+import net.datafaker.providers.base.AbstractProvider;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public interface Field<IN, OUT> {
+    String getName();
+    OUT transform(IN input);
+
+    static <MyObject, MyType> SimpleField<MyObject, MyType> field(
+        String name, Function<MyObject, MyType> transform) {
+        return new SimpleField<>(name, transform);
+    }
+
+    static <MyObject, MyType> SimpleField<MyObject, MyType> field(
+        String name, Supplier<MyType> supplier) {
+        return new SimpleField<>(name, supplier);
+    }
+
+    static <MyObject extends AbstractProvider<?>, MyType>
+    CompositeField<MyObject, MyType> compositeField(
+        String name, Field<MyObject, MyType>[] fields) {
+        return new CompositeField<>(name, fields);
+    }
+
+}

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -1,0 +1,155 @@
+package net.datafaker.transformations;
+
+import net.datafaker.providers.base.AbstractProvider;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class JsonTransformer<IN extends AbstractProvider<?>> implements Transformer<IN, Object> {
+  private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
+
+  @Override
+  public String apply(Object input, Schema<?, ? extends Object> schema) {
+    Field<?, ?>[] fields = schema.getFields();
+    if (fields.length == 0) {
+      return "{}";
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    for (int i = 0; i < fields.length; i++) {
+      value2String((fields[i].getName()), sb);
+      sb.append(": ");
+      if (fields[i] instanceof CompositeField) {
+        sb.append(apply(input, (CompositeField) fields[i]));
+      } else {
+        value2String(((SimpleField) fields[i]).transform(input), sb);
+      }
+      if (i < fields.length - 1) {
+        sb.append(", ");
+      }
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  public String generate(List<IN> input, Schema<IN, ? extends Object> schema) {
+    String result = input.stream().map(t -> apply(t, schema)).collect(Collectors.joining(",\n"));
+    return input.size() > 1 ? "{\n" + result + "}" : result;
+  }
+
+  @Override
+  public String generate(Schema<?, ?> schema, int limit) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < limit; i++) {
+      sb.append(apply(null, schema));
+      if (i < limit - 1) {
+        sb.append(",\n");
+      }
+    }
+    return limit > 1 ? "{\n" + sb + "}" : sb.toString();
+  }
+
+  private static void value2String(Object value, StringBuilder sb) {
+    if (value == null) {
+      sb.append("null");
+    } else if (value instanceof Integer
+        || value instanceof Long
+        || value instanceof Short
+        || value instanceof BigInteger
+        || value instanceof Boolean
+        || (value instanceof Double
+            && BigDecimal.valueOf((Double) value).remainder(BigDecimal.ONE).doubleValue() == 0)
+        || (value instanceof BigDecimal
+            && ((BigDecimal) value).remainder(BigDecimal.ONE).doubleValue() == 0)) {
+      sb.append(value);
+    } else if (value instanceof Collection) {
+      sb.append(generate((Collection) value));
+    } else if (value.getClass().isArray()) {
+      sb.append(generate(Arrays.asList((Object[]) value)));
+    } else {
+      String val = String.valueOf(value);
+      boolean toWrap = !val.startsWith("#{json");
+      if (toWrap) {
+        sb.append("\"");
+      }
+      for (char c : String.valueOf(value).toCharArray()) {
+        sb.append(ESCAPING_MAP.getOrDefault(c, c + ""));
+      }
+      if (toWrap) {
+        sb.append("\"");
+      }
+    }
+  }
+
+  private static String generate(Collection<Object> collection) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[");
+    int i = 0;
+    for (Object value : collection) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      i++;
+      value2String(value, sb);
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  private static Map<Character, String> createEscapeMap() {
+    final Map<Character, String> map = new HashMap<>();
+    map.put('\\', "\\\\");
+    map.put('\"', "\\\"");
+    map.put('\b', "\\b");
+    map.put('\f', "\\f");
+    map.put('\n', "\\n");
+    map.put('\r', "\\r");
+    map.put('\t', "\\t");
+    map.put('/', "\\/");
+    map.put('\u0000', "\\u0000");
+    map.put('\u0001', "\\u0001");
+    map.put('\u0002', "\\u0002");
+    map.put('\u0003', "\\u0003");
+    map.put('\u0004', "\\u0004");
+    map.put('\u0005', "\\u0005");
+    map.put('\u0006', "\\u0006");
+    map.put('\u0007', "\\u0007");
+    // map.put('\u0008', "\\u0008");
+    // covered by map.put('\b', "\\b");
+    // map.put('\u0009', "\\u0009");
+    // covered by map.put('\t', "\\t");
+    // map.put((char) 10, "\\u000A");
+    // covered by map.put('\n', "\\n");
+    map.put('\u000B', "\\u000B");
+    // map.put('\u000C', "\\u000C");
+    // covered by map.put('\f', "\\f");
+    // map.put((char) 13, "\\u000D");
+    // covered by map.put('\r', "\\r");
+    map.put('\u000E', "\\u000E");
+    map.put('\u000F', "\\u000F");
+    map.put('\u0010', "\\u0010");
+    map.put('\u0011', "\\u0011");
+    map.put('\u0012', "\\u0012");
+    map.put('\u0013', "\\u0013");
+    map.put('\u0014', "\\u0014");
+    map.put('\u0015', "\\u0015");
+    map.put('\u0016', "\\u0016");
+    map.put('\u0017', "\\u0017");
+    map.put('\u0018', "\\u0018");
+    map.put('\u0019', "\\u0019");
+    map.put('\u001A', "\\u001A");
+    map.put('\u001B', "\\u001B");
+    map.put('\u001C', "\\u001C");
+    map.put('\u001D', "\\u001D");
+    map.put('\u001E', "\\u001E");
+    map.put('\u001F', "\\u001F");
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/src/main/java/net/datafaker/transformations/Schema.java
+++ b/src/main/java/net/datafaker/transformations/Schema.java
@@ -1,0 +1,42 @@
+package net.datafaker.transformations;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class Schema<IN, OUT> {
+  private final Field<IN, OUT>[] fields;
+
+  protected Schema(Field<IN, OUT>[] fields) {
+    this.fields = fields;
+  }
+
+  public Field<IN, OUT>[] getFields() {
+    return fields;
+  }
+
+  @SafeVarargs
+  public static <IN, OUT> Schema<IN, OUT> of(Field<IN, OUT>... fields) {
+      return new Schema<>(fields);
+  }
+
+  public static class SchemaBuilder<IN, OUT> {
+    private final List<Field<IN, OUT>> fieldList = new ArrayList<>();
+
+    public SchemaBuilder<IN, OUT> of(SimpleField<IN, OUT> field) {
+      fieldList.add(field);
+      return this;
+    }
+
+    @SafeVarargs
+    public final SchemaBuilder<IN, OUT> of(Field<IN, OUT>... fields) {
+      fieldList.addAll(Arrays.asList(fields));
+      return this;
+    }
+
+    public Schema<IN, OUT> build() {
+      return new Schema<>(fieldList.toArray(new Field[0]));
+    }
+  }
+}

--- a/src/main/java/net/datafaker/transformations/SimpleField.java
+++ b/src/main/java/net/datafaker/transformations/SimpleField.java
@@ -1,0 +1,46 @@
+package net.datafaker.transformations;
+
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class SimpleField<MyObject, MyType> implements Field<MyObject, MyType> {
+  private final String name;
+  private final Function<MyObject, MyType> transform;
+  private final Supplier<MyType> supplier;
+
+  protected SimpleField(String name, Function<MyObject, MyType> transform) {
+    this(name, transform, null);
+  }
+
+  protected SimpleField(String name, Supplier<MyType> supplier) {
+    this(name, null, supplier);
+  }
+
+  private SimpleField(String name, Function<MyObject, MyType> transform, Supplier<MyType> supplier) {
+    this.name = name;
+    this.transform = transform;
+    this.supplier = supplier;
+    if (this.transform == null && this.supplier == null) {
+        throw new IllegalArgumentException("Either transform or supplier should be non-null");
+    }
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public MyType transform(MyObject input) {
+    return transform == null ? supplier.get() : transform.apply(input);
+  }
+
+  public Function<MyObject, MyType> getTransform() {
+    return transform;
+  }
+
+  public Supplier<MyType> getSupplier() {
+    return supplier;
+  }
+}

--- a/src/main/java/net/datafaker/transformations/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/SqlTransformer.java
@@ -1,0 +1,123 @@
+package net.datafaker.transformations;
+
+import net.datafaker.providers.base.AbstractProvider;
+
+import java.util.List;
+
+public class SqlTransformer<IN extends AbstractProvider<?>>
+    implements Transformer<IN, CharSequence> {
+    private static final char DEFAULT_QUOTE = '\'';
+    private static final String DEFAULT_SQL_IDENTIFIER = "\"\"";
+    private final char quote;
+    private final char openSqlIdentifier;
+    private final char closeSqlIdentifier;
+    private final String tableName;
+
+    private SqlTransformer(char quote, String sqlIdentifier, String tableName) {
+        this.quote = quote;
+        this.openSqlIdentifier = sqlIdentifier.charAt(0);
+        this.closeSqlIdentifier = sqlIdentifier.length() == 1 ? sqlIdentifier.charAt(0) : sqlIdentifier.charAt(1);
+        this.tableName = tableName;
+    }
+
+    @Override
+    public CharSequence apply(Object input, Schema<?, ? extends CharSequence> schema) {
+        Field<? extends Object, ? extends CharSequence>[] fields = schema.getFields();
+        if (fields.length == 0) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder("insert into ");
+        sb.append(openSqlIdentifier).append(tableName).append(closeSqlIdentifier).append(" (");
+        for (int i = 0; i < fields.length; i++) {
+            sb.append(openSqlIdentifier);
+            for (int j = 0; j < fields[i].getName().length(); j++) {
+                if (openSqlIdentifier == fields[i].getName().charAt(j)
+                || closeSqlIdentifier == fields[i].getName().charAt(j)) {
+                    sb.append(openSqlIdentifier);
+                }
+                sb.append(fields[i].getName().charAt(j));
+            }
+            sb.append(closeSqlIdentifier);
+            if (i < fields.length - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append(") values (");
+        for (int i = 0; i < fields.length; i++) {
+            if (fields[i] instanceof SimpleField) {
+                Object value = ((SimpleField<Object, ? extends CharSequence>) fields[i]).transform(input);
+                Class<?> clazz = value == null ? null : value.getClass();
+                if (value == null
+                    || value instanceof java.lang.Number
+                    || value instanceof java.lang.Boolean
+                    || clazz.isPrimitive()) {
+                    sb.append(value);
+                } else {
+                    String strValue = value.toString();
+                    sb.append(quote);
+                    for (int j = 0; j < strValue.length(); j++) {
+                        if (strValue.charAt(j) == quote) {
+                            sb.append(quote);
+                        }
+                        sb.append(strValue.charAt(j));
+                    }
+                    sb.append(quote);
+                }
+            }
+            if (i < fields.length - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append(");");
+        return sb.toString();
+    }
+
+    @Override
+    public String generate(List<IN> input, Schema<IN, ? extends CharSequence> schema) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < input.size(); i++) {
+            sb.append(apply(input.get(i), schema));
+            if (i < input.size() - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String generate(Schema<?, ? extends CharSequence> schema, int limit) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < limit; i++) {
+            sb.append(apply(null, schema));
+            if (i < limit - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    public static class SqlTransformerBuilder {
+        private char quote = DEFAULT_QUOTE;
+        private String sqlQuoteIdentifier = DEFAULT_SQL_IDENTIFIER;
+        private String tableName = "MyTable";
+
+        public SqlTransformerBuilder quote(char quote) {
+            this.quote = quote;
+            return this;
+        }
+
+        public SqlTransformerBuilder sqlQuoteIdentifier(String sqlQuoteIdentifier) {
+            this.sqlQuoteIdentifier = sqlQuoteIdentifier;
+            return this;
+        }
+
+        public SqlTransformerBuilder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public SqlTransformer build() {
+            return new SqlTransformer(quote, sqlQuoteIdentifier, tableName);
+        }
+    }
+}

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -1,0 +1,11 @@
+package net.datafaker.transformations;
+
+import net.datafaker.providers.base.AbstractProvider;
+
+import java.util.List;
+
+public interface Transformer<IN extends AbstractProvider<?>, OUT> {
+    OUT apply(Object input, Schema<?, ? extends OUT> schema);
+    String generate(List<IN> input, final Schema<IN, ? extends OUT> schema);
+    String generate(final Schema<?, ? extends OUT> schema, int limit);
+}

--- a/src/test/java/net/datafaker/fileformats/CsvTest.java
+++ b/src/test/java/net/datafaker/fileformats/CsvTest.java
@@ -3,6 +3,8 @@ package net.datafaker.fileformats;
 import net.datafaker.AbstractFakerTest;
 import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.Name;
+import net.datafaker.transformations.CsvTransformer;
+import net.datafaker.transformations.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -10,126 +12,261 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.ArrayList;
 import java.util.List;
 
+import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CsvTest extends AbstractFakerTest {
 
-    @Test
-    void csvTest() {
-        final BaseFaker faker = new BaseFaker();
-        String separator = "@@@";
-        int limit = 20;
-        String csv = Format.toCsv(Csv.Column.of("first_name", () -> faker.name().firstName()),
+  @Test
+  void csvTest() {
+    final BaseFaker faker = new BaseFaker();
+    String separator = "@@@";
+    int limit = 20;
+    String csv =
+        Format.toCsv(
+                Csv.Column.of("first_name", () -> faker.name().firstName()),
                 Csv.Column.of("last_name", () -> faker.name().lastName()),
                 Csv.Column.of("address", () -> faker.address().streetAddress()))
             .header(true)
             .separator(separator)
-            .limit(limit).build().get();
-        int numberOfLines = 0;
-        int numberOfSeparator = 0;
-        for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
-                numberOfLines++;
-            } else if (csv.regionMatches(i, separator, 0, separator.length())) {
-                numberOfSeparator++;
-            }
-        }
-
-        assertThat(limit + 1).isEqualTo(numberOfLines); // limit + 1 line for header
-        assertThat((limit + 1) * 2).isEqualTo(numberOfSeparator); // number of lines * (number of columns - 1)
+            .limit(limit)
+            .build()
+            .get();
+    int numberOfLines = 0;
+    int numberOfSeparator = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      } else if (csv.regionMatches(i, separator, 0, separator.length())) {
+        numberOfSeparator++;
+      }
     }
 
-    @Test
-    void csvTestWithQuotes() {
-        String separator = "$$$";
-        int limit = 20;
-        final BaseFaker faker = new BaseFaker();
-        List<Csv.Column> columns = new ArrayList<>();
-        columns.add(Csv.Column.of("first_name", () -> faker.expression("#{Name.first_name}")));
-        columns.add(Csv.Column.of("last_name", () -> faker.expression("#{Name.last_name}")));
-        String csv = Format.toCsv(columns)
+    assertThat(limit + 1).isEqualTo(numberOfLines); // limit + 1 line for header
+    assertThat((limit + 1) * 2)
+        .isEqualTo(numberOfSeparator); // number of lines * (number of columns - 1)
+  }
+
+  @Test
+  void csvTestNew() {
+    final BaseFaker faker = new BaseFaker();
+    String separator = "@@@";
+    int limit = 20;
+    Schema<String, String> schema =
+        Schema.of(
+            field("first_name", () -> faker.name().firstName()),
+            field("last_name", () -> faker.name().lastName()),
+            field("address", () -> faker.address().streetAddress()));
+    CsvTransformer<?> transformer =
+        new CsvTransformer.CsvTransformerBuilder<>().header(true).separator(separator).build();
+
+    String csv = transformer.generate(schema, limit);
+    int numberOfLines = 0;
+    int numberOfSeparator = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      } else if (csv.regionMatches(i, separator, 0, separator.length())) {
+        numberOfSeparator++;
+      }
+    }
+
+    assertThat(limit).isEqualTo(numberOfLines);
+    assertThat((limit + 1) * 2)
+        .isEqualTo(numberOfSeparator); // number of lines * (number of columns - 1)*/
+  }
+
+  @Test
+  void csvTestWithQuotes() {
+    String separator = "$$$";
+    int limit = 20;
+    final BaseFaker faker = new BaseFaker();
+    List<Csv.Column> columns = new ArrayList<>();
+    columns.add(Csv.Column.of("first_name", () -> faker.expression("#{Name.first_name}")));
+    columns.add(Csv.Column.of("last_name", () -> faker.expression("#{Name.last_name}")));
+    String csv =
+        Format.toCsv(columns)
             .header(true)
             .separator(separator)
             .quote('%')
-            .limit(limit).build().get();
-        int numberOfLines = 0;
-        int numberOfSeparator = 0;
-        for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
-                numberOfLines++;
-            } else if (csv.regionMatches(i, separator, 0, separator.length())) {
-                numberOfSeparator++;
-            }
-        }
-
-        assertThat(limit + 1).isEqualTo(numberOfLines); // limit + 1 line for header
-        assertThat((limit + 1) * (columns.size() - 1)).isEqualTo(numberOfSeparator); // number of lines * (number of columns - 1)
+            .limit(limit)
+            .build()
+            .get();
+    int numberOfLines = 0;
+    int numberOfSeparator = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      } else if (csv.regionMatches(i, separator, 0, separator.length())) {
+        numberOfSeparator++;
+      }
     }
 
-    @Test
-    void testCsvWithComma() {
-        String csv = Format.toCsv(
+    assertThat(limit + 1).isEqualTo(numberOfLines); // limit + 1 line for header
+    assertThat((limit + 1) * (columns.size() - 1))
+        .isEqualTo(numberOfSeparator); // number of lines * (number of columns - 1)
+  }
+
+  @Test
+  void csvTestWithQuotesNew() {
+    String separator = "$$$";
+    int limit = 20;
+    final BaseFaker faker = new BaseFaker();
+    Schema<String, String> schema =
+        Schema.of(
+            field("first_name", () -> faker.expression("#{Name.first_name}")),
+            field("last_name", () -> faker.expression("#{Name.last_name}")));
+    CsvTransformer<?> transformer =
+        new CsvTransformer.CsvTransformerBuilder<>().header(true).separator(separator).build();
+
+    String csv = transformer.generate(schema, limit);
+    int numberOfLines = 0;
+    int numberOfSeparator = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      } else if (csv.regionMatches(i, separator, 0, separator.length())) {
+        numberOfSeparator++;
+      }
+    }
+
+    assertThat(limit).isEqualTo(numberOfLines);
+    assertThat((limit + 1) * (schema.getFields().length - 1))
+        .isEqualTo(numberOfSeparator); // number of lines * (number of columns - 1)
+  }
+
+  @Test
+  void testCsvWithComma() {
+
+    String csv =
+        Format.toCsv(
                 Csv.Column.of("values", () -> "1,2,3"),
                 Csv.Column.of("title", () -> "The \"fabulous\" artist"))
             .header(true)
             .separator(",")
-            .limit(1).build().get();
+            .limit(1)
+            .build()
+            .get();
 
-        String expected = "\"values\",\"title\"" + System.lineSeparator() +
-            "\"1,2,3\",\"The \"\"fabulous\"\" artist\"" + System.lineSeparator();
+    String expected =
+        "\"values\",\"title\""
+            + System.lineSeparator()
+            + "\"1,2,3\",\"The \"\"fabulous\"\" artist\""
+            + System.lineSeparator();
 
-        assertThat(csv).isEqualTo(expected);
-    }
+    assertThat(csv).isEqualTo(expected);
+  }
 
-    @ParameterizedTest
-    @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-    void testLimitForCsv(int limit) {
-        final BaseFaker faker = new BaseFaker();
-        String csv = Format.toCsv(
-                faker.<Name>collection()
-                    .suppliers(faker::name)
-                    .maxLen(limit + 1)
-                    .build())
+  @Test
+  void testCsvWithCommaNew() {
+    Schema<?, ? extends CharSequence> schema =
+        Schema.of(field("values", () -> "1,2,3"), field("title", () -> "The \"fabulous\" artist"));
+    CsvTransformer<?> transformer =
+        new CsvTransformer.CsvTransformerBuilder<>().header(true).separator(",").build();
+
+    String csv = transformer.generate(schema, 1);
+
+    String expected =
+        "\"values\",\"title\""
+            + System.lineSeparator()
+            + "\"1,2,3\",\"The \"\"fabulous\"\" artist\"";
+
+    assertThat(csv).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2, 3, 10, 20, 100})
+  void testLimitForCsv(int limit) {
+    final BaseFaker faker = new BaseFaker();
+    String csv =
+        Format.toCsv(faker.<Name>collection().suppliers(faker::name).maxLen(limit + 1).build())
             .headers(() -> "firstName", () -> "lastname")
             .columns(Name::firstName, Name::lastName)
             .separator(" : ")
             .header(false)
             .limit(limit)
-            .build().get();
+            .build()
+            .get();
 
-        int numberOfLines = 0;
-        for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
-                numberOfLines++;
-            }
-        }
-
-        assertThat(numberOfLines).isEqualTo(limit);
+    int numberOfLines = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      }
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-    void testLimitForCollection(int limit) {
-        final BaseFaker faker = new BaseFaker();
-        String csv = Format.toCsv(
-                faker.<Name>collection()
-                    .suppliers(faker::name)
-                    .maxLen(limit)
-                    .build())
+    assertThat(numberOfLines).isEqualTo(limit);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2, 3, 10, 20, 100})
+  void testLimitForCsvNew(int limit) {
+    final BaseFaker faker = new BaseFaker();
+    Schema<Name, String> schema =
+        Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName));
+
+    CsvTransformer<Name> transformer =
+        new CsvTransformer.CsvTransformerBuilder<Name>().header(false).separator(",").build();
+    String csv =
+        transformer.generate(
+            faker.<Name>collection().suppliers(faker::name).maxLen(limit + 1).build().get(),
+            schema);
+
+    int numberOfLines = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      }
+    }
+
+    assertThat(numberOfLines).isEqualTo(limit);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2, 3, 10, 20, 100})
+  void testLimitForCollection(int limit) {
+    final BaseFaker faker = new BaseFaker();
+    String csv =
+        Format.toCsv(faker.<Name>collection().suppliers(faker::name).maxLen(limit).build())
             .headers(() -> "firstName", () -> "lastname")
             .columns(Name::firstName, Name::lastName)
             .separator(" : ")
             .header(false)
             .limit(limit + 1)
-            .build().get();
+            .build()
+            .get();
 
-        int numberOfLines = 0;
-        for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
-                numberOfLines++;
-            }
-        }
-
-        assertThat(numberOfLines).isEqualTo(limit);
+    int numberOfLines = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      }
     }
+
+    assertThat(numberOfLines).isEqualTo(limit);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2, 3, 10, 20, 100})
+  void testLimitForCollectionNew(int limit) {
+    final BaseFaker faker = new BaseFaker();
+    Schema<Name, String> schema =
+        Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName));
+
+    CsvTransformer<Name> transformer =
+        new CsvTransformer.CsvTransformerBuilder<Name>().header(false).separator(" : ").build();
+    String csv =
+        transformer.generate(
+            faker.<Name>collection().suppliers(faker::name).maxLen(limit + 1).build().get(),
+            schema);
+
+    int numberOfLines = 0;
+    for (int i = 0; i < csv.length(); i++) {
+      if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+        numberOfLines++;
+      }
+    }
+
+    assertThat(numberOfLines).isEqualTo(limit);
+  }
 }

--- a/src/test/java/net/datafaker/fileformats/JsonTest.java
+++ b/src/test/java/net/datafaker/fileformats/JsonTest.java
@@ -1,5 +1,8 @@
 package net.datafaker.fileformats;
 
+import net.datafaker.transformations.Field;
+import net.datafaker.transformations.JsonTransformer;
+import net.datafaker.transformations.Schema;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -12,57 +15,117 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static net.datafaker.transformations.Field.compositeField;
+import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 class JsonTest {
-    @ParameterizedTest
-    @MethodSource("generateTestJson")
-    void simpleJsonTest(Map<Object, Supplier<Object>> input, String expected) {
-        Json.JsonBuilder builder = new Json.JsonBuilder();
-        for (Map.Entry<Object, Supplier<Object>> entry : input.entrySet()) {
-            if (entry.getKey() instanceof String) {
-                builder.set((String) entry.getKey(), entry.getValue());
-            } else if (entry.getKey() instanceof Supplier) {
-                builder.set((Supplier<String>) entry.getKey(), entry.getValue());
-            } else {
-                fail("Key should be String or Supplier<String>");
-            }
-        }
-        assertThat(builder.build().generate()).isEqualTo(expected);
-    }
 
-    private static Stream<Arguments> generateTestJson() {
-        return Stream.of(
-            Arguments.of(Collections.emptyMap(), "{}"),
-            Arguments.of(map(entry(() -> "key", () -> new Json(map(entry(() -> "key", () -> "value"))))), "{\"key\": {\"key\": \"value\"}}"),
-            Arguments.of(map(entry(() -> "key", () -> "value")), "{\"key\": \"value\"}"),
-            Arguments.of(map(entry(() -> "number", () -> 123)), "{\"number\": 123}"),
-            Arguments.of(map(entry(() -> "number", () -> BigDecimal.valueOf(123.0))), "{\"number\": 123.0}"),
-            Arguments.of(map(entry(() -> "number", () -> BigDecimal.valueOf(123.123))), "{\"number\": \"123.123\"}"),
-            Arguments.of(map(entry(() -> "boolean", () -> true)), "{\"boolean\": true}"),
-            Arguments.of(map(entry(() -> "nullValue", () -> null)), "{\"nullValue\": null}"),
-            Arguments.of(map(entry(() -> "array", () -> new String[]{null, "test", "123"})), "{\"array\": [null, \"test\", \"123\"]}"),
-            Arguments.of(map(entry(() -> "array", () -> new Integer[]{123, 456, 789})), "{\"array\": [123, 456, 789]}"),
-            Arguments.of(map(entry(() -> "array", () -> new Object[]{"test", 456, true})), "{\"array\": [\"test\", 456, true]}"),
-            Arguments.of(map(entry(() -> "emptyarray", () -> new Long[]{})), "{\"emptyarray\": []}"),
-            Arguments.of(map(entry(() -> "emptyarray", Collections::emptyList)), "{\"emptyarray\": []}"),
-            Arguments.of(map(entry(() -> "es\"ca\"ped", () -> "va\"lu\"e")), "{\"es\\\"ca\\\"ped\": \"va\\\"lu\\\"e\"}"),
-            Arguments.of(map(entry(() -> "key", () -> "value"), entry(() -> "nested", () -> map(entry(() -> "nestedkey", () -> "nestedvalue")))),
-                "{\"key\": \"value\", \"nested\": {\"nestedkey\": \"nestedvalue\"}}")
-        );
-    }
+  @ParameterizedTest
+  @MethodSource("generateTestSchema")
+  void simpleJsonTestForJsonTransformer(Schema<String, String> schema, String expected) {
+    JsonTransformer<?> transformer = new JsonTransformer();
+    assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
+  }
 
-    private static Map.Entry<Supplier<String>, Supplier<Object>> entry(Supplier<String> key, Supplier<Object> value) {
-        return new AbstractMap.SimpleEntry<>(key, value);
-    }
+  private static Stream<Arguments> generateTestSchema() {
+    return Stream.of(
+        of(Schema.of(), "{}"),
+        of(
+            Schema.of(compositeField("key", new Field[] {field("key", () -> "value")})),
+            "{\"key\": {\"key\": \"value\"}}"),
+        of(Schema.of(field("key", () -> "value")), "{\"key\": \"value\"}"),
+        of(Schema.of(field("number", () -> 123)), "{\"number\": 123}"),
+        of(Schema.of(field("number", () -> 123.0)), "{\"number\": 123.0}"),
+        of(Schema.of(field("number", () -> 123.123)), "{\"number\": \"123.123\"}"),
+        of(Schema.of(field("boolean", () -> true)), "{\"boolean\": true}"),
+        of(Schema.of(field("nullValue", () -> null)), "{\"nullValue\": null}"),
+        of(
+            Schema.of(field("array", () -> new String[] {null, "test", "123"})),
+            "{\"array\": [null, \"test\", \"123\"]}"),
+        of(
+            Schema.of(field("array", () -> new Integer[] {123, 456, 789})),
+            "{\"array\": [123, 456, 789]}"),
+        of(
+            Schema.of(field("array", () -> new Object[] {"test", 456, true})),
+            "{\"array\": [\"test\", 456, true]}"),
+        of(Schema.of(field("emptyarray", () -> new Long[] {})), "{\"emptyarray\": []}"),
+        of(Schema.of(field("emptyarray", Collections::emptyList)), "{\"emptyarray\": []}"),
+        of(
+            Schema.of(field("es\"ca\"ped", () -> "va\"lu\"e")),
+            "{\"es\\\"ca\\\"ped\": \"va\\\"lu\\\"e\"}"),
+        of(
+            Schema.of(
+                field("key", () -> "value"),
+                compositeField("nested", new Field[] {field("nestedkey", () -> "nestedvalue")})),
+            "{\"key\": \"value\", \"nested\": {\"nestedkey\": \"nestedvalue\"}}"));
+  }
 
-    @SafeVarargs
-    private static Map<Supplier<String>, Supplier<Object>> map(Map.Entry<Supplier<String>, Supplier<Object>>... entries) {
-        Map<Supplier<String>, Supplier<Object>> map = new LinkedHashMap<>();
-        for (Map.Entry<Supplier<String>, Supplier<Object>> entry : entries) {
-            map.put(entry.getKey(), entry.getValue());
-        }
-        return map;
+  @ParameterizedTest
+  @MethodSource("generateTestJson")
+  void simpleJsonTest(Map<Object, Supplier<Object>> input, String expected) {
+    Json.JsonBuilder builder = new Json.JsonBuilder();
+    for (Map.Entry<Object, Supplier<Object>> entry : input.entrySet()) {
+      if (entry.getKey() instanceof String) {
+        builder.set((String) entry.getKey(), entry.getValue());
+      } else if (entry.getKey() instanceof Supplier) {
+        builder.set((Supplier<String>) entry.getKey(), entry.getValue());
+      } else {
+        fail("Key should be String or Supplier<String>");
+      }
     }
+    assertThat(builder.build().generate()).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> generateTestJson() {
+    return Stream.of(
+        of(Collections.emptyMap(), "{}"),
+        of(
+            map(entry(() -> "key", () -> new Json(map(entry(() -> "key", () -> "value"))))),
+            "{\"key\": {\"key\": \"value\"}}"),
+        of(map(entry(() -> "key", () -> "value")), "{\"key\": \"value\"}"),
+        of(map(entry(() -> "number", () -> 123)), "{\"number\": 123}"),
+        of(map(entry(() -> "number", () -> BigDecimal.valueOf(123.0))), "{\"number\": 123.0}"),
+        of(
+            map(entry(() -> "number", () -> BigDecimal.valueOf(123.123))),
+            "{\"number\": \"123.123\"}"),
+        of(map(entry(() -> "boolean", () -> true)), "{\"boolean\": true}"),
+        of(map(entry(() -> "nullValue", () -> null)), "{\"nullValue\": null}"),
+        of(
+            map(entry(() -> "array", () -> new String[] {null, "test", "123"})),
+            "{\"array\": [null, \"test\", \"123\"]}"),
+        of(
+            map(entry(() -> "array", () -> new Integer[] {123, 456, 789})),
+            "{\"array\": [123, 456, 789]}"),
+        of(
+            map(entry(() -> "array", () -> new Object[] {"test", 456, true})),
+            "{\"array\": [\"test\", 456, true]}"),
+        of(map(entry(() -> "emptyarray", () -> new Long[] {})), "{\"emptyarray\": []}"),
+        of(map(entry(() -> "emptyarray", Collections::emptyList)), "{\"emptyarray\": []}"),
+        of(
+            map(entry(() -> "es\"ca\"ped", () -> "va\"lu\"e")),
+            "{\"es\\\"ca\\\"ped\": \"va\\\"lu\\\"e\"}"),
+        of(
+            map(
+                entry(() -> "key", () -> "value"),
+                entry(() -> "nested", () -> map(entry(() -> "nestedkey", () -> "nestedvalue")))),
+            "{\"key\": \"value\", \"nested\": {\"nestedkey\": \"nestedvalue\"}}"));
+  }
+
+  private static Map.Entry<Supplier<String>, Supplier<Object>> entry(
+      Supplier<String> key, Supplier<Object> value) {
+    return new AbstractMap.SimpleEntry<>(key, value);
+  }
+
+  @SafeVarargs
+  private static Map<Supplier<String>, Supplier<Object>> map(
+      Map.Entry<Supplier<String>, Supplier<Object>>... entries) {
+    Map<Supplier<String>, Supplier<Object>> map = new LinkedHashMap<>();
+    for (Map.Entry<Supplier<String>, Supplier<Object>> entry : entries) {
+      map.put(entry.getKey(), entry.getValue());
+    }
+    return map;
+  }
 }

--- a/src/test/java/net/datafaker/fileformats/SqlTest.java
+++ b/src/test/java/net/datafaker/fileformats/SqlTest.java
@@ -1,0 +1,33 @@
+package net.datafaker.fileformats;
+
+import net.datafaker.transformations.Schema;
+import net.datafaker.transformations.SqlTransformer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static net.datafaker.transformations.Field.field;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+public class SqlTest {
+    @ParameterizedTest
+    @MethodSource("generateTestSchema")
+    void simpleJsonTestForJsonTransformer(Schema<String, String> schema, String expected) {
+        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().sqlQuoteIdentifier("`").build();
+        assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateTestSchema() {
+        return Stream.of(
+            of(Schema.of(), ""),
+            of(Schema.of(field("key", () -> "value")), "insert into `MyTable` (`key`) values ('value');"),
+            of(Schema.of(field("number", () -> 123)), "insert into `MyTable` (`number`) values (123);"),
+            of(Schema.of(field("number", () -> 123.0)), "insert into `MyTable` (`number`) values (123.0);"),
+            of(Schema.of(field("number", () -> 123.123)), "insert into `MyTable` (`number`) values (123.123);"),
+            of(Schema.of(field("boolean", () -> true)), "insert into `MyTable` (`boolean`) values (true);"),
+            of(Schema.of(field("nullValue", () -> null)), "insert into `MyTable` (`nullValue`) values (null);"));
+    }
+}


### PR DESCRIPTION
The PR introduces schemas for transformations mentioned at https://github.com/datafaker-net/datafaker/issues/429
Also it introduce a new SQL transformer

an example of usage
```java
Faker faker = new Faker();
      System.out.println(
        new SqlTransformer.SqlTransformerBuilder()
            .build()
            .generate(
                faker.collection(faker::name).len(5).generate(),
                Schema.of(field("name", Name::fullName), field("username", Name::username))));
```

which results to
```sql
insert into "MyTable" ("name", "username") values ('Joel Adams', 'darren.wiza');
insert into "MyTable" ("name", "username") values ('Cameron Runolfsdottir', 'kayla.robel');
insert into "MyTable" ("name", "username") values ('Justin Ernser', 'michel.anderson');
insert into "MyTable" ("name", "username") values ('Mauro Pouros', 'jesus.schulist');
insert into "MyTable" ("name", "username") values ('Annie Cormier Jr.', 'roseline.vonrueden');

```