### PR TITLE
Rework Generics of Transformer interface

### DIFF
--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -17,7 +17,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
   }
 
   @Override
-  public CharSequence apply(Object input, Schema<IN, ?> schema) {
+  public CharSequence apply(IN input, Schema<IN, ?> schema) {
     Field<IN, ?>[] fields = schema.getFields();
     if (fields.length == 0) {
       return "";

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -1,11 +1,8 @@
 package net.datafaker.transformations;
 
-import net.datafaker.providers.base.AbstractProvider;
-
 import java.util.List;
 
-public class CsvTransformer<IN extends AbstractProvider<?>>
-    implements Transformer<IN, CharSequence> {
+public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
   private static final String DEFAULT_SEPARATOR = ";";
   public static final char DEFAULT_QUOTE = '"';
 
@@ -20,16 +17,16 @@ public class CsvTransformer<IN extends AbstractProvider<?>>
   }
 
   @Override
-  public CharSequence apply(Object input, Schema<?, ? extends CharSequence> schema) {
-    Field<? extends Object, ? extends CharSequence>[] fields = schema.getFields();
+  public CharSequence apply(Object input, Schema<IN, ?> schema) {
+    Field<IN, ?>[] fields = schema.getFields();
     if (fields.length == 0) {
       return "";
     }
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < fields.length; i++) {
-      SimpleField<Object, ? extends CharSequence> f =
-          (SimpleField<Object, ? extends CharSequence>) fields[i];
-      addLine(sb, f.transform(input));
+      //noinspection unchecked
+      SimpleField<Object, ?> f = (SimpleField<Object, ?>) fields[i];
+	  addLine(sb, f.transform(input));
       if (i < fields.length - 1) {
         sb.append(separator);
       }
@@ -37,19 +34,8 @@ public class CsvTransformer<IN extends AbstractProvider<?>>
     return sb.toString();
   }
 
-  private void addLine(StringBuilder sb, CharSequence apply) {
-    sb.append(quote);
-    for (int j = 0; j < apply.length(); j++) {
-      if (apply.charAt(j) == quote) {
-        sb.append(quote);
-      }
-      sb.append(apply.charAt(j));
-    }
-    sb.append(quote);
-  }
-
   @Override
-  public String generate(List<IN> input, Schema<IN, ? extends CharSequence> schema) {
+  public String generate(List<IN> input, Schema<IN, ?> schema) {
     StringBuilder sb = new StringBuilder();
     generateHeader(schema, sb);
     for (int i = 0; i < input.size(); i++) {
@@ -61,7 +47,26 @@ public class CsvTransformer<IN extends AbstractProvider<?>>
     return sb.toString();
   }
 
-  private void generateHeader(Schema<?, ? extends CharSequence> schema, StringBuilder sb) {
+  private void addLine(StringBuilder sb, Object transform) {
+    if (transform instanceof CharSequence) {
+      addCharSequence(sb, (CharSequence) transform);
+    } else {
+      sb.append(transform);
+    }
+  }
+
+  private void addCharSequence(StringBuilder sb, CharSequence charSequence) {
+    sb.append(quote);
+    for (int j = 0; j < charSequence.length(); j++) {
+      if (charSequence.charAt(j) == quote) {
+        sb.append(quote);
+      }
+      sb.append(charSequence.charAt(j));
+    }
+    sb.append(quote);
+  }
+  
+  private void generateHeader(Schema<?, ?> schema, StringBuilder sb) {
     if (withHeader) {
       for (int i = 0; i < schema.getFields().length; i++) {
         addLine(sb, schema.getFields()[i].getName());
@@ -74,7 +79,7 @@ public class CsvTransformer<IN extends AbstractProvider<?>>
   }
 
   @Override
-  public String generate(Schema<?, ? extends CharSequence> schema, int limit) {
+  public String generate(Schema<IN, ?> schema, int limit) {
     StringBuilder sb = new StringBuilder();
     generateHeader(schema, sb);
     for (int i = 0; i < limit; i++) {
@@ -86,7 +91,7 @@ public class CsvTransformer<IN extends AbstractProvider<?>>
     return sb.toString();
   }
 
-  public static class CsvTransformerBuilder<IN extends AbstractProvider<?>> {
+  public static class CsvTransformerBuilder<IN> {
     private String separator = DEFAULT_SEPARATOR;
     private char quote = DEFAULT_QUOTE;
     private boolean withHeader = true;

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -14,7 +14,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
   private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
 
   @Override
-  public String apply(Object input, Schema<IN, ? extends Object> schema) {
+  public String apply(IN input, Schema<IN, ? extends Object> schema) {
     Field<?, ?>[] fields = schema.getFields();
     if (fields.length == 0) {
       return "{}";

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -1,7 +1,5 @@
 package net.datafaker.transformations;
 
-import net.datafaker.providers.base.AbstractProvider;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -12,11 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class JsonTransformer<IN extends AbstractProvider<?>> implements Transformer<IN, Object> {
+public class JsonTransformer<IN> implements Transformer<IN, Object> {
   private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
 
   @Override
-  public String apply(Object input, Schema<?, ? extends Object> schema) {
+  public String apply(Object input, Schema<IN, ? extends Object> schema) {
     Field<?, ?>[] fields = schema.getFields();
     if (fields.length == 0) {
       return "{}";
@@ -39,13 +37,14 @@ public class JsonTransformer<IN extends AbstractProvider<?>> implements Transfor
     return sb.toString();
   }
 
-  public String generate(List<IN> input, Schema<IN, ? extends Object> schema) {
+  @Override
+  public String generate(List<IN> input, Schema<IN, ?> schema) {
     String result = input.stream().map(t -> apply(t, schema)).collect(Collectors.joining(",\n"));
     return input.size() > 1 ? "{\n" + result + "}" : result;
   }
 
   @Override
-  public String generate(Schema<?, ?> schema, int limit) {
+  public String generate(Schema<IN, ?> schema, int limit) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < limit; i++) {
       sb.append(apply(null, schema));

--- a/src/main/java/net/datafaker/transformations/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/SqlTransformer.java
@@ -1,11 +1,8 @@
 package net.datafaker.transformations;
 
-import net.datafaker.providers.base.AbstractProvider;
-
 import java.util.List;
 
-public class SqlTransformer<IN extends AbstractProvider<?>>
-    implements Transformer<IN, CharSequence> {
+public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     private static final char DEFAULT_QUOTE = '\'';
     private static final String DEFAULT_SQL_IDENTIFIER = "\"\"";
 
@@ -36,8 +33,9 @@ public class SqlTransformer<IN extends AbstractProvider<?>>
     }
 
     @Override
-    public CharSequence apply(Object input, Schema<?, ? extends CharSequence> schema) {
-        Field<? extends Object, ? extends CharSequence>[] fields = schema.getFields();
+    public CharSequence apply(Object input, Schema<IN, ?> schema) {
+        //noinspection unchecked
+        Field<?, ? extends CharSequence>[] fields = (Field<?, ? extends CharSequence>[]) schema.getFields();
         if (fields.length == 0) {
             return "";
         }
@@ -74,6 +72,7 @@ public class SqlTransformer<IN extends AbstractProvider<?>>
         sb.append(") VALUES (");
         for (int i = 0; i < fields.length; i++) {
             if (fields[i] instanceof SimpleField) {
+                //noinspection unchecked
                 Object value = ((SimpleField<Object, ? extends CharSequence>) fields[i]).transform(input);
                 Class<?> clazz = value == null ? null : value.getClass();
                 if (value == null
@@ -102,7 +101,7 @@ public class SqlTransformer<IN extends AbstractProvider<?>>
     }
 
     @Override
-    public String generate(List<IN> input, Schema<IN, ? extends CharSequence> schema) {
+    public String generate(List<IN> input, Schema<IN, ?> schema) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < input.size(); i++) {
             sb.append(apply(input.get(i), schema));
@@ -114,7 +113,7 @@ public class SqlTransformer<IN extends AbstractProvider<?>>
     }
 
     @Override
-    public String generate(Schema<?, ? extends CharSequence> schema, int limit) {
+    public String generate(Schema<IN, ?> schema, int limit) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < limit; i++) {
             sb.append(apply(null, schema));
@@ -125,40 +124,40 @@ public class SqlTransformer<IN extends AbstractProvider<?>>
         return sb.toString();
     }
 
-    public static class SqlTransformerBuilder {
+    public static class SqlTransformerBuilder<IN> {
         private char quote = DEFAULT_QUOTE;
         private String sqlQuoteIdentifier = DEFAULT_SQL_IDENTIFIER;
         private String tableName = "MyTable";
         private Casing casing = Casing.TO_UPPER;
 
-        public SqlTransformerBuilder dialect(SqlDialect dialect) {
+        public SqlTransformerBuilder<IN> dialect(SqlDialect dialect) {
             sqlQuoteIdentifier = dialect.getSqlQuoteIdentifier();
             casing = dialect.getUnquotedCasing();
             return this;
         }
 
-        public SqlTransformerBuilder casing(Casing casing) {
+        public SqlTransformerBuilder<IN> casing(Casing casing) {
             this.casing = casing;
             return this;
         }
 
-        public SqlTransformerBuilder quote(char quote) {
+        public SqlTransformerBuilder<IN> quote(char quote) {
             this.quote = quote;
             return this;
         }
 
-        public SqlTransformerBuilder sqlQuoteIdentifier(String sqlQuoteIdentifier) {
+        public SqlTransformerBuilder<IN> sqlQuoteIdentifier(String sqlQuoteIdentifier) {
             this.sqlQuoteIdentifier = sqlQuoteIdentifier;
             return this;
         }
 
-        public SqlTransformerBuilder tableName(String tableName) {
+        public SqlTransformerBuilder<IN> tableName(String tableName) {
             this.tableName = tableName;
             return this;
         }
 
-        public SqlTransformer build() {
-            return new SqlTransformer(quote, sqlQuoteIdentifier, tableName, casing);
+        public SqlTransformer<IN> build() {
+            return new SqlTransformer<>(quote, sqlQuoteIdentifier, tableName, casing);
         }
     }
 }

--- a/src/main/java/net/datafaker/transformations/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/SqlTransformer.java
@@ -33,7 +33,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     @Override
-    public CharSequence apply(Object input, Schema<IN, ?> schema) {
+    public CharSequence apply(IN input, Schema<IN, ?> schema) {
         //noinspection unchecked
         Field<?, ? extends CharSequence>[] fields = (Field<?, ? extends CharSequence>[]) schema.getFields();
         if (fields.length == 0) {

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -1,11 +1,9 @@
 package net.datafaker.transformations;
 
-import net.datafaker.providers.base.AbstractProvider;
-
 import java.util.List;
 
-public interface Transformer<IN extends AbstractProvider<?>, OUT> {
-    OUT apply(Object input, Schema<?, ? extends OUT> schema);
-    String generate(List<IN> input, final Schema<IN, ? extends OUT> schema);
-    String generate(final Schema<?, ? extends OUT> schema, int limit);
+public interface Transformer<IN, OUT> {
+    OUT apply(Object input, Schema<IN, ?> schema);
+    OUT generate(List<IN> input, final Schema<IN, ?> schema);
+    OUT generate(final Schema<IN, ?> schema, int limit);
 }

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -3,7 +3,7 @@ package net.datafaker.transformations;
 import java.util.List;
 
 public interface Transformer<IN, OUT> {
-    OUT apply(Object input, Schema<IN, ?> schema);
+    OUT apply(IN input, Schema<IN, ?> schema);
     OUT generate(List<IN> input, final Schema<IN, ?> schema);
     OUT generate(final Schema<IN, ?> schema, int limit);
 }

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -26,7 +26,7 @@ class JsonTest {
   @ParameterizedTest
   @MethodSource("generateTestSchema")
   void simpleJsonTestForJsonTransformer(Schema<String, String> schema, String expected) {
-    JsonTransformer<?> transformer = new JsonTransformer();
+    JsonTransformer<String> transformer = new JsonTransformer<>();
     assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
   }
 

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -17,7 +17,7 @@ public class SqlTest {
     @ParameterizedTest
     @MethodSource("generateTestSchema")
     void simpleSqlTestForSqlTransformer(Schema<String, String> schema, String expected) {
-        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().sqlQuoteIdentifier("`").tableName("MY_TABLE").build();
+        SqlTransformer<String> transformer = new SqlTransformer.SqlTransformerBuilder<String>().sqlQuoteIdentifier("`").tableName("MY_TABLE").build();
         assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
     }
 
@@ -35,7 +35,7 @@ public class SqlTest {
     @ParameterizedTest
     @MethodSource("generateTestSchemaForPostgres")
     void simpleSqlTestForSqlTransformerPostgres(Schema<String, String> schema, String expected) {
-        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().dialect(SqlDialect.POSTGRES).build();
+        SqlTransformer<String> transformer = new SqlTransformer.SqlTransformerBuilder<String>().dialect(SqlDialect.POSTGRES).build();
         assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
     }
 
@@ -53,7 +53,7 @@ public class SqlTest {
     @ParameterizedTest
     @MethodSource("generateTestSchemaForMSSQL")
     void simpleSqlTestForSqlTransformerMSSQL(Schema<String, String> schema, String expected) {
-        SqlTransformer<?> transformer = new SqlTransformer.SqlTransformerBuilder().dialect(SqlDialect.MSSQL).build();
+        SqlTransformer<String> transformer = new SqlTransformer.SqlTransformerBuilder<String>().dialect(SqlDialect.MSSQL).build();
         assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
     }
 


### PR DESCRIPTION
@snuyanzin  could you review generics in Transformer interface, please?

I've found a number of issues here:
1. On the code below, `Schema<?, ? extends OUT>` means that `OUT transform(IN input)` function from `Field` interface could generate the value only of some specific type. For example for `CsvTransformer` class, `OUT` is defined as `CharSequence`, so it means that we can generate CSV only from CharSequence, we couldn't generate CSV (fields) from other objects (integer, double, boolean e.g.). 
Take a look on the test case `testCsvWithDifferentObjects` and `testCsvWithDifferentObjectsFunction`.
```java
public interface Transformer<IN extends AbstractProvider<?>, OUT> {
    OUT apply(Object input, Schema<?, ? extends OUT> schema);
...
```

2. Here, `IN` generic type should not extends AbstractProvider, because in fact that type corresponds to the  
`Schema<IN, ...>` interface  then it is passed to the function `OUT transform(IN input)`  from `Field` interface, that function takes an argument of IN type and feeds it to the functional interface, which generates the data based on the argument, therefore, the argument could be an object of any type. 
Take a look on the test case `testCsvWithDifferentObjects` and `testCsvWithDifferentObjectsFunction`.
```java
public interface Transformer<IN extends AbstractProvider<?>, OUT> {
    ...
    String generate(List<IN> input, final Schema<IN, ? extends OUT> schema);
    ...
}
```

3. I think all the functions from interface `Transformer` should return a data of type `OUT`

Otherwise, if we don't want to change the types definition, we have to try to adjust the code to that types.