### PR TITLE
Run AssertJ best practices OpenRewrite recipe

### DIFF
--- a/.github/workflows/openrewrite.yml
+++ b/.github/workflows/openrewrite.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: OpenRewrite dryRun
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  mvn_options: --batch-mode -Dstyle.color=always -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: OpenRewrite dryRun
+        run: ./mvnw $mvn_options rewrite:dryRun --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -378,5 +378,31 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>openrewrite-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <version>4.36.0</version>
+                        <configuration>
+                            <activeRecipes>
+                                <recipe>org.openrewrite.java.testing.assertj.Assertj</recipe>
+                                <recipe>org.openrewrite.java.testing.cleanup.BestPractices</recipe>
+                            </activeRecipes>
+                            <failOnDryRunResults>true</failOnDryRunResults>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.openrewrite.recipe</groupId>
+                                <artifactId>rewrite-testing-frameworks</artifactId>
+                                <version>1.30.0</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -199,7 +199,7 @@ class FakerTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-    void testLimitForCsvExpression(int limit) {
+    void limitForCsvExpression(int limit) {
         String csvFullExpression = faker.expression("#{csv ';','\"','false','" + limit + "','first_name','#{Name.first_name}','last_name','#{Name.last_name}'}");
         String csvShortExpression = faker.expression("#{csv '" + limit + "','first_name','#{Name.first_name}','last_name','#{Name.last_name}'}");
 

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -138,7 +138,7 @@ class CsvTest extends AbstractFakerTest {
   }
 
   @Test
-  void testCsvWithComma() {
+  void csvWithComma() {
 
     String csv =
         Format.toCsv(
@@ -160,7 +160,7 @@ class CsvTest extends AbstractFakerTest {
   }
 
   @Test
-  void testCsvWithCommaNew() {
+  void csvWithCommaNew() {
     Schema<?, ? extends CharSequence> schema =
         Schema.of(field("values", () -> "1,2,3"), field("title", () -> "The \"fabulous\" artist"));
     CsvTransformer<?> transformer =
@@ -178,7 +178,7 @@ class CsvTest extends AbstractFakerTest {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-  void testLimitForCsv(int limit) {
+  void limitForCsv(int limit) {
     final BaseFaker faker = new BaseFaker();
     String csv =
         Format.toCsv(faker.<Name>collection().suppliers(faker::name).maxLen(limit + 1).build())
@@ -202,7 +202,7 @@ class CsvTest extends AbstractFakerTest {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-  void testLimitForCsvNew(int limit) {
+  void limitForCsvNew(int limit) {
     final BaseFaker faker = new BaseFaker();
     Schema<Name, String> schema =
         Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName));
@@ -226,7 +226,7 @@ class CsvTest extends AbstractFakerTest {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-  void testLimitForCollection(int limit) {
+  void limitForCollection(int limit) {
     final BaseFaker faker = new BaseFaker();
     String csv =
         Format.toCsv(faker.<Name>collection().suppliers(faker::name).maxLen(limit).build())
@@ -250,7 +250,7 @@ class CsvTest extends AbstractFakerTest {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 2, 3, 10, 20, 100})
-  void testLimitForCollectionNew(int limit) {
+  void limitForCollectionNew(int limit) {
     final BaseFaker faker = new BaseFaker();
     Schema<Name, String> schema =
         Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName));
@@ -273,7 +273,7 @@ class CsvTest extends AbstractFakerTest {
   }
 
     @Test
-    void testInfiniteCsv() {
+    void infiniteCsv() {
         final BaseFaker faker = new BaseFaker();
         FakeSequence<Name> infiniteSequence = faker.<Name>stream()
             .suppliers(faker::name)
@@ -292,7 +292,7 @@ class CsvTest extends AbstractFakerTest {
     }
 
     @Test
-    void testInfiniteCsvWithLimit() {
+    void infiniteCsvWithLimit() {
         int limit = 10;
         final BaseFaker faker = new BaseFaker();
         FakeSequence<Name> infiniteSequence = faker.<Name>stream()

--- a/src/test/java/net/datafaker/idnumbers/EnZAIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/EnZAIdNumberTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EnZAIdNumberTest {
 
     @Test
-    void testExistSsn() {
+    void existSsn() {
         EnZAIdNumber idNumber = new EnZAIdNumber();
 
         assertThat(idNumber.validSsn("9202204720085")).isFalse();
@@ -26,7 +26,7 @@ class EnZAIdNumberTest {
     }
 
     @RepeatedTest(100)
-    void testFakerSsn() {
+    void fakerSsn() {
         EnZAIdNumber idNumber = new EnZAIdNumber();
         final BaseFaker f = new BaseFaker(new Locale("en", "ZA"));
 
@@ -35,7 +35,7 @@ class EnZAIdNumberTest {
     }
 
     @RepeatedTest(100)
-    void testSsnFormat() {
+    void ssnFormat() {
         final BaseFaker f = new BaseFaker(new Locale("en", "ZA"));
         assertThat(f.idNumber().valid()).matches("\\d{10}[01]8\\d");
         assertThat(f.idNumber().invalid()).matches("\\d{10}[01]8\\d");

--- a/src/test/java/net/datafaker/idnumbers/EsMXIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/EsMXIdNumberTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EsMXIdNumberTest {
 
     @RepeatedTest(100)
-    void testValidMXSsn() {
+    void validMXSsn() {
         final BaseFaker f = new BaseFaker(new Locale("es-MX"));
         assertThat(f.idNumber().valid()).matches("[A-Z][A-Z][A-Z][A-Z]\\d{6}[HM]" +
             "[A-Z][A-Z][A-Z][A-Z][A-Z][A-Z,0-9]\\d");
@@ -19,7 +19,7 @@ class EsMXIdNumberTest {
     }
 
     @RepeatedTest(100)
-    void testInvalidMXSsn() {
+    void invalidMXSsn() {
         final BaseFaker f = new BaseFaker(new Locale("es-MX"));
         assertThat(f.idNumber().validEsMXSsn()).matches("[A-Z][A-Z][A-Z][A-Z]\\d{6}[HM]" +
             "[A-Z][A-Z][A-Z][A-Z][A-Z][A-Z,0-9]\\d");

--- a/src/test/java/net/datafaker/idnumbers/PeselNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/PeselNumberTest.java
@@ -28,7 +28,7 @@ class PeselNumberTest {
 
     @ParameterizedTest
     @EnumSource(value = Gender.class, names = {"MALE", "FEMALE"})
-    void testGenderedPesel(Gender givenGender) {
+    void genderedPesel(Gender givenGender) {
         /*
          * Given
          */
@@ -50,7 +50,7 @@ class PeselNumberTest {
 
     @ParameterizedTest
     @ValueSource(ints = {1850, 1950, 2050, 2150, 2250})
-    void testCenturiesPesel(int givenBirthYear) {
+    void centuriesPesel(int givenBirthYear) {
         /*
          * Given
          */
@@ -71,7 +71,7 @@ class PeselNumberTest {
 
     @ParameterizedTest()
     @ValueSource(ints = {1799, 2300})
-    void testInvalidCenturiesPesel(int givenBirthYear) {
+    void invalidCenturiesPesel(int givenBirthYear) {
         /*
          * Given
          */
@@ -85,7 +85,7 @@ class PeselNumberTest {
     }
 
     @Test
-    void testNullGender() {
+    void nullGender() {
         /*
          * Given
          */

--- a/src/test/java/net/datafaker/idnumbers/PtNifIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/PtNifIdNumberTest.java
@@ -19,19 +19,19 @@ class PtNifIdNumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    void testInValid() {
+    void inValid() {
         PtNifIdNumber idNumber = new PtNifIdNumber();
         assertThat(idNumber.getInvalid(ptFaker)).matches("[0-9]{9,10}");
     }
 
     @RepeatedTest(100)
-    void testValid() {
+    void valid() {
         PtNifIdNumber idNumber = new PtNifIdNumber();
         assertThat(idNumber.getValid(ptFaker)).matches("[0-9]{9,10}");
     }
 
     @RepeatedTest(100)
-    void testValidWithFaker() {
+    void validWithFaker() {
         assertThat(ptFaker.idNumber().valid()).matches("[0-9]{9,10}");
     }
 

--- a/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.Locale;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ZhCNIdNumberTest extends AbstractFakerTest {
 

--- a/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ZhCNIdNumberTest extends AbstractFakerTest {
 
     @RepeatedTest(10)
-    void testValidChineseIdNumber() {
+    void validChineseIdNumber() {
         BaseFaker faker = new BaseFaker(new Locale("zh_CN"));
         String idNumber = faker.idNumber().valid();
         boolean isSatisfied = idNumber.length() == 18;
@@ -33,7 +33,7 @@ class ZhCNIdNumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(10)
-    void testChecksumOfChineseIdNumber() {
+    void checksumOfChineseIdNumber() {
         BaseFaker faker = new BaseFaker(new Locale("zh_CN"));
         String s = faker.idNumber().valid();
         boolean isSatisfied = true;
@@ -63,7 +63,7 @@ class ZhCNIdNumberTest extends AbstractFakerTest {
     }
 
     @RepeatedTest(100)
-    void testValidZhCnIdNumber() {
+    void validZhCnIdNumber() {
         ZhCnIdNumber id = new ZhCnIdNumber();
         String idNumber = id.getValidSsn(faker);
         boolean isSatisfied = idNumber.length() == 18;

--- a/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
+++ b/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
@@ -83,7 +83,7 @@ class FakerIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("dataParameters")
-    void testAllFakerMethodsThatReturnStrings(Locale locale, Random random) throws Exception {
+    void allFakerMethodsThatReturnStrings(Locale locale, Random random) throws Exception {
         final Faker faker = init(locale, random);
 
         Method[] methods = faker.getClass().getMethods();
@@ -129,7 +129,7 @@ class FakerIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("dataParameters")
-    void testExceptionsNotCoveredInAboveTest(Locale locale, Random random) {
+    void exceptionsNotCoveredInAboveTest(Locale locale, Random random) {
         final BaseFaker faker = init(locale, random);
         assertThat(faker.bothify("####???")).isNotNull();
         assertThat(faker.letterify("????")).isNotNull();

--- a/src/test/java/net/datafaker/providers/base/AddressTest.java
+++ b/src/test/java/net/datafaker/providers/base/AddressTest.java
@@ -45,31 +45,31 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     private final static Function<Locale, String> ESCAPED_DECIMAL_SEPARATOR = t -> "\\" + new DecimalFormatSymbols(t).getDecimalSeparator();
 
     @Test
-    void testStreetName() {
+    void streetName() {
         final BaseFaker faker = new BaseFaker();
         assertThat(faker.address().streetName()).isNotEmpty();
     }
 
     @Test
-    void testBulgarianStreetName() {
+    void bulgarianStreetName() {
         final BaseFaker localFaker = new BaseFaker(new Locale("bg"));
         assertThat(localFaker.address().streetName()).isNotEmpty();
     }
 
     @Test
-    void testStreetAddressStartsWithNumber() {
+    void streetAddressStartsWithNumber() {
         final String streetAddressNumber = faker.address().streetAddress();
         assertThat(streetAddressNumber).matches("[0-9]+ .+");
     }
 
     @Test
-    void testStreetAddressIsANumber() {
+    void streetAddressIsANumber() {
         final String streetAddressNumber = faker.address().streetAddressNumber();
         assertThat(streetAddressNumber).matches("[0-9]+");
     }
 
     @RepeatedTest(100)
-    void testLatitude() {
+    void latitude() {
         String latStr = faker.address().latitude().replace(decimalSeparator, '.');
         assertThat(latStr).is(IS_A_NUMBER);
         Double lat = Double.valueOf(latStr);
@@ -77,7 +77,7 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testLongitude() {
+    void longitude() {
         String longStr = faker.address().longitude().replace(decimalSeparator, '.');
         assertThat(longStr).is(IS_A_NUMBER);
         Double lon = Double.valueOf(longStr);
@@ -85,56 +85,56 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testLocaleLatitude() {
+    void localeLatitude() {
         BaseFaker engFaker = new BaseFaker(Locale.ENGLISH);
         String engLatStr = engFaker.address().latitude();
         assertThat(engLatStr).matches("-?\\d{1,3}\\.\\d+");
     }
 
     @RepeatedTest(10)
-    void testLocaleLongitude() {
+    void localeLongitude() {
         BaseFaker engFaker = new BaseFaker(Locale.ENGLISH);
         String engLatStr = engFaker.address().longitude();
         assertThat(engLatStr).matches("-?\\d{1,3}\\.\\d+");
     }
 
     @Test
-    void testTimeZone() {
+    void timeZone() {
         assertThat(faker.address().timeZone()).matches("[A-Za-z_]+/[A-Za-z_]+[/A-Za-z_]*");
     }
 
     @Test
-    void testState() {
+    void state() {
         assertThat(faker.address().state()).matches("[A-Za-z ]+");
     }
 
     @Test
-    void testCity() {
+    void city() {
         assertThat(faker.address().city()).matches("[A-Za-z'() ]+");
     }
 
     @Test
-    void testCityName() {
+    void cityName() {
         assertThat(faker.address().cityName()).matches("[A-Za-z'() ]+");
     }
 
     @Test
-    void testCountry() {
+    void country() {
         assertThat(faker.address().country()).matches("[A-Za-z\\- &.,'()\\d]+");
     }
 
     @Test
-    void testCountryCode() {
+    void countryCode() {
         assertThat(faker.address().countryCode()).matches("[A-Za-z ]+");
     }
 
     @Test
-    void testStreetAddressIncludeSecondary() {
+    void streetAddressIncludeSecondary() {
         assertThat(faker.address().streetAddress(true)).isNotEmpty();
     }
 
     @Test
-    void testCityWithLocaleFranceAndSeed() {
+    void cityWithLocaleFranceAndSeed() {
         long seed = 1L;
         BaseFaker firstFaker = new BaseFaker(Locale.FRANCE, new Random(seed));
         BaseFaker secondFaker = new BaseFaker(Locale.FRANCE, new Random(seed));
@@ -142,24 +142,24 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testFullAddress() {
+    void fullAddress() {
         assertThat(faker.address().fullAddress()).isNotEmpty();
     }
 
     @Test
-    void testZipCodeByState() {
+    void zipCodeByState() {
         final BaseFaker localFaker = new BaseFaker(new Locale("en", "US"));
         assertThat(localFaker.address().zipCodeByState(localFaker.address().stateAbbr())).matches("[0-9]{5}");
     }
 
     @Test
-    void testHungarianZipCodeByState() {
+    void hungarianZipCodeByState() {
         final BaseFaker localFaker = new BaseFaker(new Locale("hu"));
         assertThat(localFaker.address().zipCodeByState(localFaker.address().stateAbbr())).matches("[0-9]{4}");
     }
 
     @Test
-    void testCountyByZipCode() {
+    void countyByZipCode() {
         final BaseFaker localFaker = new BaseFaker(new Locale("en", "US"));
         assertThat(localFaker.address().countyByZipCode("47732")).isNotEmpty();
     }
@@ -167,7 +167,7 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     @ParameterizedTest
     @NullSource
     @ValueSource(strings = {"1", "asd", "qwe", "wrong"})
-    void testCountyForWrongZipCode(String zipCode) {
+    void countyForWrongZipCode(String zipCode) {
         final BaseFaker localFaker = new BaseFaker(new Locale("en", "US"));
         assertThatThrownBy(() -> localFaker.address().countyByZipCode(zipCode))
             .isInstanceOf(RuntimeException.class)
@@ -175,44 +175,44 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testStreetPrefix() {
+    void streetPrefix() {
         assertThat(faker.address().streetPrefix()).isNotEmpty();
     }
 
     @Test
-    void testStreetSuffix() {
+    void streetSuffix() {
         assertThat(faker.address().streetSuffix()).isNotEmpty();
     }
 
     @Test
-    void testCityPrefix() {
+    void cityPrefix() {
         assertThat(faker.address().cityPrefix()).isNotEmpty();
     }
 
     @Test
-    void testCitySuffix() {
+    void citySuffix() {
         assertThat(faker.address().citySuffix()).isNotEmpty();
     }
 
     @RepeatedTest(10)
-    void testMailbox() {
+    void mailbox() {
         assertThat(faker.address().mailBox()).matches("PO Box [0-9]{2,4}");
     }
 
     @Test
-    void testZipIsFiveChars() {
+    void zipIsFiveChars() {
         final BaseFaker localFaker = new BaseFaker(new Locale("en", "US"));
         assertThat(localFaker.address().zipCode()).hasSize(5);
     }
 
     @Test
-    void testZipPlus4IsTenChars() {
+    void zipPlus4IsTenChars() {
         final BaseFaker localFaker = new BaseFaker(new Locale("en", "US"));
         assertThat(localFaker.address().zipCodePlus4()).hasSize(10);  // includes dash
     }
 
     @Test
-    void testZipPlus4IsNineDigits() {
+    void zipPlus4IsNineDigits() {
         final BaseFaker localFaker = new BaseFaker(new Locale("en", "US"));
         final String[] zipCodeParts = localFaker.address().zipCodePlus4().split("-");
         assertThat(zipCodeParts[0]).matches("[0-9]{5}");
@@ -220,37 +220,37 @@ class AddressTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testLatLonEnUs() {
+    void latLonEnUs() {
         assertThat(US_FAKER.address().latLon())
             .matches(BI_LAT_LON_REGEX.apply(ESCAPED_DECIMAL_SEPARATOR.apply(US_FAKER.getContext().getLocale()), ","));
     }
 
     @RepeatedTest(100)
-    void testLatLonNl() {
+    void latLonNl() {
         assertThat(NL_FAKER.address().latLon())
             .matches(BI_LAT_LON_REGEX.apply(ESCAPED_DECIMAL_SEPARATOR.apply(NL_FAKER.getContext().getLocale()), ","));
     }
 
     @RepeatedTest(100)
-    void testLonLatEnUs() {
+    void lonLatEnUs() {
         assertThat(US_FAKER.address().lonLat())
             .matches(BI_LON_LAT_REGEX.apply(ESCAPED_DECIMAL_SEPARATOR.apply(US_FAKER.getContext().getLocale()), ","));
     }
 
     @RepeatedTest(100)
-    void testLonLatNl() {
+    void lonLatNl() {
         assertThat(NL_FAKER.address().lonLat())
             .matches(BI_LON_LAT_REGEX.apply(ESCAPED_DECIMAL_SEPARATOR.apply(NL_FAKER.getContext().getLocale()), ","));
     }
 
     @Test
-    void testLonLatRU() {
+    void lonLatRU() {
         assertThat(RU_FAKER.address().lonLat(";"))
             .matches(BI_LON_LAT_REGEX.apply(ESCAPED_DECIMAL_SEPARATOR.apply(RU_FAKER.getContext().getLocale()), ";"));
     }
 
     @Test
-    void testLatLonRU() {
+    void latLonRU() {
         assertThat(RU_FAKER.address().latLon(";"))
             .matches(BI_LAT_LON_REGEX.apply(ESCAPED_DECIMAL_SEPARATOR.apply(RU_FAKER.getContext().getLocale()), ";"));
     }

--- a/src/test/java/net/datafaker/providers/base/AppTest.java
+++ b/src/test/java/net/datafaker/providers/base/AppTest.java
@@ -7,17 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AppTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.app().name()).matches("([\\w-]+ ?)+");
     }
 
     @Test
-    void testVersion() {
+    void version() {
         assertThat(faker.app().version()).matches("\\d\\.(\\d){1,2}(\\.\\d)?");
     }
 
     @Test
-    void testAuthor() {
+    void author() {
         assertThat(faker.app().author()).matches("([\\w']+[-&,.]? ?){2,9}");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/AwsTest.java
+++ b/src/test/java/net/datafaker/providers/base/AwsTest.java
@@ -7,47 +7,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AwsTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testAccountId() {
+    void accountId() {
         assertThat(faker.aws().accountId()).matches("^\\d{10}$");
     }
 
     @Test
-    void testAcmARN() {
+    void acmARN() {
         assertThat(faker.aws().acmARN()).matches("^arn:aws:acm:\\w+-\\w+-\\d:\\d{10}:certificate/[\\w\\-]+$");
     }
 
     @Test
-    void testAlbARN() {
+    void albARN() {
         assertThat(faker.aws().albARN()).matches("^arn:aws:elasticloadbalancing:\\w+-\\w+-\\d:\\d{10}:loadbalancer/app/[\\w]+/\\w+$");
     }
 
     @Test
-    void testAlbTargetGroupARN() {
+    void albTargetGroupARN() {
         assertThat(faker.aws().albTargetGroupARN()).matches("^arn:aws:elasticloadbalancing:\\w+-\\w+-\\d:\\d{10}:targetgroup/[\\w]+/\\w+$");
     }
 
     @Test
-    void testRoute53ZoneId() {
+    void route53ZoneId() {
         assertThat(faker.aws().route53ZoneId()).matches("^\\w{21}$");
     }
 
     @Test
-    void testSecurityGroupId() {
+    void securityGroupId() {
         assertThat(faker.aws().securityGroupId()).matches("^sg-[0-9a-f]{16}$");
     }
 
     @Test
-    void testSubnetId() {
+    void subnetId() {
         assertThat(faker.aws().subnetId()).matches("^subnet-[0-9a-f]{16}$");
     }
 
     @Test
-    void testVpcId() {
+    void vpcId() {
         assertThat(faker.aws().vpcId()).matches("^vpc-[0-9a-f]{16}$");
     }
 
     @Test
-    void testRegion() {
+    void region() {
         String region = faker.aws().region();
         assertThat(region).matches("^[a-z]{2}-(south|east|north|west|northeast|central|southeast)-\\d$");
     }

--- a/src/test/java/net/datafaker/providers/base/BarcodeTest.java
+++ b/src/test/java/net/datafaker/providers/base/BarcodeTest.java
@@ -27,55 +27,55 @@ class BarcodeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testEan13() {
+    void ean13() {
         assertThat(String.valueOf(faker.barcode().ean13())).matches("[0-9]{13}");
     }
 
     @Test
-    void testGtin13() {
+    void gtin13() {
         assertThat(String.valueOf(faker.barcode().gtin13())).matches("[0-9]{13}");
     }
 
     @Test
-    void testEan8() {
+    void ean8() {
         assertThat(String.valueOf(faker.barcode().ean8())).matches("[0-9]{8}");
     }
 
     @Test
-    void testGtin8() {
+    void gtin8() {
         assertThat(String.valueOf(faker.barcode().gtin8())).matches("[0-9]{8}");
     }
 
     @Test
-    void testGtin14Length() {
+    void gtin14Length() {
         assertThat(String.valueOf(faker.barcode().gtin14())).matches("[0-9]{14}");
     }
 
     @Test
-    void testGtin12Length() {
+    void gtin12Length() {
         assertThat(String.valueOf(faker.barcode().gtin12())).matches("[0-9]{12}");
     }
 
     @Test
-    void testGtin12CheckSum() {
+    void gtin12CheckSum() {
         long barcode = faker.barcode().gtin12();
         assertThat(BarcodeTest.isBarcodeValid(barcode)).isTrue();
     }
 
     @Test
-    void testGtin14CheckSum() {
+    void gtin14CheckSum() {
         long barcode = faker.barcode().gtin14();
         assertThat(BarcodeTest.isBarcodeValid(barcode)).isTrue();
     }
 
     @Test
-    void testEan8CheckSum() {
+    void ean8CheckSum() {
         long barcode = faker.barcode().ean8();
         assertThat(BarcodeTest.isBarcodeValid(barcode)).isTrue();
     }
 
     @Test
-    void testEan13CheckSum() {
+    void ean13CheckSum() {
         long barcode = faker.barcode().ean13();
         char[] array = String.valueOf(barcode).toCharArray();
         int sum = 0;

--- a/src/test/java/net/datafaker/providers/base/BloodTypeTest.java
+++ b/src/test/java/net/datafaker/providers/base/BloodTypeTest.java
@@ -22,7 +22,7 @@ class BloodTypeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testBloodGroup() {
+    void bloodGroup() {
         assertThat(faker.bloodtype().bloodGroup()).matches("(A|B|AB|O)[+-]");
     }
 

--- a/src/test/java/net/datafaker/providers/base/BookTest.java
+++ b/src/test/java/net/datafaker/providers/base/BookTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BookTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/BookTest.java
+++ b/src/test/java/net/datafaker/providers/base/BookTest.java
@@ -7,22 +7,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BookTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testTitle() {
+    void title() {
         assertThat(faker.book().title()).matches("([\\p{L}'\\-?]+[!,]? ?){2,9}");
     }
 
     @Test
-    void testAuthor() {
+    void author() {
         assertThat(faker.book().author()).matches("([\\w']+\\.? ?){2,3}");
     }
 
     @Test
-    void testPublisher() {
+    void publisher() {
         assertThat(faker.book().publisher()).matches("([\\p{L}'&\\-]+[,.]? ?){1,5}");
     }
 
     @Test
-    void testGenre() {
+    void genre() {
         assertThat(faker.book().genre()).matches("([\\w/]+ ?){2,4}");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/BoolTest.java
+++ b/src/test/java/net/datafaker/providers/base/BoolTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BoolTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(100)
-    void testBool() {
+    void bool() {
         assertThat(faker.bool().bool()).isIn(true, false);
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CameraTest.java
+++ b/src/test/java/net/datafaker/providers/base/CameraTest.java
@@ -7,17 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CameraTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testBrand() {
+    void brand() {
         assertThat(faker.camera().brand()).matches("^[a-zA-Z0-9 -]+$");
     }
 
     @Test
-    void testModel() {
+    void model() {
         assertThat(faker.camera().model()).matches("^[a-zA-Z0-9 -]+$");
     }
 
     @Test
-    void testBrandWithModel() {
+    void brandWithModel() {
         assertThat(faker.camera().brandWithModel()).matches("^[a-zA-Z0-9 -]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CannabisTest.java
+++ b/src/test/java/net/datafaker/providers/base/CannabisTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CannabisTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
+++ b/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ChiquitoTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/CodeTest.java
+++ b/src/test/java/net/datafaker/providers/base/CodeTest.java
@@ -33,7 +33,7 @@ class CodeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testIsbn10() {
+    void isbn10() {
         final BaseFaker faker = new BaseFaker();
         final String isbn10NoSep = faker.code().isbn10(false);
         final String isbn10Sep = faker.code().isbn10(true);
@@ -46,7 +46,7 @@ class CodeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testIsbn13() {
+    void isbn13() {
         final BaseFaker faker = new BaseFaker();
         final String isbn13NoSep = faker.code().isbn13(false);
         final String isbn13Sep = faker.code().isbn13(true);
@@ -68,7 +68,7 @@ class CodeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testOverrides() {
+    void overrides() {
         BaseFaker faker = new BaseFaker(new Locale("test"));
 
         final String isbn10Sep = faker.code().isbn10(true);

--- a/src/test/java/net/datafaker/providers/base/ColorTest.java
+++ b/src/test/java/net/datafaker/providers/base/ColorTest.java
@@ -7,17 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ColorTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.color().name()).matches("(\\w+ ?){1,2}");
     }
 
     @Test
-    void testHex() {
+    void hex() {
         assertThat(faker.color().hex()).matches("^#[0-9A-F]{6}$");
     }
 
     @Test
-    void testHexNoHashSign() {
+    void hexNoHashSign() {
         assertThat(faker.color().hex(false)).matches("^[0-9A-F]{6}$");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CommerceTest.java
+++ b/src/test/java/net/datafaker/providers/base/CommerceTest.java
@@ -15,47 +15,47 @@ class CommerceTest extends BaseFakerTest<BaseFaker> {
     private static final String PROMOTION_CODE_REGEX = CAPITALIZED_WORD_REGEX + "(-" + CAPITALIZED_WORD_REGEX + ")*";
 
     @Test
-    void testDepartment() {
+    void department() {
         assertThat(faker.commerce().department()).matches("(\\w+(, | & )?){1,3}");
     }
 
     @Test
-    void testProductName() {
+    void productName() {
         assertThat(faker.commerce().productName()).matches("(\\w+ ?){3,4}");
     }
 
     @Test
-    void testMaterial() {
+    void material() {
         assertThat(faker.commerce().material()).matches("\\w+");
     }
 
     @Test
-    void testBrand() {
+    void brand() {
         assertThat(faker.commerce().brand()).matches("\\w+");
     }
 
     @Test
-    void testVendor() {
+    void vendor() {
         assertThat(faker.commerce().vendor()).matches("[A-Za-z'() 0-9-,]+");
     }
 
     @Test
-    void testPrice() {
+    void price() {
         assertThat(faker.commerce().price()).matches("\\d{1,3}\\" + decimalSeparator + "\\d{2}");
     }
 
     @Test
-    void testPriceMinMax() {
+    void priceMinMax() {
         assertThat(faker.commerce().price(100, 1000)).matches("\\d{3,4}\\" + decimalSeparator + "\\d{2}");
     }
 
     @Test
-    void testPromotionCode() {
+    void promotionCode() {
         assertThat(faker.commerce().promotionCode()).matches(PROMOTION_CODE_REGEX + PROMOTION_CODE_REGEX + "\\d{6}");
     }
 
     @Test
-    void testPromotionCodeDigits() {
+    void promotionCodeDigits() {
         assertThat(faker.commerce().promotionCode(3)).matches(PROMOTION_CODE_REGEX + PROMOTION_CODE_REGEX + "\\d{3}");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CommunityTest.java
+++ b/src/test/java/net/datafaker/providers/base/CommunityTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CommunityTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testCharacter() {
+    void character() {
         assertThat(faker.community().character()).isNotEmpty();
     }
 
     @Test
-    void testQuote() {
+    void quote() {
         assertThat(faker.community().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CompanyTest.java
+++ b/src/test/java/net/datafaker/providers/base/CompanyTest.java
@@ -8,47 +8,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CompanyTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.company().name()).matches("[A-Za-z\\-&', ]+");
     }
 
     @Test
-    void testSuffix() {
+    void suffix() {
         assertThat(faker.company().suffix()).matches("[A-Za-z ]+");
     }
 
     @Test
-    void testIndustry() {
+    void industry() {
         assertThat(faker.company().industry()).matches("(\\w+([ ,&/-]{1,3})?){1,4}+");
     }
 
     @Test
-    void testBuzzword() {
+    void buzzword() {
         assertThat(faker.company().buzzword()).matches("(\\w+[ /-]?){1,3}");
     }
 
     @Test
-    void testCatchPhrase() {
+    void catchPhrase() {
         assertThat(faker.company().catchPhrase()).matches("(\\w+[ /-]?){1,9}");
     }
 
     @Test
-    void testBs() {
+    void bs() {
         assertThat(faker.company().bs()).matches("(\\w+[ /-]?){1,9}");
     }
 
     @Test
-    void testLogo() {
+    void logo() {
         assertThat(faker.company().logo()).matches("https://pigment.github.io/fake-logos/logos/medium/color/\\d+\\.png");
     }
 
     @Test
-    void testProfession() {
+    void profession() {
         assertThat(faker.company().profession()).matches("[a-z ]+");
     }
 
     @RepeatedTest(100)
-    void testUrl() {
+    void url() {
         String regexp = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])";
         assertThat(faker.company().url()).matches(regexp);
     }

--- a/src/test/java/net/datafaker/providers/base/ComputerTest.java
+++ b/src/test/java/net/datafaker/providers/base/ComputerTest.java
@@ -7,32 +7,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ComputerTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testType() {
+    void type() {
         assertThat(faker.computer().type()).isNotEmpty();
     }
 
     @Test
-    void testPlatform() {
+    void platform() {
         assertThat(faker.computer().platform()).isNotEmpty();
     }
 
     @Test
-    void testOperatingSystem() {
+    void operatingSystem() {
         assertThat(faker.computer().operatingSystem()).isNotEmpty();
     }
 
     @Test
-    void testLinux() {
+    void linux() {
         assertThat(faker.computer().linux()).isNotEmpty();
     }
 
     @Test
-    void testMacos() {
+    void macos() {
         assertThat(faker.computer().macos()).isNotEmpty();
     }
 
     @Test
-    void testWindows() {
+    void windows() {
         assertThat(faker.computer().windows()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/ConstructionTest.java
+++ b/src/test/java/net/datafaker/providers/base/ConstructionTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ConstructionTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/CountryTest.java
+++ b/src/test/java/net/datafaker/providers/base/CountryTest.java
@@ -8,38 +8,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CountryTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(10)
-    void testFlag() {
+    void flag() {
         String flag = faker.country().flag();
         assertThat(flag).matches("^https://flags.fmcdn\\.net/data/flags/w580/[a-zA-Z0-9_]+\\.png$");
     }
 
     @Test
-    void testCode2() {
+    void code2() {
         assertThat(faker.country().countryCode2()).matches("([a-z]{2})");
     }
 
     @Test
-    void testCode3() {
+    void code3() {
         assertThat(faker.country().countryCode3()).matches("([a-z]{3})");
     }
 
     @Test
-    void testCapital() {
+    void capital() {
         assertThat(faker.country().capital()).matches("([\\p{L}0-9+,. '-])+");
     }
 
     @Test
-    void testCurrency() {
+    void currency() {
         assertThat(faker.country().currency()).matches("([A-Za-zÀ-ÿ'’()-]+ ?)+");
     }
 
     @Test
-    void testCurrencyCode() {
+    void currencyCode() {
         assertThat(faker.country().currencyCode()).matches("([\\w-’í]+ ?)+");
     }
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.country().name()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CurrencyTest.java
+++ b/src/test/java/net/datafaker/providers/base/CurrencyTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CurrencyTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.currency().name()).matches("[\\w'.\\-() ]+");
     }
 
     @Test
-    void testCode() {
+    void code() {
         final Currency currency = faker.currency();
         assertThat(currency.code()).matches("[A-Z]{3}");
     }

--- a/src/test/java/net/datafaker/providers/base/DateAndTimeTest.java
+++ b/src/test/java/net/datafaker/providers/base/DateAndTimeTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testFutureDate() {
+    void futureDate() {
         Timestamp now = new Timestamp(System.currentTimeMillis());
         for (int i = 0; i < 1000; i++) {
             Date future = faker.date().future(1, TimeUnit.SECONDS, now);
@@ -38,7 +38,7 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testFutureDateWithMinimum() {
+    void futureDateWithMinimum() {
         final Date now = new Date();
         for (int i = 0; i < 1000; i++) {
             Date future = faker.date().future(5, 4, TimeUnit.SECONDS);
@@ -49,7 +49,7 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPastDateWithMinimum() {
+    void pastDateWithMinimum() {
         for (int i = 0; i < 1000; i++) {
             final long now = System.currentTimeMillis();
             Date past = faker.date().past(5, 4, TimeUnit.SECONDS);
@@ -60,7 +60,7 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPastDateWithReferenceDate() {
+    void pastDateWithReferenceDate() {
         Date now = new Date();
 
         for (int i = 0; i < 1000; i++) {
@@ -71,14 +71,14 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPastDate() {
+    void pastDate() {
         Date now = new Date();
         Date past = faker.date().past(100, TimeUnit.SECONDS);
         assertThat(past.getTime()).isLessThan(now.getTime());
     }
 
     @Test
-    void testBetween() {
+    void between() {
         Timestamp now = new Timestamp(System.currentTimeMillis());
         Timestamp then = new Timestamp(System.currentTimeMillis() + 1000);
 
@@ -90,12 +90,12 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testBetweenDateAsArgument() {
+    void betweenDateAsArgument() {
          faker.date().between(new Date(), new Date());
     }
 
     @Test
-    void testBetweenThenLargerThanNow() {
+    void betweenThenLargerThanNow() {
         Timestamp now = new Timestamp(System.currentTimeMillis());
         Timestamp then = new Timestamp(System.currentTimeMillis() + 1000);
         assertThatThrownBy(() -> faker.date().between(then, now))
@@ -104,7 +104,7 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testBirthday() {
+    void birthday() {
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         int currentMonth = Calendar.getInstance().get(Calendar.MONTH);
         int currentDay = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
@@ -119,7 +119,7 @@ class DateAndTimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testBirthdayWithAges() {
+    void birthdayWithAges() {
         LocalDateTime nw = LocalDateTime.now();
 
         for (int i = 0; i < 5000; i++) {

--- a/src/test/java/net/datafaker/providers/base/DiseaseTest.java
+++ b/src/test/java/net/datafaker/providers/base/DiseaseTest.java
@@ -7,43 +7,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DiseaseTest extends BaseFakerTest<BaseFaker> {
     @Test
-    void testInternalDisease() {
+    void internalDisease() {
         assertThat(faker.disease().internalDisease()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testNeurology() {
+    void neurology() {
         assertThat(faker.disease().neurology()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testSurgery() {
+    void surgery() {
         assertThat(faker.disease().surgery()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testPaediatrics() {
+    void paediatrics() {
         assertThat(faker.disease().paediatrics()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testGynecologyAndObstetrics() {
+    void gynecologyAndObstetrics() {
         assertThat(faker.disease().gynecologyAndObstetrics()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testOphthalmologyAndOtorhinolaryngology() {
+    void ophthalmologyAndOtorhinolaryngology() {
         assertThat(faker.disease().ophthalmologyAndOtorhinolaryngology()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testDermatolory() {
+    void dermatolory() {
         assertThat(faker.disease().dermatolory()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
 
     @Test
-    void testInternalDiseaseWith10000Times() {
+    void internalDiseaseWith10000Times() {
         boolean isExist = false;
         for (int i = 0; i < 10000; i++) {
             String generateString = faker.disease().internalDisease();
@@ -55,32 +55,32 @@ class DiseaseTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(1000)
-    void testNeurologyWith1000Times() {
+    void neurologyWith1000Times() {
         assertThat(faker.disease().neurology()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    void testSurgeryWith1000Times() {
+    void surgeryWith1000Times() {
         assertThat(faker.disease().surgery()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    void testPaediatricsWith1000Times() {
+    void paediatricsWith1000Times() {
         assertThat(faker.disease().paediatrics()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    void testGynecologyAndObstetricsWith1000Times() {
+    void gynecologyAndObstetricsWith1000Times() {
         assertThat(faker.disease().gynecologyAndObstetrics()).isNotEmpty();
     }
 
     @RepeatedTest(1000)
-    void testOphthalmologyAndOtorhinolaryngologyWith1000Times() {
+    void ophthalmologyAndOtorhinolaryngologyWith1000Times() {
         assertThat(faker.disease().ophthalmologyAndOtorhinolaryngology()).isNotEmpty();
     }
 
     @RepeatedTest(10000)
-    void testDermatoloryWith10000Times() {
+    void dermatoloryWith10000Times() {
         assertThat(faker.disease().dermatolory()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/DomainTest.java
+++ b/src/test/java/net/datafaker/providers/base/DomainTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.Test;
 class DomainTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testFirstLevelDomainNotNull() {
+    void firstLevelDomainNotNull() {
         String ret = faker.domain().firstLevelDomain("example");
         assert (ret != null);
     }
 
     @Test
-    void testFirstLevelDomain() {
+    void firstLevelDomain() {
         String[] components = faker.domain().firstLevelDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);
@@ -20,13 +20,13 @@ class DomainTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testSecondLevelDomainNotNull() {
+    void secondLevelDomainNotNull() {
         String ret = faker.domain().secondLevelDomain("example");
         assert (ret != null);
     }
 
     @Test
-    void testSecondLevelDomain() {
+    void secondLevelDomain() {
         String[] components = faker.domain().secondLevelDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);
@@ -35,13 +35,13 @@ class DomainTest extends BaseFakerTest<BaseFaker> {
 
 
     @Test
-    void testFullDomainNotNull() {
+    void fullDomainNotNull() {
         String ret = faker.domain().fullDomain("example");
         assert (ret != null);
     }
 
     @Test
-    void testFullDomain() {
+    void fullDomain() {
         String[] components = faker.domain().fullDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);
@@ -49,13 +49,13 @@ class DomainTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testValidDomainNotNull() {
+    void validDomainNotNull() {
         String ret = faker.domain().validDomain("example");
         assert (ret != null);
     }
 
     @Test
-    void testValidDomain() {
+    void validDomain() {
         String[] components = faker.domain().validDomain("example").split("\\.");
         for (String str : components) {
             assert (str.length() > 0);

--- a/src/test/java/net/datafaker/providers/base/DungeonsAndDragonsTest.java
+++ b/src/test/java/net/datafaker/providers/base/DungeonsAndDragonsTest.java
@@ -1,54 +1,55 @@
 package net.datafaker.providers.base;
 
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class DungeonsAndDragonsTest extends net.datafaker.AbstractFakerTest {
 
     @Test
     void alignments() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().alignments()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().alignments()).isNotEmpty();
     }
 
     @Test
     void backgrounds() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().backgrounds()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().backgrounds()).isNotEmpty();
     }
 
     @Test
     void cities() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().cities()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().cities()).isNotEmpty();
     }
 
     @Test
     void klasses() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().klasses()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().klasses()).isNotEmpty();
     }
 
     @Test
     void languages() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().languages()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().languages()).isNotEmpty();
     }
 
     @Test
     void meleeWeapons() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().meleeWeapons()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().meleeWeapons()).isNotEmpty();
     }
 
     @Test
     void monsters() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().monsters()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().monsters()).isNotEmpty();
     }
 
     @Test
     void races() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().races()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().races()).isNotEmpty();
     }
 
     @Test
     void rangedWeapons() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().rangedWeapons()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().rangedWeapons()).isNotEmpty();
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/DurationTest.java
+++ b/src/test/java/net/datafaker/providers/base/DurationTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DurationTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testDurationSeconds() {
+    void durationSeconds() {
         final long maxSeconds = 55;
         Duration randomDuration = faker.duration().atMostSeconds(maxSeconds);
         Duration lowerBound = Duration.ofSeconds(0);
@@ -19,7 +19,7 @@ class DurationTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testDurationMinutes() {
+    void durationMinutes() {
         final long maxMins = 45;
         Duration randomDuration = faker.duration().atMostMinutes(maxMins);
         Duration lowerBound = Duration.ofMinutes(0);
@@ -29,7 +29,7 @@ class DurationTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testDurationHours() {
+    void durationHours() {
         final long maxHours = 35;
         Duration randomDuration = faker.duration().atMostHours(maxHours);
         Duration lowerBound = Duration.ofHours(0);
@@ -39,7 +39,7 @@ class DurationTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testDurationDays() {
+    void durationDays() {
         final long maxDays = 40;
         Duration randomDuration = faker.duration().atMostDays(maxDays);
         Duration lowerBound = Duration.ofDays(0);

--- a/src/test/java/net/datafaker/providers/base/EducatorTest.java
+++ b/src/test/java/net/datafaker/providers/base/EducatorTest.java
@@ -7,22 +7,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EducatorTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testUniversity() {
+    void university() {
         assertThat(faker.educator().university()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    void testCourse() {
+    void course() {
         assertThat(faker.educator().course()).matches("(\\(?\\w+\\)? ?){3,6}");
     }
 
     @Test
-    void testSecondarySchool() {
+    void secondarySchool() {
         assertThat(faker.educator().secondarySchool()).matches("(\\w+ ?){2,3}");
     }
 
     @Test
-    void testCampus() {
+    void campus() {
         assertThat(faker.educator().campus()).matches("(\\w+ ?){1,2}");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/ElectricalComponentsTest.java
+++ b/src/test/java/net/datafaker/providers/base/ElectricalComponentsTest.java
@@ -7,19 +7,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ElectricalComponentsTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testActive() {
+    void active() {
         String activeComponent = faker.electricalComponents().active();
         assertThat(activeComponent).isNotEmpty();
     }
 
     @Test
-    void testPassive() {
+    void passive() {
         String passiveComponent = faker.electricalComponents().passive();
         assertThat(passiveComponent).isNotEmpty();
     }
 
     @Test
-    void testElectromechanical() {
+    void electromechanical() {
         String electromechanicalComponent = faker.electricalComponents().electromechanical();
         assertThat(electromechanicalComponent).isNotEmpty();
     }

--- a/src/test/java/net/datafaker/providers/base/FamousLastWordsTest.java
+++ b/src/test/java/net/datafaker/providers/base/FamousLastWordsTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FamousLastWordsTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(1000)
-    void testLastWords() {
+    void lastWords() {
         assertThat(faker.famousLastWords().lastWords()).matches("^[A-Za-z- .,'!?-…]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/FileTest.java
+++ b/src/test/java/net/datafaker/providers/base/FileTest.java
@@ -8,41 +8,41 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FileTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(10)
-    void testExtension() {
+    void extension() {
         assertThat(faker.file().extension())
             .matches("(flac|mp3|wav|bmp|gif|jpeg|jpg|png|tiff|css|csv|html|js|json|txt|mp4|avi|mov|webm|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|pages|numbers|key|pdf)");
     }
 
     @RepeatedTest(10)
-    void testMimeTypeFormat() {
+    void mimeTypeFormat() {
         assertThat(faker.file().mimeType()).matches(".+/.+");
     }
 
     @RepeatedTest(10)
-    void testFileName() {
+    void fileName() {
         assertThat(faker.file().fileName()).matches("([a-z\\-_]+)([\\\\/])([a-z\\-_]+)\\.([a-z0-9]+)");
     }
 
     @Test
-    void testFileNameSpecifyExtension() {
+    void fileNameSpecifyExtension() {
         assertThat(faker.file().fileName(null, null, "txt", null))
             .matches("([a-z\\-_]+)([\\\\/])([a-z\\-_]+)\\.txt");
     }
 
     @Test
-    void testFileNameSpecifyDir() {
+    void fileNameSpecifyDir() {
         assertThat(faker.file().fileName("my_dir", null, null, null))
             .matches("my_dir([\\\\/])([a-z\\-_]+)\\.([a-z0-9]+)");
     }
 
     @Test
-    void testFileNameSpecifySeparator() {
+    void fileNameSpecifySeparator() {
         assertThat(faker.file().fileName(null, null, null, "\\"))
             .matches("([a-z\\-_]+)\\\\([a-z\\-_]+)\\.([a-z0-9]+)");
     }
 
     @Test
-    void testFileNameSpecifyName() {
+    void fileNameSpecifyName() {
         assertThat(faker.file().fileName(null, "da_name", null, null))
             .matches("([a-z\\-_]+)([\\\\/])da_name\\.([a-z0-9]+)");
     }

--- a/src/test/java/net/datafaker/providers/base/GreekPhilosopherTest.java
+++ b/src/test/java/net/datafaker/providers/base/GreekPhilosopherTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GreekPhilosopherTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(10)
-    void testName() {
+    void name() {
         assertThat(faker.greekPhilosopher().name()).matches("^[a-zA-Z ]+$");
     }
 
     @RepeatedTest(10)
-    void testQuote() {
+    void quote() {
         assertThat(faker.greekPhilosopher().quote()).matches("^[a-zA-Z ,.']+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/HackerTest.java
+++ b/src/test/java/net/datafaker/providers/base/HackerTest.java
@@ -7,27 +7,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HackerTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testAbbreviation() {
+    void abbreviation() {
         assertThat(faker.hacker().abbreviation()).matches("[A-Z]{2,4}");
     }
 
     @Test
-    void testAdjective() {
+    void adjective() {
         assertThat(faker.hacker().adjective()).matches("(\\w+[- ]?){1,2}");
     }
 
     @Test
-    void testNoun() {
+    void noun() {
         assertThat(faker.hacker().noun()).matches("\\w+( \\w+)?");
     }
 
     @Test
-    void testVerb() {
+    void verb() {
         assertThat(faker.hacker().verb()).matches("\\w+( \\w+)?");
     }
 
     @Test
-    void testIngverb() {
+    void ingverb() {
         assertThat(faker.hacker().ingverb()).matches("\\w+ing( \\w+)?");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/HashingTest.java
+++ b/src/test/java/net/datafaker/providers/base/HashingTest.java
@@ -7,32 +7,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HashingTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testMd2() {
+    void md2() {
         assertThat(faker.hashing().md2()).matches("\\b[a-fA-F\\d]{32}\\b");
     }
 
     @Test
-    void testMd5() {
+    void md5() {
         assertThat(faker.hashing().md5()).matches("\\b[a-fA-F\\d]{32}\\b");
     }
 
     @Test
-    void testSha1() {
+    void sha1() {
         assertThat(faker.hashing().sha1()).matches("\\b[a-fA-F\\d]{40}\\b");
     }
 
     @Test
-    void testSha256() {
+    void sha256() {
         assertThat(faker.hashing().sha256()).matches("\\b[a-fA-F\\d]{64}\\b");
     }
 
     @Test
-    void testSha384() {
+    void sha384() {
         assertThat(faker.hashing().sha384()).matches("\\b[a-fA-F\\d]{96}\\b");
     }
 
     @Test
-    void testSha512() {
+    void sha512() {
         assertThat(faker.hashing().sha512()).matches("\\b[a-fA-F\\d]{128}\\b");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/HouseTest.java
+++ b/src/test/java/net/datafaker/providers/base/HouseTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HouseTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testFurniture() {
+    void furniture() {
         assertThat(faker.house().furniture()).matches("^[a-zA-Z ]+$");
     }
 
     @Test
-    void testRoom() {
+    void room() {
         assertThat(faker.house().room()).matches("^[a-zA-Z ]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/IdNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/IdNumberTest.java
@@ -10,66 +10,66 @@ import static org.assertj.core.api.Assertions.assertThat;
 class IdNumberTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testValid() {
+    void valid() {
         assertThat(faker.idNumber().valid()).matches("[0-8]\\d{2}-\\d{2}-\\d{4}");
     }
 
     @Test
-    void testInvalid() {
+    void invalid() {
         assertThat(faker.idNumber().invalid()).matches("[0-9]\\d{2}-\\d{2}-\\d{4}");
     }
 
     @RepeatedTest(100)
-    void testSsnValid() {
+    void ssnValid() {
         assertThat(faker.idNumber().ssnValid()).matches("[0-8]\\d{2}-\\d{2}-\\d{4}");
     }
 
     @RepeatedTest(100)
-    void testValidSwedishSsn() {
+    void validSwedishSsn() {
         final BaseFaker f = new BaseFaker(new Locale("sv_SE"));
         assertThat(f.idNumber().validSvSeSsn()).matches("\\d{6}[-+]\\d{4}");
     }
 
     @RepeatedTest(100)
-    void testInvalidSwedishSsn() {
+    void invalidSwedishSsn() {
         final BaseFaker f = new BaseFaker(new Locale("sv_SE"));
         assertThat(f.idNumber().invalidSvSeSsn()).matches("\\d{6}[-+]\\d{4}");
     }
 
     @RepeatedTest(100)
-    void testValidEnZaSsn() {
+    void validEnZaSsn() {
         final BaseFaker f = new BaseFaker(new Locale("en_ZA"));
         assertThat(f.idNumber().validEnZaSsn()).matches("[0-9]{10}([01])8[0-9]");
     }
 
     @RepeatedTest(100)
-    void testInvalidEnZaSsn() {
+    void invalidEnZaSsn() {
         final BaseFaker f = new BaseFaker(new Locale("en_ZA"));
         assertThat(f.idNumber().inValidEnZaSsn()).matches("[0-9]{10}([01])8[0-9]");
     }
 
     @RepeatedTest(100)
-    void testSingaporeanFin() {
+    void singaporeanFin() {
         assertThat(faker.idNumber().singaporeanFin()).matches("G[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    void testSingaporeanFinBefore2000() {
+    void singaporeanFinBefore2000() {
         assertThat(faker.idNumber().singaporeanFinBefore2000()).matches("F[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    void testSingaporeanUin() {
+    void singaporeanUin() {
         assertThat(faker.idNumber().singaporeanUin()).matches("T[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    void testSingaporeanUinBefore2000() {
+    void singaporeanUinBefore2000() {
         assertThat(faker.idNumber().singaporeanUinBefore2000()).matches("S[0-9]{7}[A-Z]");
     }
 
     @RepeatedTest(100)
-    void testPeselNumber() {
+    void peselNumber() {
         assertThat(faker.idNumber().peselNumber()).matches("[0-9]{11}");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/IndustrySegmentsTest.java
+++ b/src/test/java/net/datafaker/providers/base/IndustrySegmentsTest.java
@@ -7,22 +7,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class IndustrySegmentsTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testIndustry() {
+    void industry() {
         assertThat(faker.industrySegments().industry()).isNotEmpty();
     }
 
     @Test
-    void testSuperSector() {
+    void superSector() {
         assertThat(faker.industrySegments().superSector()).isNotEmpty();
     }
 
     @Test
-    void testSector() {
+    void sector() {
         assertThat(faker.industrySegments().sector()).isNotEmpty();
     }
 
     @Test
-    void testSubSector() {
+    void subSector() {
         assertThat(faker.industrySegments().subSector()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/InternetPasswordTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetPasswordTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class InternetPasswordTest extends BaseFakerTest<BaseFaker> {
     @Test

--- a/src/test/java/net/datafaker/providers/base/InternetPasswordTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetPasswordTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class InternetPasswordTest extends BaseFakerTest<BaseFaker> {
     @Test
-    void testPassword1000() {
+    void password1000() {
         final Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
         final Pattern digitPattern = Pattern.compile("[0-9]");
         for (int i = 0; i < 1000; i++) {

--- a/src/test/java/net/datafaker/providers/base/InternetTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetTest.java
@@ -21,20 +21,20 @@ import static org.assertj.core.api.Assertions.fail;
 class InternetTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testEmailAddress() {
+    void emailAddress() {
         String emailAddress = faker.internet().emailAddress();
         assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
     }
 
     @Test
-    void testEmailAddressWithLocalPartParameter() {
+    void emailAddressWithLocalPartParameter() {
         String emailAddress = faker.internet().emailAddress("john");
         assertThat(emailAddress).startsWith("john@");
         assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
     }
 
     @Test
-    void testSafeEmailAddress() {
+    void safeEmailAddress() {
         List<String> emails = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             String emailAddress = faker.internet().safeEmailAddress();
@@ -48,7 +48,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testSafeEmailAddressWithLocalPartParameter() {
+    void safeEmailAddressWithLocalPartParameter() {
         List<String> emails = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             String emailAddress = faker.internet().safeEmailAddress("john");
@@ -63,91 +63,91 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
+    void emailAddressDoesNotIncludeAccentsInTheLocalPart() {
         String emailAddress = faker.internet().emailAddress("áéíóú");
         assertThat(emailAddress).startsWith("aeiou@");
     }
 
     @Test
-    void testSafeEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
+    void safeEmailAddressDoesNotIncludeAccentsInTheLocalPart() {
         String emailAddress = faker.internet().safeEmailAddress("áéíóú");
         assertThat(emailAddress).startsWith("aeiou@");
     }
 
     @Test
-    void testUrl() {
+    void url() {
         assertThat(faker.internet().url()).matches("www\\.(\\w|-)+\\.\\w+");
     }
 
     @Test
-    void testImage() {
+    void image() {
         String imageUrl = faker.internet().image();
         assertThat(imageUrl).matches("^https://picsum\\.photos/\\d{1,4}/\\d{1,4}$");
     }
 
     @Test
-    void testDomainName() {
+    void domainName() {
         assertThat(faker.internet().domainName()).matches("[a-z]+\\.\\w{2,4}");
     }
 
     @Test
-    void testDomainWord() {
+    void domainWord() {
         assertThat(faker.internet().domainWord()).matches("[a-z]+");
     }
 
     @Test
-    void testDomainSuffix() {
+    void domainSuffix() {
         assertThat(faker.internet().domainSuffix()).matches("\\w{2,4}");
     }
 
     @Test
-    void testImageWithExplicitParams() {
+    void imageWithExplicitParams() {
         String imageUrl = faker.internet().image(800, 600, "lorem");
         assertThat(imageUrl).matches("^https://picsum\\.photos/seed/lorem/800/600$");
     }
 
     @Test
-    void testHttpMethod() {
+    void httpMethod() {
         assertThat(faker.internet().httpMethod()).isNotEmpty();
     }
 
     @Test
-    void testPassword() {
+    void password() {
         assertThat(faker.internet().password()).matches("[a-z\\d]{8,16}");
     }
 
     @Test
-    void testPasswordWithFixedLength() {
+    void passwordWithFixedLength() {
         String password = new BaseFaker().internet().password(32, 32, true, true, true);
         assertThat(password).hasSize(32);
     }
 
     @Test
-    void testPasswordIncludeDigit() {
+    void passwordIncludeDigit() {
         assertThat(faker.internet().password()).matches("[a-z\\d]{8,16}");
         assertThat(faker.internet().password(false)).matches("[a-z]{8,16}");
     }
 
     @Test
-    void testPasswordMinLengthMaxLength() {
+    void passwordMinLengthMaxLength() {
         assertThat(faker.internet().password(10, 25)).matches("[a-z\\d]{10,25}");
     }
 
     @Test
-    void testPasswordMinLengthMaxLengthIncludeUpperCase() {
+    void passwordMinLengthMaxLengthIncludeUpperCase() {
         assertThat(faker.internet().password(1, 2, false)).matches("[a-z\\d]{1,2}");
         assertThat(faker.internet().password(10, 25, true)).matches("[a-zA-Z\\d]{10,25}");
     }
 
     @Test
-    void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecial() {
+    void passwordMinLengthMaxLengthIncludeUpperCaseIncludeSpecial() {
         assertThat(faker.internet().password(10, 25, false, false)).matches("[a-z\\d]{10,25}");
         assertThat(faker.internet().password(10, 25, false, true)).matches("[a-z\\d!@#$%^&*]{10,25}");
         assertThat(faker.internet().password(10, 25, true, true)).matches("[a-zA-Z\\d!@#$%^&*]{10,25}");
     }
 
     @RepeatedTest(100)
-    void testPort() {
+    void port() {
         assertThat(faker.internet().port()).isBetween(0, 65535);
     }
 
@@ -166,7 +166,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPasswordMinLengthMaxLengthIncludeUpperCaseIncludeSpecialIncludeDigit() {
+    void passwordMinLengthMaxLengthIncludeUpperCaseIncludeSpecialIncludeDigit() {
         assertThat(faker.internet().password(10, 25, false, false, false)).matches("[a-z]{10,25}");
         assertThat(faker.internet().password(10, 25, false, true, true)).matches("[a-z\\d!@#$%^&*]{10,25}");
         assertThat(faker.internet().password(10, 25, true, true, false)).matches("[a-zA-Z!@#$%^&*]{10,25}");
@@ -192,7 +192,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testMacAddress() {
+    void macAddress() {
         Condition<String> colon = getCharacterCondition(':', 5);
         assertThat(faker.internet().macAddress()).is(colon);
         assertThat(faker.internet().macAddress("")).is(colon);
@@ -212,7 +212,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testIpV4Address() {
+    void ipV4Address() {
         Condition<String> colon = getCharacterCondition('.', 3);
         assertThat(faker.internet().ipV4Address()).is(colon);
         for (int i = 0; i < 100; i++) {
@@ -229,7 +229,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testIpV4Cidr() {
+    void ipV4Cidr() {
         assertThat(faker.internet().ipV4Cidr())
             .is(getCharacterCondition('.', 3))
             .is(getCharacterCondition('/', 1));
@@ -241,7 +241,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPrivateIpV4Address() {
+    void privateIpV4Address() {
         String tenDot = "^10\\..+";
         String oneTwoSeven = "^127\\..+";
         String oneSixNine = "^169\\.254\\..+";
@@ -266,7 +266,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPublicIpV4Address() {
+    void publicIpV4Address() {
         String tenDot = "^10\\.";
         String oneTwoSeven = "^127\\.";
         String oneSixNine = "^169\\.254";
@@ -287,7 +287,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testIpV6() {
+    void ipV6() {
         assertThat(faker.internet().ipV6Address()).is(getCharacterCondition(':', 7));
 
         for (int i = 0; i < 1000; i++) {
@@ -301,7 +301,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testIpV6Cidr() {
+    void ipV6Cidr() {
         assertThat(faker.internet().ipV6Cidr())
             .is(getCharacterCondition(':', 7))
             .is(getCharacterCondition('/', 1));
@@ -313,17 +313,17 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testSlugWithParams() {
+    void slugWithParams() {
         assertThat(faker.internet().slug(Arrays.asList("a", "b"), "-")).matches("[a-zA-Z]+-[a-zA-Z]+");
     }
 
     @RepeatedTest(10)
-    void testSlug() {
+    void slug() {
         assertThat(faker.internet().slug()).matches("[a-zA-Z]+_[a-zA-Z]+");
     }
 
     @Test
-    void testUuidv3ConstantRandomSeed() {
+    void uuidv3ConstantRandomSeed() {
         final int randomSeed = 42;
         // Two fakers, same random seed.
         final BaseFaker faker1 = new BaseFaker(new Random(randomSeed));
@@ -342,17 +342,17 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testUuidv3() {
+    void uuidv3() {
         assertThat(faker.internet().uuidv3()).matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
     }
 
     @RepeatedTest(10)
-    void testUuid() {
+    void uuid() {
         assertThat(faker.internet().uuid()).matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
     }
 
     @RepeatedTest(100)
-    void testFarsiIDNs() {
+    void farsiIDNs() {
         // in this case, we're just making sure Farsi doesn't blow up.
         // there have been issues with Farsi not being produced.
         final BaseFaker f = new BaseFaker(new Locale("fa"));
@@ -363,7 +363,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testUserAgent() {
+    void userAgent() {
         Internet.UserAgent[] agents = Internet.UserAgent.values();
         for (Internet.UserAgent agent : agents) {
             assertThat(faker.internet().userAgent(agent)).isNotEmpty();
@@ -374,7 +374,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testBotUserAgent() {
+    void botUserAgent() {
         Internet.BotUserAgent[] agents = Internet.BotUserAgent.values();
         for (Internet.BotUserAgent agent : agents) {
             assertThat(faker.internet().botUserAgent(agent)).isNotEmpty();
@@ -385,7 +385,7 @@ class InternetTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testSlugWithNull() {
+    void slugWithNull() {
         assertThat(faker.internet().slug(null, "_")).isNotNull();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/LocalityTest.java
+++ b/src/test/java/net/datafaker/providers/base/LocalityTest.java
@@ -31,7 +31,7 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
      * Test to check that list of all locales support is loaded
      */
     @Test
-    void testAllSuppportedLocales() {
+    void allSuppportedLocales() {
         // Check that directory of locale resources exists
         File resourceDirectory = new File("./src/main/resources");
         assertThat(resourceDirectory).exists();
@@ -51,7 +51,7 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
      * should have deterministic results.
      */
     @Test
-    void testLocaleStringRandom() {
+    void localeStringRandom() {
         // Check that we get the same locale when using pseudorandom number generator with a fixed seed
         final long fixedSeed = 5;
 
@@ -69,7 +69,7 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
      * locale is within the set of all supported locales
      */
     @RepeatedTest(100)
-    void testLocaleStringWithRandom() {
+    void localeStringWithRandom() {
         Random random = new Random();
         String randomLocale = locality.localeStringWithRandom(random);
         assertThat(allLocales).contains(randomLocale);
@@ -81,7 +81,7 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
      * It ensures that all the locales supported are represented once.
      */
     @Test
-    void testLocaleStringWithoutReplacement() {
+    void localeStringWithoutReplacement() {
         Random random = new Random();
 
         // loop through all supported locales
@@ -97,12 +97,12 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testLocaleString() {
+    void localeString() {
         assertThat(allLocales).contains(locality.localeString());
     }
 
     @Test
-    void testLocaleWithoutReplacement() {
+    void localeWithoutReplacement() {
         assertThat(locality.localeStringWithoutReplacement()).isNotNull();
     }
 

--- a/src/test/java/net/datafaker/providers/base/LoremTest.java
+++ b/src/test/java/net/datafaker/providers/base/LoremTest.java
@@ -27,18 +27,18 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testCharacter() {
+    void character() {
         assertThat(String.valueOf(faker.lorem().character())).matches("[a-z\\d]{1}");
     }
 
     @Test
-    void testCharacterIncludeUpperCase() {
+    void characterIncludeUpperCase() {
         assertThat(String.valueOf(faker.lorem().character(false))).matches("[a-z\\d]{1}");
         assertThat(String.valueOf(faker.lorem().character(true))).matches("[a-zA-Z\\d]{1}");
     }
 
     @Test
-    void testCharactersShouldIncludeMinAndMaxLenght() {
+    void charactersShouldIncludeMinAndMaxLenght() {
         List<String> results = new ArrayList<>();
         for (int i = 0; i < 300; i++) {
             results.add(faker.lorem().characters(1, 10));
@@ -52,18 +52,18 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testCharacters() {
+    void characters() {
         assertThat(faker.lorem().characters()).matches("[a-z\\d]{255}");
     }
 
     @Test
-    void testCharactersIncludeUpperCase() {
+    void charactersIncludeUpperCase() {
         assertThat(faker.lorem().characters(false)).matches("[a-z\\d]{255}");
         assertThat(faker.lorem().characters(true)).matches("[a-zA-Z\\d]{255}");
     }
 
     @Test
-    void testCharactersWithLength() {
+    void charactersWithLength() {
         assertThat(faker.lorem().characters(2)).matches("[a-z\\d]{2}");
         assertThat(faker.lorem().characters(500)).matches("[a-z\\d]{500}");
         assertThat(faker.lorem().characters(0)).isEmpty();
@@ -71,7 +71,7 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testCharactersWithLengthIncludeUppercase() {
+    void charactersWithLengthIncludeUppercase() {
         assertThat(faker.lorem().characters(2, false)).matches("[a-z\\d]{2}");
         assertThat(faker.lorem().characters(500, false)).matches("[a-z\\d]{500}");
         assertThat(faker.lorem().characters(2, true)).matches("[a-zA-Z\\d]{2}");
@@ -81,22 +81,22 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testCharactersMinimumMaximumLength() {
+    void charactersMinimumMaximumLength() {
         assertThat(faker.lorem().characters(1, 10)).matches("[a-z\\d]{1,10}");
     }
 
     @RepeatedTest(10)
-    void testCharactersMinimumMaximumLengthEquals() {
+    void charactersMinimumMaximumLengthEquals() {
         assertThat(faker.lorem().characters(5, 5)).matches("[a-z\\d]{5}");
     }
 
     @RepeatedTest(10)
-    void testCharactersMinimumMaximumLengthEqualsIncludingUppercaseAndIncludingDigit() {
+    void charactersMinimumMaximumLengthEqualsIncludingUppercaseAndIncludingDigit() {
         assertThat(faker.lorem().characters(8, 8, true, true)).matches("[a-zA-Z\\d]{8}");
     }
 
     @Test
-    void testFixedNumberOfCharactersEmpty() {
+    void fixedNumberOfCharactersEmpty() {
         assertThat(faker.lorem().characters(-1)).isEmpty();
         assertThat(faker.lorem().characters(0)).isEmpty();
 
@@ -106,18 +106,18 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
 
 
     @Test
-    void testCharactersMinimumMaximumLengthIncludeUppercase() {
+    void charactersMinimumMaximumLengthIncludeUppercase() {
         assertThat(faker.lorem().characters(1, 10, true)).matches("[a-zA-Z\\d]{1,10}");
     }
 
     @Test
-    void testCharactersMinimumMaximumLengthIncludeUppercaseIncludeDigit() {
+    void charactersMinimumMaximumLengthIncludeUppercaseIncludeDigit() {
         assertThat(faker.lorem().characters(1, 10, false, false)).matches("[a-zA-Z]{1,10}");
         assertThat(faker.lorem().characters(2, 10, true, true)).matches("[a-zA-Z\\d]{1,10}");
     }
 
     @Test
-    void testSentence() {
+    void sentence() {
         String sentence = faker.lorem().sentence();
         String[] words = sentence.split(" ");
 
@@ -126,7 +126,7 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testSentenceWithWordCount() {
+    void sentenceWithWordCount() {
         String sentence = faker.lorem().sentence(10);
         String[] words = sentence.split(" ");
 
@@ -135,22 +135,22 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testSentenceWithWordCountAndRandomWordsToAdd() {
+    void sentenceWithWordCountAndRandomWordsToAdd() {
         assertThat(faker.lorem().sentence(10, 10)).matches("(\\w+\\s?){10,20}\\.");
     }
 
     @RepeatedTest(10)
-    void testSentenceFixedNumberOfWords() {
+    void sentenceFixedNumberOfWords() {
         assertThat(faker.lorem().sentence(10, 0)).matches("(\\w+\\s?){10}\\.");
     }
 
     @Test
-    void testWords() {
+    void words() {
         assertThat(faker.lorem().words()).isNotEmpty();
     }
 
     @RepeatedTest(10)
-    void testMaxLengthSentence() {
+    void maxLengthSentence() {
         Random rand = new Random();
         // Test different lengths over 10 runs
         int length = Math.abs(rand.nextInt(10000));
@@ -159,26 +159,26 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testMaxLengthWithEmptySentence() {
+    void maxLengthWithEmptySentence() {
         String s = faker.lorem().maxLengthSentence(0);
         assertThat(s).isEmpty();
     }
 
     @Test
-    void testMaxLengthWithNegativeLengthSentence() {
+    void maxLengthWithNegativeLengthSentence() {
         String s = faker.lorem().maxLengthSentence(-1);
         assertThat(s).isEmpty();
     }
 
     @RepeatedTest(10)
-    void testSentences() {
+    void sentences() {
         String paragraph = faker.lorem().paragraph();
         int matches = StringUtils.countMatches(paragraph, ".");
         assertThat(matches).isBetween(3, 6);
     }
 
     @RepeatedTest(10)
-    void testSentencesWithCount() {
+    void sentencesWithCount() {
         String paragraph = faker.lorem().paragraph(1);
         int matches = StringUtils.countMatches(paragraph, ".");
         assertThat(matches).isBetween(1, 3);

--- a/src/test/java/net/datafaker/providers/base/MeasurementTest.java
+++ b/src/test/java/net/datafaker/providers/base/MeasurementTest.java
@@ -9,42 +9,42 @@ class MeasurementTest extends BaseFakerTest<BaseFaker> {
     public static final String WORDS = "^[a-z ]+$";
 
     @RepeatedTest(10)
-    void testHeight() {
+    void height() {
         assertThat(faker.measurement().height()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testLength() {
+    void length() {
         assertThat(faker.measurement().length()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testVolume() {
+    void volume() {
         assertThat(faker.measurement().volume()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testWeight() {
+    void weight() {
         assertThat(faker.measurement().weight()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testMetricHeight() {
+    void metricHeight() {
         assertThat(faker.measurement().metricHeight()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testMetricLength() {
+    void metricLength() {
         assertThat(faker.measurement().metricLength()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testMetricVolume() {
+    void metricVolume() {
         assertThat(faker.measurement().metricVolume()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testMetricWeight() {
+    void metricWeight() {
         assertThat(faker.measurement().metricWeight()).matches(WORDS);
     }
 }

--- a/src/test/java/net/datafaker/providers/base/MedicalTest.java
+++ b/src/test/java/net/datafaker/providers/base/MedicalTest.java
@@ -10,27 +10,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MedicalTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testMedicineName() {
+    void medicineName() {
         assertThat(faker.medical().medicineName()).isNotEmpty();
     }
 
     @Test
-    void testDiseaseName() {
+    void diseaseName() {
         assertThat(faker.medical().diseaseName()).isNotEmpty();
     }
 
     @Test
-    void testHospitalName() {
+    void hospitalName() {
         assertThat(faker.medical().hospitalName()).isNotEmpty();
     }
 
     @Test
-    void testSymptom() {
+    void symptom() {
         assertThat(faker.medical().symptoms()).isNotEmpty();
     }
 
     @Test
-    void testDiagnosisCodeUS() {
+    void diagnosisCodeUS() {
         // will use icd-10-cm - https://www.johndcook.com/blog/2019/05/05/regex_icd_codes/
         BaseFaker faker = new BaseFaker(Locale.US);
 
@@ -41,7 +41,7 @@ class MedicalTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testDiagnosisCodeAU() {
+    void diagnosisCodeAU() {
         // will use icd-10-am - https://ace.ihpa.gov.au/Downloads/Current/ICD-10-AM-ACHI-ACS%2011th%20Edition/Education/11th%20Edition%20PDF%20files/Coding-Exercise-Workbook-Eleventh-Edition%20V2-15%20Jun%202019.pdf
         BaseFaker faker = new BaseFaker(new Locale("en", "au"));
 
@@ -50,7 +50,7 @@ class MedicalTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testDiagnosisCodeNotAustraliaNorUS() {
+    void diagnosisCodeNotAustraliaNorUS() {
         // will use icd-10 - variation of https://regexlib.com/REDetails.aspx?regexp_id=2276&AspxAutoDetectCookieSupport=1
         BaseFaker faker = new BaseFaker(Locale.FRANCE);
 
@@ -59,7 +59,7 @@ class MedicalTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testProcedureCodes() {
+    void procedureCodes() {
         // will use icd-10-pcs - https://regex101.com/library/nJ1wC4
         String procedureCode = faker.medical().procedureCode();
         assertThat(procedureCode).matches("^[a-hj-np-zA-HJ-NP-Z0-9]{7}$");

--- a/src/test/java/net/datafaker/providers/base/MoneyTest.java
+++ b/src/test/java/net/datafaker/providers/base/MoneyTest.java
@@ -8,12 +8,12 @@ import static org.assertj.core.util.Strings.isNullOrEmpty;
 class MoneyTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testCurrency() {
+    void currency() {
         assertThat(isNullOrEmpty(faker.money().currency())).isFalse();
     }
 
     @Test
-    void testCurrencyCode() {
+    void currencyCode() {
         assertThat(isNullOrEmpty(faker.money().currencyCode())).isFalse();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/MountainTest.java
+++ b/src/test/java/net/datafaker/providers/base/MountainTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MountainTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testMountainName() {
+    void mountainName() {
         String mountainName = faker.mountain().name();
         assertThat(mountainName).isNotEmpty();
     }
 
     @Test
-    void testMountainLeague() {
+    void mountainLeague() {
         String mountainLeague = faker.mountain().range();
         assertThat(mountainLeague).isNotEmpty();
     }

--- a/src/test/java/net/datafaker/providers/base/NameTest.java
+++ b/src/test/java/net/datafaker/providers/base/NameTest.java
@@ -16,17 +16,17 @@ class NameTest extends BaseFakerTest<BaseFaker> {
     private BaseFaker mockedFaker;
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.name().name()).matches("([\\w']+\\.?( )?){2,3}");
     }
 
     @Test
-    void testNameWithMiddle() {
+    void nameWithMiddle() {
         assertThat(faker.name().nameWithMiddle()).matches("([\\w']+\\.?( )?){3,4}");
     }
 
     @Test
-    void testNameWithMiddleDoesNotHaveRepeatedName() {
+    void nameWithMiddleDoesNotHaveRepeatedName() {
         int theSameNameCnt = 0;
         int total = 100;
         for (int i = 0; i < total; i++) {
@@ -40,12 +40,12 @@ class NameTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testFullName() {
+    void fullName() {
         assertThat(faker.name().fullName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    void testFullNameArabic() {
+    void fullNameArabic() {
         BaseFaker localFaker = new BaseFaker(new Locale("ar"));
 
         for (int i = 0; i < 25; i++) {
@@ -54,37 +54,37 @@ class NameTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testFirstName() {
+    void firstName() {
         assertThat(faker.name().firstName()).matches("\\w+");
     }
 
     @Test
-    void testLastName() {
+    void lastName() {
         assertThat(faker.name().lastName()).matches("[A-Za-z']+");
     }
 
     @Test
-    void testPrefix() {
+    void prefix() {
         assertThat(faker.name().prefix()).matches("\\w+\\.?");
     }
 
     @Test
-    void testSuffix() {
+    void suffix() {
         assertThat(faker.name().suffix()).matches("\\w+\\.?");
     }
 
     @Test
-    void testTitle() {
+    void title() {
         assertThat(faker.name().title()).matches("(\\w+\\.?( )?){3}");
     }
 
     @RepeatedTest(100)
-    void testUsername() {
+    void username() {
         assertThat(faker.name().username()).matches("^(\\w+)\\.(\\w+)$");
     }
 
     @Test
-    void testUsernameWithSpaces() {
+    void usernameWithSpaces() {
         final Name name = Mockito.spy(new Name(mockedFaker));
         doReturn("Compound Name").when(name).firstName();
         doReturn(name).when(mockedFaker).name();

--- a/src/test/java/net/datafaker/providers/base/NumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/NumberTest.java
@@ -27,7 +27,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     final double percentRunsGtUniquePercentage = 0.90;
 
     @Test
-    void testRandomDigit() {
+    void randomDigit() {
         Set<Integer> nums = new HashSet<>();
         for (int i = 0; i < 1000; ++i) {
             int value = faker.number().randomDigit();
@@ -39,7 +39,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testRandomDigitNotZero() {
+    void randomDigitNotZero() {
         Set<Integer> nums = new HashSet<>();
         for (int i = 0; i < 1000; ++i) {
             int value = faker.number().randomDigitNotZero();
@@ -51,13 +51,13 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testRandomNumber() {
+    void randomNumber() {
         long value = faker.number().randomNumber();
         assertThat(value).isLessThan(Long.MAX_VALUE);
     }
 
     @Test
-    void testRandomNumberWithSingleDigitStrict() {
+    void randomNumberWithSingleDigitStrict() {
         for (int i = 0; i < 100; ++i) {
             long value = faker.number().randomNumber(1, true);
             assertThat(value).isLessThan(10L)
@@ -66,7 +66,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testRandomNumberWithZeroDigitsStrict() {
+    void randomNumberWithZeroDigitsStrict() {
         for (int i = 0; i < 100; ++i) {
             long value = faker.number().randomNumber(0, true);
             assertThat(value).isZero();
@@ -74,7 +74,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testRandomNumberWithGivenDigitsStrict() {
+    void randomNumberWithGivenDigitsStrict() {
         for (int i = 1; i < 9; ++i) {
             for (int x = 0; x < 100; ++x) {
                 long value = faker.number().randomNumber(i, true);
@@ -85,7 +85,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testRandomDouble() {
+    void randomDouble() {
         for (int i = 1; i < 5; ++i) {
             for (int x = 0; x < 100; ++x) {
                 double value = faker.number().randomDouble(i, 1, 1000);
@@ -99,7 +99,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNumberBetween() {
+    void numberBetween() {
         for (int i = 1; i < 100; ++i) {
             int v = faker.number().numberBetween(0, i);
             assertThat(v).isLessThanOrEqualTo(i)
@@ -119,7 +119,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testLongNumberBetweenRepeated() {
+    void longNumberBetweenRepeated() {
         long low = 1;
         long high = 10;
         long v = faker.number().numberBetween(low, high);
@@ -128,7 +128,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(100)
-    void testIntNumberBetweenRepeated() {
+    void intNumberBetweenRepeated() {
         int low = 1;
         int high = 10;
         int v = faker.number().numberBetween(low, high);
@@ -137,7 +137,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNumberBetweenOneAndThree() {
+    void numberBetweenOneAndThree() {
         Set<Integer> nums = new HashSet<>();
         final int lowerLimit = 0;
         final int upperLimit = 3;
@@ -151,7 +151,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testLongBetweenOneAndThree() {
+    void longBetweenOneAndThree() {
         Set<Long> nums = new HashSet<>();
         final long lowerLimit = 0;
         final long upperLimit = 3;
@@ -265,7 +265,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testRandomDoubleMaxEqualsMin() {
+    void randomDoubleMaxEqualsMin() {
         double actual = faker.number().randomDouble(1, 42, 42);
 
         double expected = BigDecimal.valueOf(42).doubleValue();
@@ -274,14 +274,14 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testDigit() {
+    void digit() {
         String digit = faker.number().digit();
 
         assertThat(digit).matches("[0-9]");
     }
 
     @Test
-    void testDigits() {
+    void digits() {
         String digits = faker.number().digits(5);
 
         assertThat(digits).matches("[0-9]{5}");
@@ -341,7 +341,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testIntNumberBetweenQuality() {
+    void intNumberBetweenQuality() {
         //test whether the fake number made by numberBetween(int min, int max)
         // is not randomly and evenly distributed
         // (The difference between the average is less than 10%)
@@ -364,7 +364,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testLongNumberBetweenQuality() {
+    void longNumberBetweenQuality() {
         //test whether the fake number made by numberBetween(long min, long max)
         // is not randomly and evenly distributed
         // (The difference between the average is less than 10%)
@@ -388,7 +388,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNumberBetweenContain() {
+    void numberBetweenContain() {
 
         Set<Integer> ints = new HashSet<>();
         Set<Long> longs = new HashSet<>();
@@ -423,7 +423,7 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNumberBetweenBorder() {
+    void numberBetweenBorder() {
 
         Random random = new Random();
 
@@ -447,12 +447,12 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testPositive() {
+    void positive() {
         assertThat(faker.number().positive()).isGreaterThan(0);
     }
 
     @RepeatedTest(10)
-    void testNegative() {
+    void negative() {
         assertThat(faker.number().negative()).isLessThan(0);
 
     }

--- a/src/test/java/net/datafaker/providers/base/OptionsTest.java
+++ b/src/test/java/net/datafaker/providers/base/OptionsTest.java
@@ -21,17 +21,17 @@ class OptionsTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testOptionWithArray() {
+    void optionWithArray() {
         assertThat(faker.options().option(options)).isIn((Object[]) options);
     }
 
     @Test
-    void testOptionWithVarargsString() {
+    void optionWithVarargsString() {
         assertThat(faker.options().option("A", "B", "C")).isIn((Object[]) options);
     }
 
     @Test
-    void testOptionWithVarargs() {
+    void optionWithVarargs() {
         Integer[] integerOptions = new Integer[]{1, 3, 4, 5};
         assertThat(faker.options().option(1, 3, 4, 5)).isIn((Object[]) integerOptions);
         Long[] longOptions = new Long[]{1L, 3L, 4L, 5L};
@@ -53,7 +53,7 @@ class OptionsTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testSubset() {
+    void subset() {
         Integer[] integerOptions = new Integer[]{1, 3, 4, 5};
         assertThat(faker.options().subset(1, integerOptions))
             .doesNotContainAnyElementsOf(Arrays.asList(2, 6))
@@ -84,7 +84,7 @@ class OptionsTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testSubsetWithDuplicate() {
+    void subsetWithDuplicate() {
         Object[] array = new Object[]{1, 1, 2, 2};
         assertThat(faker.options().subset(5, array)).hasSize(2);
         String[] strArray = new String[]{"a", "s", "s", "a"};
@@ -92,7 +92,7 @@ class OptionsTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testEmptySubset() {
+    void emptySubset() {
         Object[] array = new Object[]{1, 2, 3};
         assertThat(faker.options().subset(0, array)).isEmpty();
         assertThatThrownBy(() -> faker.options().subset(-1, array))
@@ -103,12 +103,12 @@ class OptionsTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testOptionWithEnum() {
+    void optionWithEnum() {
         assertThat(faker.options().option(Day.class)).isIn((Object[]) Day.values());
     }
 
     @Test
-    void testNextArrayElement() {
+    void nextArrayElement() {
         Integer[] array = new Integer[]{1, 2, 3, 5, 8, 13, 21};
 
         for (int i = 1; i < 10; i++) {
@@ -117,7 +117,7 @@ class OptionsTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNextListElement() {
+    void nextListElement() {
         List<Integer> list = Arrays.asList(1, 2, 3, 5, 8, 13, 21);
         for (int i = 1; i < 10; i++) {
             assertThat(faker.options().nextElement(list)).isIn(list);

--- a/src/test/java/net/datafaker/providers/base/OverwatchTest.java
+++ b/src/test/java/net/datafaker/providers/base/OverwatchTest.java
@@ -1,24 +1,25 @@
 package net.datafaker.providers.base;
 
 import net.datafaker.providers.videogame.VideoGameFakerTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class OverwatchTest extends VideoGameFakerTest {
 
     @Test
     void hero() {
-        Assertions.assertThat(faker.overwatch().hero()).matches("^(\\w+\\.?\\s?)+$");
+        assertThat(faker.overwatch().hero()).matches("^(\\w+\\.?\\s?)+$");
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.overwatch().location()).matches("^(.+'?:?\\s?)+$");
+        assertThat(faker.overwatch().location()).matches("^(.+'?:?\\s?)+$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.overwatch().quote()).isNotEmpty();
+        assertThat(faker.overwatch().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/PassportTest.java
+++ b/src/test/java/net/datafaker/providers/base/PassportTest.java
@@ -9,13 +9,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PassportTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(10)
-    void testDefaultLocale() {
+    void defaultLocale() {
         assertThat(new BaseFaker().passport().valid())
             .hasSize(9);
     }
 
     @RepeatedTest(10)
-    void testValidDutch() {
+    void validDutch() {
         assertThat(new BaseFaker(new Locale("nl", "nl")).passport().valid())
             .hasSize(9)
             .doesNotContain("O")
@@ -23,57 +23,57 @@ class PassportTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testValidChinese() {
+    void validChinese() {
         assertThat(new BaseFaker(new Locale("zh", "CN")).passport().valid())
             .hasSize(9);
     }
 
     @RepeatedTest(10)
-    void testValidUnitedStates() {
+    void validUnitedStates() {
         assertThat(new BaseFaker(new Locale("en", "US")).passport().valid())
             .hasSize(9);
     }
 
     @RepeatedTest(10)
-    void testValidAustralia() {
+    void validAustralia() {
         assertThat(new BaseFaker(new Locale("en", "AU")).passport().valid())
             .hasSize(8)
             .matches("[A-Z][0-9]{7}");
     }
 
     @RepeatedTest(10)
-    void testValidCanada() {
+    void validCanada() {
         assertThat(new BaseFaker(new Locale("en", "CA")).passport().valid())
             .hasSize(8);
     }
 
     @RepeatedTest(10)
-    void testValidUnitedKingdom() {
+    void validUnitedKingdom() {
         assertThat(new BaseFaker(new Locale("en", "GB")).passport().valid())
             .hasSize(9);
     }
 
     @RepeatedTest(10)
-    void testValidJapan() {
+    void validJapan() {
         assertThat(new BaseFaker(new Locale("ja")).passport().valid())
             .hasSize(9)
             .matches("[MT][A-Z][0-9]{7}");
     }
 
     @RepeatedTest(10)
-    void testValidSpain() {
+    void validSpain() {
         assertThat(new BaseFaker(new Locale("es")).passport().valid())
             .matches("[A-z0-9]{2,3}[0-9]{6}");
     }
 
     @RepeatedTest(10)
-    void testValidBulgaria() {
+    void validBulgaria() {
         assertThat(new BaseFaker(new Locale("bg")).passport().valid())
             .hasSize(9);
     }
 
     @RepeatedTest(10)
-    void testValidFinland() {
+    void validFinland() {
         assertThat(new BaseFaker(new Locale("fi", "FI")).passport().valid())
             .hasSize(9);
     }

--- a/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
@@ -14,14 +14,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testCellPhone_enUS() {
+    void cellPhone_enUS() {
         final BaseFaker f = new BaseFaker(Locale.US);
         String cellPhone = f.phoneNumber().cellPhone();
         assertThat(cellPhone).matches("\\(?\\d+\\)?([- .]\\d+){1,3}");
     }
 
     @RepeatedTest(10)
-    void testAllCellPhone_enUS() throws NumberParseException {
+    void allCellPhone_enUS() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         String phoneNumber = new BaseFaker(new Locale("en_US")).phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "US");
@@ -30,7 +30,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
 
 
     @RepeatedTest(10)
-    void testAllCellPhone_svSE() throws NumberParseException {
+    void allCellPhone_svSE() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         String phoneNumber = new BaseFaker(new Locale("sv_SE")).phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "SE");
@@ -39,7 +39,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
 
 
     @RepeatedTest(10)
-    void testAllCellPhone_csCZ() throws NumberParseException {
+    void allCellPhone_csCZ() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         String phoneNumber = new BaseFaker(new Locale("cs_CZ")).phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "CZ");
@@ -48,7 +48,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
 
 
     @Test
-    void testAllCellPhone_enGB() throws NumberParseException {
+    void allCellPhone_enGB() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         int errorCount = 0;
         final BaseFaker faker = new BaseFaker(new Locale("en_GB"));
@@ -66,7 +66,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
 
 
     @Test
-    void testAllCellPhone_nbNO() throws NumberParseException {
+    void allCellPhone_nbNO() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         int errorCount = 0;
 
@@ -86,7 +86,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
 
 
     @RepeatedTest(10)
-    void testAllCellPhone_nl() throws NumberParseException {
+    void allCellPhone_nl() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         String phoneNumber = new BaseFaker(new Locale("nl_NL")).phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "NL");
@@ -94,7 +94,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPhone_esMx() {
+    void phone_esMx() {
         final BaseFaker f = new BaseFaker(new Locale("es_MX"));
         for (int i = 0; i < 10; i++) {
             assertThat(f.phoneNumber().cellPhone()).matches("(044 )?\\(?\\d+\\)?([- .]\\d+){1,3}");
@@ -103,7 +103,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPhone_CA() {
+    void phone_CA() {
         final Locale[] locales = new Locale[]{Locale.CANADA, new Locale("ca")};
         for (Locale locale : locales) {
             final BaseFaker f = new BaseFaker(locale);
@@ -119,7 +119,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testAllCellPhone_enPh() throws NumberParseException {
+    void allCellPhone_enPh() throws NumberParseException {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         String phoneNumber = new BaseFaker(new Locale("en_PH")).phoneNumber().phoneNumber();
         Phonenumber.PhoneNumber proto = util.parse(phoneNumber, "PH");
@@ -127,27 +127,27 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testCellPhone() {
+    void cellPhone() {
         assertThat(faker.phoneNumber().cellPhone()).matches("\\(?\\d+\\)?([- .]\\d+){1,3}");
     }
 
     @Test
-    void testPhoneNumber() {
+    void phoneNumber() {
         assertThat(faker.phoneNumber().phoneNumber()).matches("\\(?\\d+\\)?([- .]x?\\d+){1,5}");
     }
 
     @Test
-    void testExtension() {
+    void extension() {
         assertThat(faker.phoneNumber().extension()).matches("\\d{4}");
     }
 
     @Test
-    void testSubscriberNumber() {
+    void subscriberNumber() {
         assertThat(faker.phoneNumber().subscriberNumber()).matches("\\d{4}");
     }
 
     @Test
-    void testSubscriberNumberWithLength() {
+    void subscriberNumberWithLength() {
         assertThat(faker.phoneNumber().subscriberNumber(10)).matches("\\d{10}");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/PhoneNumberValidityFinderTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhoneNumberValidityFinderTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PhoneNumberValidityFinderTest extends AbstractFakerTest {
 
     @Test
-    void testAllCellPhoneForLocale() throws NumberParseException {
+    void allCellPhoneForLocale() throws NumberParseException {
         String language = "en";
         String region = "GB";
         BaseFaker localFaker = new BaseFaker(new Locale(language, region));
@@ -45,7 +45,7 @@ class PhoneNumberValidityFinderTest extends AbstractFakerTest {
     }
 
     @Test
-    void testValidNumber() throws NumberParseException {
+    void validNumber() throws NumberParseException {
         String phoneNumber = "0140 123456";
         String region = "SE";
 
@@ -55,7 +55,7 @@ class PhoneNumberValidityFinderTest extends AbstractFakerTest {
     }
 
     @Test
-    void testAllPhoneNumbers() {
+    void allPhoneNumbers() {
         List<String> allSupportedLocales = faker.locality().allSupportedLocales();
         Map<Locale, Integer> errorCounts = new HashMap<>();
 

--- a/src/test/java/net/datafaker/providers/base/PhotographyTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhotographyTest.java
@@ -8,13 +8,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PhotographyTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testAperture() {
+    void aperture() {
         final String value = faker.photography().aperture();
         assertThat(value).startsWith("f");
     }
 
     @Test
-    void testTerm() {
+    void term() {
         final String value = faker.photography().term();
         assertNonNullOrEmpty(value);
     }

--- a/src/test/java/net/datafaker/providers/base/RandomFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/RandomFakerTest.java
@@ -21,7 +21,7 @@ class RandomFakerTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNumerifyRandomnessCanBeControlled() {
+    void numerifyRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.numerify("###");
 
@@ -31,7 +31,7 @@ class RandomFakerTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testLetterifyRandomnessCanBeControlled() {
+    void letterifyRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.letterify("???");
 
@@ -41,7 +41,7 @@ class RandomFakerTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testNameRandomnessCanBeControlled() {
+    void nameRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.name().name();
 
@@ -51,7 +51,7 @@ class RandomFakerTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testEmailRandomnessCanBeControlled() {
+    void emailRandomnessCanBeControlled() {
         resetRandomSeed();
         final String firstInvocation = faker.internet().emailAddress();
 

--- a/src/test/java/net/datafaker/providers/base/ScienceTest.java
+++ b/src/test/java/net/datafaker/providers/base/ScienceTest.java
@@ -23,7 +23,7 @@ class ScienceTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testUnit() {
+    void unit() {
         assertThat(faker.science().unit()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/providers/base/ShakespeareTest.java
+++ b/src/test/java/net/datafaker/providers/base/ShakespeareTest.java
@@ -7,22 +7,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ShakespeareTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testHamletQuote() {
+    void hamletQuote() {
         assertThat(faker.shakespeare().hamletQuote()).isNotEmpty();
     }
 
     @Test
-    void testAsYouLikeItQuote() {
+    void asYouLikeItQuote() {
         assertThat(faker.shakespeare().asYouLikeItQuote()).isNotEmpty();
     }
 
     @Test
-    void testKingRichardIIIQuote() {
+    void kingRichardIIIQuote() {
         assertThat(faker.shakespeare().kingRichardIIIQuote()).isNotEmpty();
     }
 
     @Test
-    void testRomeoAndJulietQuote() {
+    void romeoAndJulietQuote() {
         assertThat(faker.shakespeare().romeoAndJulietQuote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/StockTest.java
+++ b/src/test/java/net/datafaker/providers/base/StockTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class StockTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testNasdaq() {
+    void nasdaq() {
         assertThat(faker.stock().nsdqSymbol()).isNotEmpty();
     }
 
     @Test
-    void testNYSE() {
+    void nYSE() {
         assertThat(faker.stock().nyseSymbol()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/providers/base/SuperheroTest.java
+++ b/src/test/java/net/datafaker/providers/base/SuperheroTest.java
@@ -7,27 +7,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SuperheroTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.superhero().name()).matches("[A-Za-z' -/]+");
     }
 
     @Test
-    void testPrefix() {
+    void prefix() {
         assertThat(faker.superhero().prefix()).matches("[A-Za-z -]+");
     }
 
     @Test
-    void testSuffix() {
+    void suffix() {
         assertThat(faker.superhero().suffix()).matches("[A-Za-z -]+");
     }
 
     @Test
-    void testPower() {
+    void power() {
         assertThat(faker.superhero().power()).matches("[A-Za-z/ -]+");
     }
 
     @Test
-    void testDescriptor() {
+    void descriptor() {
         assertThat(faker.superhero().descriptor()).matches("[A-Za-z' -]+");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/TeamTest.java
+++ b/src/test/java/net/datafaker/providers/base/TeamTest.java
@@ -9,28 +9,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TeamTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.team().name()).matches("(\\w+( )?){2,4}");
     }
 
     @Test
-    void testCreature() {
+    void creature() {
         assertThat(faker.team().creature()).matches("\\w+( \\w+)?");
     }
 
     @Test
-    void testState() {
+    void state() {
         assertThat(faker.team().state()).matches("(\\w+( )?){1,2}");
     }
 
     @Test
-    void testStateWithZaLocale() {
+    void stateWithZaLocale() {
         BaseFaker zaFaker = new BaseFaker(new Locale("en", "ZA"));
         assertThat(zaFaker.team().state()).isNotEmpty();
     }
 
     @Test
-    void testSport() {
+    void sport() {
         assertThat(faker.team().sport()).matches("(\\p{L}|\\s)+");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/TimeTest.java
+++ b/src/test/java/net/datafaker/providers/base/TimeTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TimeTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testFutureTime() {
+    void futureTime() {
         LocalTime now = LocalTime.now();
         for (int i = 0; i < 1000; i++) {
             long future = faker.time().future(1, ChronoUnit.SECONDS);
@@ -23,7 +23,7 @@ public class TimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testFutureTimeWithMinimum() {
+    void futureTimeWithMinimum() {
         LocalTime now = LocalTime.now();
         for (int i = 0; i < 1000; i++) {
             long future = faker.time().future(5, 4, ChronoUnit.SECONDS);
@@ -35,7 +35,7 @@ public class TimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPastTimeWithMinimum() {
+    void pastTimeWithMinimum() {
         LocalTime now = LocalTime.now();
         for (int i = 0; i < 1000; i++) {
             long past = faker.time().past(5, 4, ChronoUnit.SECONDS);
@@ -47,14 +47,14 @@ public class TimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testPastTime() {
+    void pastTime() {
         LocalTime now = LocalTime.now();
         long past = faker.time().past(100, ChronoUnit.SECONDS);
         assertThat(LocalTime.ofNanoOfDay(past)).isBefore(now);
     }
 
     @Test
-    void testBetween() {
+    void between() {
         LocalTime now = LocalTime.now();
         LocalTime then = now.plus(1, ChronoUnit.SECONDS);
 
@@ -67,7 +67,7 @@ public class TimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testBetweenThenLargerThanNow() {
+    void betweenThenLargerThanNow() {
         LocalTime now = LocalTime.now();
         LocalTime then = now.plus(1, ChronoUnit.SECONDS);
         assertThatThrownBy(() -> faker.time().between(then, now))

--- a/src/test/java/net/datafaker/providers/base/TronTest.java
+++ b/src/test/java/net/datafaker/providers/base/TronTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TronTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/TwitterTest.java
+++ b/src/test/java/net/datafaker/providers/base/TwitterTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TwitterTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testCreatedDateForward() {
+    void createdDateForward() {
         Date testDate = new Date();
         Date constrainDate = new Date(testDate.getTime() + 3000000);
         Date generated = faker.twitter().createdTime(true, testDate, constrainDate);
@@ -19,7 +19,7 @@ class TwitterTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testCreatedDateBackward() {
+    void createdDateBackward() {
         Date testDate = new Date();
         Date constrainDate = new Date(testDate.getTime() - 3000000);
         Date generated = faker.twitter().createdTime(false, testDate, constrainDate);
@@ -28,28 +28,28 @@ class TwitterTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testShortTwitterIdLength() {
+    void shortTwitterIdLength() {
         int expectedLength = 6;
         String generatedID = faker.twitter().twitterId(expectedLength);
         assertThat(generatedID).hasSize(expectedLength);
     }
 
     @RepeatedTest(100)
-    void testLongTwitterIdLength() {
+    void longTwitterIdLength() {
         int expectedLength = 25;
         String generatedID = faker.twitter().twitterId(expectedLength);
         assertThat(generatedID).hasSize(expectedLength);
     }
 
     @Test
-    void testTwitterIdLength() {
+    void twitterIdLength() {
         int expectedLength = 15;
         String generatedID = faker.twitter().twitterId(expectedLength);
         assertThat(generatedID).hasSize(expectedLength);
     }
 
     @Test
-    void testTwitterIdUnique() {
+    void twitterIdUnique() {
         int expectedLength = 15;
         String generatedIDOne = faker.twitter().twitterId(expectedLength);
         String generatedIDTwo = faker.twitter().twitterId(expectedLength);
@@ -57,7 +57,7 @@ class TwitterTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testTextLength() {
+    void textLength() {
         int sentenceMaxLength = 15;
         int wordMaxLength = 5;
         String text = faker.twitter().text(null, sentenceMaxLength, wordMaxLength);
@@ -66,7 +66,7 @@ class TwitterTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void testTextKeyWords() {
+    void textKeyWords() {
         int sentenceMaxLength = 15;
         int wordMaxLength = 5;
         String[] keywords = new String[]{"buy", "see"};

--- a/src/test/java/net/datafaker/providers/base/UniversityTest.java
+++ b/src/test/java/net/datafaker/providers/base/UniversityTest.java
@@ -7,17 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class UniversityTest extends BaseFakerTest<BaseFaker> {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.university().name()).matches("[A-Za-z'() ]+");
     }
 
     @Test
-    void testPrefix() {
+    void prefix() {
         assertThat(faker.university().prefix()).matches("\\w+");
     }
 
     @Test
-    void testSuffix() {
+    void suffix() {
         assertThat(faker.university().suffix()).matches("\\w+");
     }
 }

--- a/src/test/java/net/datafaker/providers/base/VehicleTest.java
+++ b/src/test/java/net/datafaker/providers/base/VehicleTest.java
@@ -14,87 +14,87 @@ class VehicleTest extends BaseFakerTest<BaseFaker> {
     private static final String INTERNATIONAL_WORDS_MATCH = "\\P{Cc}+";
 
     @RepeatedTest(10)
-    void testVin() {
+    void vin() {
         assertThat(faker.vehicle().vin()).matches(Vehicle.VIN_REGEX);
     }
 
     @RepeatedTest(10)
-    void testManufacturer() {
+    void manufacturer() {
         assertThat(faker.vehicle().manufacturer()).matches(INTERNATIONAL_WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testMake() {
+    void make() {
         assertThat(faker.vehicle().make()).matches(INTERNATIONAL_WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testModel() {
+    void model() {
         assertThat(faker.vehicle().model()).matches(INTERNATIONAL_WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testModelWithParams() {
+    void modelWithParams() {
         assertThat(faker.vehicle().model("Toyota")).matches(INTERNATIONAL_WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testMakeAndModel() {
+    void makeAndModel() {
         assertThat(faker.vehicle().makeAndModel()).matches(INTERNATIONAL_WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testStyle() {
+    void style() {
         assertThat(faker.vehicle().style()).matches(WORD_MATCH);
     }
 
     @RepeatedTest(10)
-    void testColor() {
+    void color() {
         assertThat(faker.vehicle().color()).matches(WORD_MATCH);
     }
 
     @RepeatedTest(10)
-    void testUpholsteryColor() {
+    void upholsteryColor() {
         assertThat(faker.vehicle().upholsteryColor()).matches(WORD_MATCH);
     }
 
     @RepeatedTest(10)
-    void testUpholsteryFabric() {
+    void upholsteryFabric() {
         assertThat(faker.vehicle().upholsteryFabric()).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testUpholstery() {
+    void upholstery() {
         assertThat(faker.vehicle().upholstery()).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testTransmission() {
+    void transmission() {
         assertThat(faker.vehicle().transmission()).matches(WORD_MATCH);
     }
 
     @RepeatedTest(10)
-    void testDriveType() {
+    void driveType() {
         assertThat(faker.vehicle().driveType()).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testFuelType() {
+    void fuelType() {
         assertThat(faker.vehicle().fuelType()).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testCarType() {
+    void carType() {
         assertThat(faker.vehicle().carType()).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testEngine() {
+    void engine() {
         assertThat(faker.vehicle().engine()).matches("\\d Cylinder Engine");
     }
 
     @RepeatedTest(10)
-    void testCarOptions() {
+    void carOptions() {
         List<String> carOptions = faker.vehicle().carOptions();
         assertThat(carOptions)
             .hasSizeGreaterThanOrEqualTo(5)
@@ -102,7 +102,7 @@ class VehicleTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testCarOptionsMinMax() {
+    void carOptionsMinMax() {
         List<String> carOptions = faker.vehicle().carOptions(11, 12);
 
         assertThat(carOptions)
@@ -113,7 +113,7 @@ class VehicleTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testStandardSpecsMinMax() {
+    void standardSpecsMinMax() {
         List<String> standardSpecs = faker.vehicle().standardSpecs(13, 14);
 
         assertThat(standardSpecs)
@@ -122,7 +122,7 @@ class VehicleTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testStandardSpecs() {
+    void standardSpecs() {
         List<String> standardSpecs = faker.vehicle().standardSpecs();
 
         assertThat(standardSpecs)
@@ -131,23 +131,23 @@ class VehicleTest extends BaseFakerTest<BaseFaker> {
     }
 
     @RepeatedTest(10)
-    void testDoor() {
+    void door() {
         assertThat(faker.vehicle().doors()).matches("\\d");
     }
 
     @RepeatedTest(10)
-    void testLicensePlate() {
+    void licensePlate() {
         assertThat(faker.vehicle().licensePlate()).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(10)
-    void testLicensePlateWithParam() {
+    void licensePlateWithParam() {
         assertThat(faker.vehicle().licensePlate("GA")).matches(WORDS_MATCH);
         assertThat(faker.vehicle().licensePlate("AL")).matches(WORDS_MATCH);
     }
 
     @RepeatedTest(100)
-    void testLicensePlateWithParam_Canada() {
+    void licensePlateWithParam_Canada() {
         BaseFaker test = new BaseFaker(Locale.CANADA);
         assertThat(test.vehicle().licensePlate("MB")).matches(WORDS_MATCH);
         assertThat(test.vehicle().licensePlate("ON")).matches(WORDS_MATCH);

--- a/src/test/java/net/datafaker/providers/base/VerbTest.java
+++ b/src/test/java/net/datafaker/providers/base/VerbTest.java
@@ -9,27 +9,27 @@ class VerbTest extends BaseFakerTest<BaseFaker> {
     public static final String WORDS = "[\\w-]+";
 
     @RepeatedTest(10)
-    void testBase() {
+    void base() {
         assertThat(faker.verb().base()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testPast() {
+    void past() {
         assertThat(faker.verb().past()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testPastParticiple() {
+    void pastParticiple() {
         assertThat(faker.verb().pastParticiple()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testSimplePresent() {
+    void simplePresent() {
         assertThat(faker.verb().simplePresent()).matches(WORDS);
     }
 
     @RepeatedTest(10)
-    void testIngForm() {
+    void ingForm() {
         assertThat(faker.verb().ingForm()).matches(WORDS);
     }
 }

--- a/src/test/java/net/datafaker/providers/foods/BeerTest.java
+++ b/src/test/java/net/datafaker/providers/foods/BeerTest.java
@@ -7,27 +7,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BeerTest extends FoodFakerTest {
 
     @Test
-    void testName() {
+    void name() {
         assertThat(faker.beer().name()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testStyle() {
+    void style() {
         assertThat(faker.beer().style()).matches("[A-Za-z'() 0-9-]+");
     }
 
     @Test
-    void testHop() {
+    void hop() {
         assertThat(faker.beer().hop()).matches("[A-Za-z'’(). 0-9-]+");
     }
 
     @Test
-    void testMalt() {
+    void malt() {
         assertThat(faker.beer().malt()).matches("[A-Za-z'() 0-9-]+");
     }
 
     @Test
-    void testYeast() {
+    void yeast() {
         assertThat(faker.beer().yeast()).matches("[\\p{L}'() 0-9-ö]+");
     }
 }

--- a/src/test/java/net/datafaker/providers/foods/CoffeeTest.java
+++ b/src/test/java/net/datafaker/providers/foods/CoffeeTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.foods;
 import net.datafaker.providers.food.Coffee;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CoffeeTest extends FoodFakerTest {
 

--- a/src/test/java/net/datafaker/providers/foods/TeaTest.java
+++ b/src/test/java/net/datafaker/providers/foods/TeaTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TeaTest extends FoodFakerTest {
 
     @Test
-    void testVariety() {
+    void variety() {
         assertThat(faker.tea().variety()).matches("^(?:[A-Z]['.\\-a-z]+[\\s-])*[A-Z]['.\\-a-z]+$");
     }
 
     @Test
-    void testType() {
+    void type() {
         assertThat(faker.tea().type()).matches("^[A-Z][a-z]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/AvatarTest.java
+++ b/src/test/java/net/datafaker/providers/movie/AvatarTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AvatarTest extends MovieFakerTest {
 
     @RepeatedTest(10)
-    void testAvatar() {
+    void avatar() {
         String avatar = faker.avatar().image();
         assertThat(avatar).matches("^https://robohash.org/[a-z]{8}.png$");
     }

--- a/src/test/java/net/datafaker/providers/movie/Babylon5Test.java
+++ b/src/test/java/net/datafaker/providers/movie/Babylon5Test.java
@@ -1,18 +1,19 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class Babylon5Test extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.babylon5().character()).isNotEmpty();
+        assertThat(faker.babylon5().character()).isNotEmpty();
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.babylon5().quote()).isNotEmpty();
+        assertThat(faker.babylon5().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/BigBangTheoryTest.java
+++ b/src/test/java/net/datafaker/providers/movie/BigBangTheoryTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BigBangTheoryTest extends MovieFakerTest {
 
     @RepeatedTest(50)
-    void testCharacter() {
+    void character() {
         assertThat(faker.bigBangTheory().character()).matches("^[A-Z][a-zA-Z .]+$");
     }
 
     @RepeatedTest(50)
-    void testQuote() {
+    void quote() {
         assertThat(faker.bigBangTheory().quote()).matches("^[A-Z][a-zA-Z .’'!,?]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/BojackHorsemanTest.java
+++ b/src/test/java/net/datafaker/providers/movie/BojackHorsemanTest.java
@@ -7,17 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BojackHorsemanTest extends MovieFakerTest {
 
     @Test
-    void testCharacters1() {
+    void characters1() {
         assertThat(faker.bojackHorseman().characters()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testQuotes1() {
+    void quotes1() {
         assertThat(faker.bojackHorseman().quotes()).isNotEmpty();
     }
 
     @Test
-    void testTongueTwisters1() {
+    void tongueTwisters1() {
         assertThat(faker.bojackHorseman().tongueTwisters()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/BuffyTest.java
+++ b/src/test/java/net/datafaker/providers/movie/BuffyTest.java
@@ -6,27 +6,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class BuffyTest extends MovieFakerTest {
     @Test
-    void testCharacters() {
+    void characters() {
         assertThat(faker.buffy().characters()).isNotEmpty();
     }
 
     @Test
-    void testQuotes() {
+    void quotes() {
         assertThat(faker.buffy().quotes()).isNotEmpty();
     }
 
     @Test
-    void testCelebrities() {
+    void celebrities() {
         assertThat(faker.buffy().celebrities()).isNotEmpty();
     }
 
     @Test
-    void testBigBads() {
+    void bigBads() {
         assertThat(faker.buffy().bigBads()).isNotEmpty();
     }
 
     @Test
-    void testEpisodes() {
+    void episodes() {
         assertThat(faker.buffy().episodes()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/ChuckNorrisTest.java
+++ b/src/test/java/net/datafaker/providers/movie/ChuckNorrisTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChuckNorrisTest extends MovieFakerTest {
 
     @Test
-    void testFact() {
+    void fact() {
         assertThat(faker.chuckNorris().fact()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/DarkSoulTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DarkSoulTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.movie;
 
 import org.junit.jupiter.api.RepeatedTest;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DarkSoulTest extends MovieFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/DarkSoulTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DarkSoulTest.java
@@ -9,22 +9,22 @@ class DarkSoulTest extends MovieFakerTest {
     public static final String DARK_SOUL_REGEX = "[A-Za-z '-]+";
 
     @RepeatedTest(10)
-    void testClasses() {
+    void classes() {
         assertThat(faker.darkSoul().classes()).matches(DARK_SOUL_REGEX);
     }
 
     @RepeatedTest(10)
-    void testCovenants() {
+    void covenants() {
         assertThat(faker.darkSoul().covenants()).matches(DARK_SOUL_REGEX);
     }
 
     @RepeatedTest(10)
-    void testShield() {
+    void shield() {
         assertThat(faker.darkSoul().shield()).matches(DARK_SOUL_REGEX);
     }
 
     @RepeatedTest(10)
-    void testStats() {
+    void stats() {
         assertThat(faker.darkSoul().stats()).matches(DARK_SOUL_REGEX);
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/DepartedTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DepartedTest.java
@@ -7,17 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DepartedTest extends MovieFakerTest {
 
     @RepeatedTest(100)
-    void testActor() {
+    void actor() {
         assertThat(faker.departed().actor()).matches("^[a-zA-Z ']+$");
     }
 
     @RepeatedTest(100)
-    void testCharacter() {
+    void character() {
         assertThat(faker.departed().character()).matches("^[a-zA-Z ]+$");
     }
 
     @RepeatedTest(100)
-    void testQuote() {
+    void quote() {
         assertThat(faker.departed().quote()).matches("^[a-zA-Z '.?!,]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/DetectiveConanTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DetectiveConanTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.movie;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DetectiveConanTest extends net.datafaker.AbstractFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/DuneTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DuneTest.java
@@ -1,46 +1,47 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class DuneTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.dune().character()).matches("[A-Za-z '\\-\"]+");
+        assertThat(faker.dune().character()).matches("[A-Za-z '\\-\"]+");
     }
 
     @Test
     void title() {
-        Assertions.assertThat(faker.dune().title()).matches("[A-Za-z ]+");
+        assertThat(faker.dune().title()).matches("[A-Za-z ]+");
     }
 
     @Test
     void planet() {
-        Assertions.assertThat(faker.dune().planet()).matches("[A-Za-z ]+");
+        assertThat(faker.dune().planet()).matches("[A-Za-z ]+");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.dune().quote()).matches("\\P{Cc}+");
+        assertThat(faker.dune().quote()).matches("\\P{Cc}+");
     }
 
     @RepeatedTest(100)
     void randomQuote() {
-        Assertions.assertThat(
+        assertThat(
             faker.dune().quote(faker.options().option(Dune.Quote.class))).matches("\\P{Cc}+");
     }
 
     @Test
     void saying() {
-        Assertions.assertThat(faker.dune().saying()).matches("\\P{Cc}+");
+        assertThat(faker.dune().saying()).matches("\\P{Cc}+");
     }
 
     @RepeatedTest(100)
     void randomSaying() {
-        Assertions.assertThat(
+        assertThat(
             faker.dune().saying(faker.options().option(Dune.Saying.class))).matches("\\P{Cc}+");
     }
 

--- a/src/test/java/net/datafaker/providers/movie/FinalSpaceTest.java
+++ b/src/test/java/net/datafaker/providers/movie/FinalSpaceTest.java
@@ -1,23 +1,24 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class FinalSpaceTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.finalSpace().character()).isNotEmpty();
+        assertThat(faker.finalSpace().character()).isNotEmpty();
     }
 
     @Test
     void vehicle() {
-        Assertions.assertThat(faker.finalSpace().vehicle()).isNotEmpty();
+        assertThat(faker.finalSpace().vehicle()).isNotEmpty();
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.finalSpace().quote()).isNotEmpty();
+        assertThat(faker.finalSpace().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/HeyArnoldTest.java
+++ b/src/test/java/net/datafaker/providers/movie/HeyArnoldTest.java
@@ -1,23 +1,24 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class HeyArnoldTest extends MovieFakerTest {
 
     @Test
     void characters() {
-        Assertions.assertThat(faker.heyArnold().characters()).isNotEmpty();
+        assertThat(faker.heyArnold().characters()).isNotEmpty();
     }
 
     @Test
     void locations() {
-        Assertions.assertThat(faker.heyArnold().locations()).isNotEmpty();
+        assertThat(faker.heyArnold().locations()).isNotEmpty();
     }
 
     @Test
     void quotes() {
-        Assertions.assertThat(faker.heyArnold().quotes()).isNotEmpty();
+        assertThat(faker.heyArnold().quotes()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/HitchhikersGuideToTheGalaxyTest.java
+++ b/src/test/java/net/datafaker/providers/movie/HitchhikersGuideToTheGalaxyTest.java
@@ -1,38 +1,39 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class HitchhikersGuideToTheGalaxyTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().character()).matches("^(\\w+(\\.?\\s?'?))+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().character()).matches("^(\\w+(\\.?\\s?'?))+$");
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().location()).matches("^(\\w+\\S?\\.?\\s?'?-?)+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().location()).matches("^(\\w+\\S?\\.?\\s?'?-?)+$");
     }
 
     @Test
     void marvinQuote() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().marvinQuote()).isNotEmpty();
+        assertThat(faker.hitchhikersGuideToTheGalaxy().marvinQuote()).isNotEmpty();
     }
 
     @Test
     void planet() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().planet()).matches("^(\\w+-?\\s?)+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().planet()).matches("^(\\w+-?\\s?)+$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().quote()).isNotEmpty();
+        assertThat(faker.hitchhikersGuideToTheGalaxy().quote()).isNotEmpty();
     }
 
     @Test
     void species() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().species()).matches("^(\\w+'?\\s?)+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().species()).matches("^(\\w+'?\\s?)+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/HobbitTest.java
+++ b/src/test/java/net/datafaker/providers/movie/HobbitTest.java
@@ -1,28 +1,29 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class HobbitTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.hobbit().character()).matches("^(\\(?\\w+\\.?\\s?\\)?)+$");
+        assertThat(faker.hobbit().character()).matches("^(\\(?\\w+\\.?\\s?\\)?)+$");
     }
 
     @Test
     void thorinsCompany() {
-        Assertions.assertThat(faker.hobbit().thorinsCompany()).matches("^(\\w+\\s?)+$");
+        assertThat(faker.hobbit().thorinsCompany()).matches("^(\\w+\\s?)+$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.hobbit().quote()).isNotEmpty();
+        assertThat(faker.hobbit().quote()).isNotEmpty();
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.hobbit().location()).matches("^(\\w+'?-?\\s?)+$");
+        assertThat(faker.hobbit().location()).matches("^(\\w+'?-?\\s?)+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/KaamelottTest.java
+++ b/src/test/java/net/datafaker/providers/movie/KaamelottTest.java
@@ -7,12 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class KaamelottTest extends MovieFakerTest {
 
     @Test
-    void testCharacter() {
+    void character() {
         assertThat(faker.kaamelott().character()).matches("[A-Za-z' -ÇÉàçêèéïîüùú]+");
     }
 
     @Test
-    void testQuote() {
+    void quote() {
         assertThat(faker.kaamelott().quote()).matches("[-A-Za-z0-9 —ÇÉàçêèéïîüùú;:…?!.’‘'”“,\\[\\]]+");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/LebowskiTest.java
+++ b/src/test/java/net/datafaker/providers/movie/LebowskiTest.java
@@ -1,22 +1,23 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class LebowskiTest extends MovieFakerTest {
     @Test
     void actor() {
-        Assertions.assertThat(faker.lebowski().actor()).matches("^([\\w]+ ?){1,3}$");
+        assertThat(faker.lebowski().actor()).matches("^([\\w]+ ?){1,3}$");
     }
 
     @Test
     void character() {
-        Assertions.assertThat(faker.lebowski().character()).matches("^([\\w]+ ?){1,3}$");
+        assertThat(faker.lebowski().character()).matches("^([\\w]+ ?){1,3}$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.lebowski().quote()).matches("^([\\w.,!?'-]+ ?)+$");
+        assertThat(faker.lebowski().quote()).matches("^([\\w.,!?'-]+ ?)+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/MovieTest.java
+++ b/src/test/java/net/datafaker/providers/movie/MovieTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MovieTest extends MovieFakerTest {
 
     @RepeatedTest(50)
-    void testQuote() {
+    void quote() {
         assertThat(faker.movie().quote()).matches("^[a-zA-Z ,'’.?]+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/ResidentEvilTest.java
+++ b/src/test/java/net/datafaker/providers/movie/ResidentEvilTest.java
@@ -9,7 +9,7 @@ class ResidentEvilTest extends MovieFakerTest {
     static private final String WORDS_WITH_SPECIAL_CHAR_REGEX = "^(?! )[A-Za-z0-9αγβ'.()\\- ]*(?<! )$";
 
     @Test
-    void testCharacter() {
+    void character() {
         String character = faker.residentEvil().character();
         assertThat(character)
             .isNotEmpty()
@@ -17,7 +17,7 @@ class ResidentEvilTest extends MovieFakerTest {
     }
 
     @Test
-    void testBiologicalAgent() {
+    void biologicalAgent() {
         String biologicalAgent = faker.residentEvil().biologicalAgent();
         assertThat(biologicalAgent)
             .isNotEmpty()
@@ -25,7 +25,7 @@ class ResidentEvilTest extends MovieFakerTest {
     }
 
     @Test
-    void testEquipment() {
+    void equipment() {
         String equipment = faker.residentEvil().equipment();
         assertThat(equipment)
             .isNotEmpty()
@@ -33,7 +33,7 @@ class ResidentEvilTest extends MovieFakerTest {
     }
 
     @Test
-    void testLocation() {
+    void location() {
         String location = faker.residentEvil().location();
         assertThat(location)
             .isNotEmpty()
@@ -41,7 +41,7 @@ class ResidentEvilTest extends MovieFakerTest {
     }
 
     @Test
-    void testCreature() {
+    void creature() {
         String creature = faker.residentEvil().creature();
         assertThat(creature)
             .isNotEmpty()

--- a/src/test/java/net/datafaker/providers/movie/SeinfeldTest.java
+++ b/src/test/java/net/datafaker/providers/movie/SeinfeldTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.movie;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SeinfeldTest extends MovieFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/SimpsonsTest.java
+++ b/src/test/java/net/datafaker/providers/movie/SimpsonsTest.java
@@ -1,23 +1,24 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class SimpsonsTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.simpsons().character()).isNotEmpty();
+        assertThat(faker.simpsons().character()).isNotEmpty();
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.simpsons().location()).isNotEmpty();
+        assertThat(faker.simpsons().location()).isNotEmpty();
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.simpsons().quote()).isNotEmpty();
+        assertThat(faker.simpsons().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/StarTrekTest.java
+++ b/src/test/java/net/datafaker/providers/movie/StarTrekTest.java
@@ -1,33 +1,34 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class StarTrekTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.starTrek().character()).matches("^(\\w+-?'?\\.?\\s?)+$");
+        assertThat(faker.starTrek().character()).matches("^(\\w+-?'?\\.?\\s?)+$");
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.starTrek().location()).matches("^(\\w+'?\\s?)+$");
+        assertThat(faker.starTrek().location()).matches("^(\\w+'?\\s?)+$");
     }
 
     @Test
     void species() {
-        Assertions.assertThat(faker.starTrek().species()).matches("^(\\w+-?'?\\s?)+$");
+        assertThat(faker.starTrek().species()).matches("^(\\w+-?'?\\s?)+$");
     }
 
     @Test
     void villain() {
-        Assertions.assertThat(faker.starTrek().villain()).matches("^(\\w+'?\\.?\\s?)+$");
+        assertThat(faker.starTrek().villain()).matches("^(\\w+'?\\.?\\s?)+$");
     }
 
     @Test
     void klingon() {
-        Assertions.assertThat(faker.starTrek().klingon()).isNotEmpty();
+        assertThat(faker.starTrek().klingon()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/WitcherTest.java
+++ b/src/test/java/net/datafaker/providers/movie/WitcherTest.java
@@ -7,47 +7,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WitcherTest extends MovieFakerTest {
 
     @Test
-    void testCharacter() {
+    void character() {
         assertThat(faker.witcher().character()).matches("[A-Za-z' -éúï]+");
     }
 
     @Test
-    void testWitcher() {
+    void witcher() {
         assertThat(faker.witcher().witcher()).matches("[A-Za-z -ëúï]+");
     }
 
     @Test
-    void testSchool() {
+    void school() {
         assertThat(faker.witcher().school()).matches("[A-Za-z]+");
     }
 
     @Test
-    void testLocation() {
+    void location() {
         assertThat(faker.witcher().location()).matches("[A-Za-z -áâé]+");
     }
 
     @Test
-    void testQuote() {
+    void quote() {
         assertThat(faker.witcher().quote()).matches("[-A-Za-z0-9 —;…?!.’‘'”“,\\[\\]]+");
     }
 
     @Test
-    void testMonster() {
+    void monster() {
         assertThat(faker.witcher().monster()).matches("[A-Za-z -]+");
     }
 
     @Test
-    void testSign() {
+    void sign() {
         assertThat(faker.witcher().sign()).matches("[A-Za-z -]+");
     }
 
     @Test
-    void testPotion() {
+    void potion() {
         assertThat(faker.witcher().potion()).matches("[A-Za-z '-]+");
     }
 
     @Test
-    void testBook() {
+    void book() {
         assertThat(faker.witcher().book()).matches("[A-Za-z -]+");
     }
 }

--- a/src/test/java/net/datafaker/providers/sport/BasketballTest.java
+++ b/src/test/java/net/datafaker/providers/sport/BasketballTest.java
@@ -7,22 +7,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BasketballTest extends SportFakerTest {
 
     @Test
-    void testPositions() {
+    void positions() {
         assertThat(faker.basketball().positions()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testTeams() {
+    void teams() {
         assertThat(faker.basketball().teams()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testCoaches() {
+    void coaches() {
         assertThat(faker.basketball().coaches()).matches("[\\p{L}'()., 0-9-’]+");
     }
 
     @Test
-    void testPlayers() {
+    void players() {
         assertThat(faker.basketball().players()).matches("[\\p{L}'()., 0-9-’]+");
     }
 }

--- a/src/test/java/net/datafaker/providers/sport/CricketTest.java
+++ b/src/test/java/net/datafaker/providers/sport/CricketTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.sport;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CricketTest extends SportFakerTest {
 

--- a/src/test/java/net/datafaker/providers/sport/EnglandFootBallTest.java
+++ b/src/test/java/net/datafaker/providers/sport/EnglandFootBallTest.java
@@ -8,13 +8,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EnglandFootBallTest extends SportFakerTest {
 
     @Test
-    void testLeague() {
+    void league() {
         String league = faker.englandfootball().league();
         assertThat(league).isNotEmpty();
     }
 
     @Test
-    void testTeam() {
+    void team() {
         String team = faker.englandfootball().team();
         assertThat(team).isNotEmpty();
     }

--- a/src/test/java/net/datafaker/providers/sport/FootballTest.java
+++ b/src/test/java/net/datafaker/providers/sport/FootballTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.sport;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class FootballTest extends SportFakerTest {
 

--- a/src/test/java/net/datafaker/providers/videogame/ElderScrollsTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/ElderScrollsTest.java
@@ -10,42 +10,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ElderScrollsTest extends VideoGameFakerTest {
 
     @Test
-    void testCity() {
+    void city() {
         assertThat(faker.elderScrolls().city()).isNotEmpty();
     }
 
     @Test
-    void testCreature() {
+    void creature() {
         assertThat(faker.elderScrolls().creature()).isNotEmpty();
     }
 
     @Test
-    void testDragon() {
+    void dragon() {
         assertThat(faker.elderScrolls().dragon()).isNotEmpty();
     }
 
     @Test
-    void testFirstName() {
+    void firstName() {
         assertThat(faker.elderScrolls().firstName()).isNotEmpty();
     }
 
     @Test
-    void testLastName() {
+    void lastName() {
         assertThat(faker.elderScrolls().lastName()).isNotEmpty();
     }
 
     @Test
-    void testRace() {
+    void race() {
         assertThat(faker.elderScrolls().race()).isNotEmpty();
     }
 
     @Test
-    void testRegion() {
+    void region() {
         assertThat(faker.elderScrolls().region()).isNotEmpty();
     }
 
     @Test
-    void testQuote() {
+    void quote() {
         assertThat(faker.elderScrolls().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/videogame/FalloutTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/FalloutTest.java
@@ -8,22 +8,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FalloutTest extends VideoGameFakerTest {
 
     @Test
-    void testCharacter() {
+    void character() {
         assertThat(faker.fallout().character()).isNotEmpty();
     }
 
     @Test
-    void testFaction() {
+    void faction() {
         assertThat(faker.fallout().faction()).isNotEmpty();
     }
 
     @Test
-    void testLocation() {
+    void location() {
         assertThat(faker.fallout().location()).isNotEmpty();
     }
 
     @Test
-    void testQuote() {
+    void quote() {
         assertThat(faker.fallout().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/videogame/HeroesOfTheStormTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/HeroesOfTheStormTest.java
@@ -7,22 +7,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HeroesOfTheStormTest extends VideoGameFakerTest {
 
     @Test
-    void testBattleground() {
+    void battleground() {
         assertThat(faker.heroesOfTheStorm().battleground()).isNotEmpty();
     }
 
     @Test
-    void testHeroClass() {
+    void heroClass() {
         assertThat(faker.heroesOfTheStorm().heroClass()).isNotEmpty();
     }
 
     @Test
-    void testHero() {
+    void hero() {
         assertThat(faker.heroesOfTheStorm().hero()).isNotEmpty();
     }
 
     @Test
-    void testQuote() {
+    void quote() {
         assertThat(faker.heroesOfTheStorm().quote()).isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/providers/videogame/MinecraftTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/MinecraftTest.java
@@ -8,32 +8,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MinecraftTest extends VideoGameFakerTest {
 
     @Test
-    void testItemName() {
+    void itemName() {
         assertThat(faker.minecraft().itemName()).matches("([\\w'()]+\\.?( )?){2,4}");
     }
 
     @Test
-    void testTileName() {
+    void tileName() {
         assertThat(faker.minecraft().tileName()).matches("([\\w'()]+\\.?( )?){2,5}");
     }
 
     @Test
-    void testEntityName() {
+    void entityName() {
         assertThat(faker.minecraft().entityName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    void testMonsterName() {
+    void monsterName() {
         assertThat(faker.minecraft().monsterName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    void testAnimalName() {
+    void animalName() {
         assertThat(faker.minecraft().animalName()).matches("([\\w']+\\.?( )?){2,4}");
     }
 
     @Test
-    void testTileItemName() {
+    void tileItemName() {
         assertThat(faker.minecraft().tileItemName()).matches("([\\w()']+\\.?( )?){2,5}");
     }
 

--- a/src/test/java/net/datafaker/providers/videogame/StarCraftTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/StarCraftTest.java
@@ -9,7 +9,7 @@ class StarCraftTest extends VideoGameFakerTest {
     private final String noLeadingTrailingWhitespaceRegex = "^(?! )[-A-Za-z\\d' ]*(?<! )$";
 
     @Test
-    void testUnit() {
+    void unit() {
         String unit = faker.starCraft().unit();
         assertThat(unit)
             .isNotEmpty()
@@ -17,7 +17,7 @@ class StarCraftTest extends VideoGameFakerTest {
     }
 
     @RepeatedTest(1000)
-    void testUnitOneThousand() {
+    void unitOneThousand() {
         String unit = faker.starCraft().unit();
         // System.out.println(unit);
         assertThat(unit)
@@ -26,7 +26,7 @@ class StarCraftTest extends VideoGameFakerTest {
     }
 
     @Test
-    void testBuilding() {
+    void building() {
         String building = faker.starCraft().building();
         assertThat(building)
             .isNotEmpty()
@@ -34,7 +34,7 @@ class StarCraftTest extends VideoGameFakerTest {
     }
 
     @Test
-    void testCharacter() {
+    void character() {
         String character = faker.starCraft().character();
         assertThat(character)
             .isNotEmpty()
@@ -42,7 +42,7 @@ class StarCraftTest extends VideoGameFakerTest {
     }
 
     @Test
-    void testPlanet() {
+    void planet() {
         String planet = faker.starCraft().planet();
         assertThat(planet)
             .isNotEmpty()
@@ -50,7 +50,7 @@ class StarCraftTest extends VideoGameFakerTest {
     }
 
     @RepeatedTest(1000)
-    void testPlanetOneThousand() {
+    void planetOneThousand() {
         String planet = faker.starCraft().planet();
         assertThat(planet)
             .isNotEmpty()

--- a/src/test/java/net/datafaker/providers/videogame/TouhouTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/TouhouTest.java
@@ -8,27 +8,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TouhouTest extends VideoGameFakerTest {
 
     @RepeatedTest(100)
-    void testCharacterName() {
+    void characterName() {
         assertThat(faker.touhou().characterName()).matches("[a-zA-Z0-9 \\-']+");
     }
 
     @RepeatedTest(100)
-    void testCharacterFirstName() {
+    void characterFirstName() {
         assertThat(faker.touhou().characterFirstName()).matches("[a-zA-Z0-9 \\-']+");
     }
 
     @RepeatedTest(100)
-    void testCharacterLastName() {
+    void characterLastName() {
         assertThat(faker.touhou().characterLastName()).matches("[a-zA-Z0-9 \\-']+");
     }
 
     @RepeatedTest(100)
-    void testTrackName() {
+    void trackName() {
         assertThat(faker.touhou().trackName()).matches(".+");
     }
 
     @RepeatedTest(100)
-    void testGameName() {
+    void gameName() {
         String s = faker.touhou().gameName();
         assertThat(s).matches("[a-zA-Z0-9 \\-'.]+");
     }

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -205,35 +205,35 @@ class FakeValuesServiceTest extends AbstractFakerTest {
     }
 
     @Test
-    void testLocaleChain() {
+    void localeChain() {
         final List<Locale> chain = context.localeChain(Locale.SIMPLIFIED_CHINESE);
 
         assertThat(chain).contains(Locale.SIMPLIFIED_CHINESE, Locale.CHINESE, Locale.ENGLISH);
     }
 
     @Test
-    void testLocaleChainEnglish() {
+    void localeChainEnglish() {
         final List<Locale> chain = new FakerContext(Locale.ENGLISH, null).localeChain(Locale.ENGLISH);
 
         assertThat(chain).contains(Locale.ENGLISH);
     }
 
     @Test
-    void testLocaleChainLanguageOnly() {
+    void localeChainLanguageOnly() {
         final List<Locale> chain = new FakerContext(Locale.CHINESE, null).localeChain(Locale.CHINESE);
 
         assertThat(chain).contains(Locale.CHINESE, Locale.ENGLISH);
     }
 
     @Test
-    void testLocalesChainGetter() {
+    void localesChainGetter() {
         final List<Locale> chain = context.getLocaleChain();
 
         assertThat(chain).contains(new Locale("test"), Locale.ENGLISH);
     }
 
     @Test
-    void testLocalesChainGetterRu() {
+    void localesChainGetterRu() {
         final FakerContext FVS = new FakerContext(new Locale("ru"), randomService);
         final List<Locale> processedChain = FVS.localeChain(new Locale("ru"));
         final List<Locale> chain = FVS.getLocaleChain();

--- a/src/test/java/net/datafaker/service/RandomServiceTest.java
+++ b/src/test/java/net/datafaker/service/RandomServiceTest.java
@@ -21,14 +21,14 @@ class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testPositiveBoundariesOnly(RandomService randomService) {
+    void positiveBoundariesOnly(RandomService randomService) {
         assertThatThrownBy(() -> randomService.nextLong(0L))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testLongWithinBoundary(RandomService randomService) {
+    void longWithinBoundary(RandomService randomService) {
         assertThat(randomService.nextLong(1)).isZero();
 
         for (int i = 1; i < 10; i++) {
@@ -38,13 +38,13 @@ class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testLongMaxBoundary(RandomService randomService) {
+    void longMaxBoundary(RandomService randomService) {
         assertThat(randomService.nextLong(Long.MAX_VALUE)).isStrictlyBetween(0L, Long.MAX_VALUE);
     }
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testIntInRange(RandomService randomService) {
+    void intInRange(RandomService randomService) {
         final Condition<Integer> lessThanOrEqual = new Condition<>(t -> t <= 5, "should be less than or equal 5");
         final Condition<Integer> greaterThanOrEqual = new Condition<>(t -> t >= -5, "should be greater than or equal -5");
         for (int i = 1; i < 100; i++) {
@@ -84,7 +84,7 @@ class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testDoubleInRange(RandomService randomService) {
+    void doubleInRange(RandomService randomService) {
         final Condition<Double> lessThanOrEqual = new Condition<>(t -> t <= 5d, "should be less than or equal 5");
         final Condition<Double> greaterThanOrEqual = new Condition<>(t -> t >= -5d, "should be greater than or equal -5");
         for (int i = 1; i < 100; i++) {
@@ -94,7 +94,7 @@ class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testLongInRange(RandomService randomService) {
+    void longInRange(RandomService randomService) {
         final Condition<Long> lessThanOrEqual = new Condition<>(t -> t <= 5_000_000_000L, "should be less than or equal 5_000_000_000L");
         final Condition<Long> greaterThanOrEqual = new Condition<>(t -> t >= -5_000_000_000L, "should be greater than or equal -5_000_000_000L");
         for (int i = 1; i < 1_000; i++) {
@@ -104,13 +104,13 @@ class RandomServiceTest extends AbstractFakerTest {
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testHex(RandomService randomService) {
+    void hex(RandomService randomService) {
         assertThat(randomService.hex(8)).matches("^[0-9A-F]{8}$");
     }
 
     @ParameterizedTest
     @MethodSource("randomServiceProvider")
-    void testDefaultHex(RandomService randomService) {
+    void defaultHex(RandomService randomService) {
         assertThat(randomService.hex()).matches("^[0-9A-F]{8}$");
     }
 


### PR DESCRIPTION
Fairly simple changes automatically applied through OpenRewrite.
Now consistently uses static imports for assertions, and test method names dropped the no-longer-needed-test-prefix.

https://docs.openrewrite.org/reference/recipes/java/testing/assertj/assertj
https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/bestpractices