### PR TITLE
Add support of sql dialect while sql generation

### DIFF
--- a/src/main/java/net/datafaker/formats/Csv.java
+++ b/src/main/java/net/datafaker/formats/Csv.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Deprecated // Use CsvTransformer
 public class Csv<T> {
     public static final char DEFAULT_QUOTE = '"';
     public static final String DEFAULT_SEPARATOR = ",";

--- a/src/main/java/net/datafaker/formats/Format.java
+++ b/src/main/java/net/datafaker/formats/Format.java
@@ -4,6 +4,7 @@ import net.datafaker.sequence.FakeSequence;
 
 import java.util.List;
 
+@Deprecated // Use Transformer
 public class Format {
     public static <T> Csv.CsvCollectionBasedBuilder<T> toCsv(FakeSequence<T> sequence) {
         return new Csv.CsvCollectionBasedBuilder<T>().sequence(sequence);

--- a/src/main/java/net/datafaker/formats/Json.java
+++ b/src/main/java/net/datafaker/formats/Json.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Deprecated // Use JsonTransformer
 public class Json {
     private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
     private final Map<Supplier<String>, Supplier<Object>> map;

--- a/src/main/java/net/datafaker/transformations/Casing.java
+++ b/src/main/java/net/datafaker/transformations/Casing.java
@@ -1,0 +1,12 @@
+package net.datafaker.transformations;
+
+public enum Casing {
+    /** The case of identifiers is not changed. */
+    UNCHANGED,
+
+    /** Identifiers are converted to upper-case. */
+    TO_UPPER,
+
+    /** Identifiers are converted to lower-case. */
+    TO_LOWER
+}

--- a/src/main/java/net/datafaker/transformations/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/SqlDialect.java
@@ -1,0 +1,45 @@
+package net.datafaker.transformations;
+
+public enum SqlDialect {
+    ANSI("`"),
+    BIGQUERY("`", Casing.UNCHANGED),
+    CALCITE("\""),
+    CLICKHOUSE("`"),
+    EXASOL("\""),
+    FIREBOLT("\""),
+    H2("\""),
+    INFOBRIGHT("`"),
+    LUCIDDB("\""),
+    MSSQL("[]"),
+    MYSQL("[]", Casing.UNCHANGED),
+    NETEZZA("\""),
+    ORACLE("\""),
+    PARACCEL("\""),
+    PHOENIX("\""),
+    POSTGRES("\""),
+    PRESTO("\"", Casing.UNCHANGED),
+    REDSHIFT("\"", Casing.TO_LOWER),
+    SNOWFLAKE("\""),
+    TERADATA("\""),
+    VERTICA("\"", Casing.UNCHANGED);
+
+    private final String sqlQuoteIdentifier;
+    private final Casing unquotedCasing;
+
+    SqlDialect(String sqlQuoteIdentifier, Casing casing) {
+        this.sqlQuoteIdentifier = sqlQuoteIdentifier;
+        this.unquotedCasing = casing;
+    }
+
+    SqlDialect(String sqlQuoteIdentifier) {
+        this(sqlQuoteIdentifier, Casing.TO_UPPER);
+    }
+
+    public String getSqlQuoteIdentifier() {
+        return sqlQuoteIdentifier;
+    }
+
+    public Casing getUnquotedCasing() {
+        return unquotedCasing;
+    }
+}

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -1,6 +1,7 @@
 package net.datafaker.formats;
 
 import net.datafaker.transformations.Schema;
+import net.datafaker.transformations.SqlDialect;
 import net.datafaker.transformations.SqlTransformer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -15,19 +16,55 @@ import static org.junit.jupiter.params.provider.Arguments.of;
 public class SqlTest {
     @ParameterizedTest
     @MethodSource("generateTestSchema")
-    void simpleJsonTestForJsonTransformer(Schema<String, String> schema, String expected) {
-        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().sqlQuoteIdentifier("`").build();
+    void simpleSqlTestForSqlTransformer(Schema<String, String> schema, String expected) {
+        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().sqlQuoteIdentifier("`").tableName("MY_TABLE").build();
         assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
     }
 
     private static Stream<Arguments> generateTestSchema() {
         return Stream.of(
             of(Schema.of(), ""),
-            of(Schema.of(field("key", () -> "value")), "insert into `MyTable` (`key`) values ('value');"),
-            of(Schema.of(field("number", () -> 123)), "insert into `MyTable` (`number`) values (123);"),
-            of(Schema.of(field("number", () -> 123.0)), "insert into `MyTable` (`number`) values (123.0);"),
-            of(Schema.of(field("number", () -> 123.123)), "insert into `MyTable` (`number`) values (123.123);"),
-            of(Schema.of(field("boolean", () -> true)), "insert into `MyTable` (`boolean`) values (true);"),
-            of(Schema.of(field("nullValue", () -> null)), "insert into `MyTable` (`nullValue`) values (null);"));
+            of(Schema.of(field("key", () -> "value")), "INSERT INTO MY_TABLE (`key`) VALUES ('value');"),
+            of(Schema.of(field("number", () -> 123)), "INSERT INTO MY_TABLE (`number`) VALUES (123);"),
+            of(Schema.of(field("number", () -> 123.0)), "INSERT INTO MY_TABLE (`number`) VALUES (123.0);"),
+            of(Schema.of(field("number", () -> 123.123)), "INSERT INTO MY_TABLE (`number`) VALUES (123.123);"),
+            of(Schema.of(field("boolean", () -> true)), "INSERT INTO MY_TABLE (`boolean`) VALUES (true);"),
+            of(Schema.of(field("nullValue", () -> null)), "INSERT INTO MY_TABLE (`nullValue`) VALUES (null);"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateTestSchemaForPostgres")
+    void simpleSqlTestForSqlTransformerPostgres(Schema<String, String> schema, String expected) {
+        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().dialect(SqlDialect.POSTGRES).build();
+        assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateTestSchemaForPostgres() {
+        return Stream.of(
+            of(Schema.of(), ""),
+            of(Schema.of(field("key", () -> "value")), "INSERT INTO \"MyTable\" (\"key\") VALUES ('value');"),
+            of(Schema.of(field("number", () -> 123)), "INSERT INTO \"MyTable\" (\"number\") VALUES (123);"),
+            of(Schema.of(field("number", () -> 123.0)), "INSERT INTO \"MyTable\" (\"number\") VALUES (123.0);"),
+            of(Schema.of(field("number", () -> 123.123)), "INSERT INTO \"MyTable\" (\"number\") VALUES (123.123);"),
+            of(Schema.of(field("boolean", () -> true)), "INSERT INTO \"MyTable\" (\"boolean\") VALUES (true);"),
+            of(Schema.of(field("nullValue", () -> null)), "INSERT INTO \"MyTable\" (\"nullValue\") VALUES (null);"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateTestSchemaForMSSQL")
+    void simpleSqlTestForSqlTransformerMSSQL(Schema<String, String> schema, String expected) {
+        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().dialect(SqlDialect.MSSQL).build();
+        assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateTestSchemaForMSSQL() {
+        return Stream.of(
+            of(Schema.of(), ""),
+            of(Schema.of(field("key", () -> "value")), "INSERT INTO [MyTable] ([key]) VALUES ('value');"),
+            of(Schema.of(field("number", () -> 123)), "INSERT INTO [MyTable] ([number]) VALUES (123);"),
+            of(Schema.of(field("number", () -> 123.0)), "INSERT INTO [MyTable] ([number]) VALUES (123.0);"),
+            of(Schema.of(field("number", () -> 123.123)), "INSERT INTO [MyTable] ([number]) VALUES (123.123);"),
+            of(Schema.of(field("boolean", () -> true)), "INSERT INTO [MyTable] ([boolean]) VALUES (true);"),
+            of(Schema.of(field("nullValue", () -> null)), "INSERT INTO [MyTable] ([nullValue]) VALUES (null);"));
     }
 }


### PR DESCRIPTION
The PR adds supports of several SQL dialects 
e.g. for postgres there is `"` as a sql quote identifier , for MSSQL it's `[]`, for some other dbs it's `
e.g. for postgresql
```sql
INSERT INTO "MyTable" ("key") VALUES ('value');
INSERT INTO "MyTable" ("number") VALUES (123);
INSERT INTO "MyTable" ("number") VALUES (123.0);
```
for MSSQL
```sql
INSERT INTO [MyTable] ([number]) VALUES (123.123);
INSERT INTO [MyTable] ([boolean]) VALUES (true);
```

to generate the following code could be used
```java
SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().dialect(SqlDialect.MSSQL).build();
transformer.generate(Schema.of(field("number", () -> 123.123)), 1);
```

possible output
```sql
INSERT INTO [MyTable] ([number]) VALUES (123.123);
```

same for postgres
```java
SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().dialect(SqlDialect.POSTGRES).build();
transformer.generate(Schema.of(field("number", () -> 123.123)), 1);
```

output
```sql
INSERT INTO "MyTable" ("number") VALUES (123.123);
```