### PR TITLE
Run AssertJ best practices OpenRewrite recipe

### DIFF
--- a/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/ZhCNIdNumberTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.Locale;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ZhCNIdNumberTest extends AbstractFakerTest {
 

--- a/src/test/java/net/datafaker/providers/base/BookTest.java
+++ b/src/test/java/net/datafaker/providers/base/BookTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BookTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/CannabisTest.java
+++ b/src/test/java/net/datafaker/providers/base/CannabisTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CannabisTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
+++ b/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ChiquitoTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/ConstructionTest.java
+++ b/src/test/java/net/datafaker/providers/base/ConstructionTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ConstructionTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/base/DungeonsAndDragonsTest.java
+++ b/src/test/java/net/datafaker/providers/base/DungeonsAndDragonsTest.java
@@ -1,54 +1,55 @@
 package net.datafaker.providers.base;
 
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class DungeonsAndDragonsTest extends net.datafaker.AbstractFakerTest {
 
     @Test
     void alignments() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().alignments()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().alignments()).isNotEmpty();
     }
 
     @Test
     void backgrounds() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().backgrounds()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().backgrounds()).isNotEmpty();
     }
 
     @Test
     void cities() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().cities()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().cities()).isNotEmpty();
     }
 
     @Test
     void klasses() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().klasses()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().klasses()).isNotEmpty();
     }
 
     @Test
     void languages() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().languages()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().languages()).isNotEmpty();
     }
 
     @Test
     void meleeWeapons() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().meleeWeapons()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().meleeWeapons()).isNotEmpty();
     }
 
     @Test
     void monsters() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().monsters()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().monsters()).isNotEmpty();
     }
 
     @Test
     void races() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().races()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().races()).isNotEmpty();
     }
 
     @Test
     void rangedWeapons() {
-        AssertionsForClassTypes.assertThat(faker.dungeonsAndDragons().rangedWeapons()).isNotEmpty();
+        assertThat(faker.dungeonsAndDragons().rangedWeapons()).isNotEmpty();
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/InternetPasswordTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetPasswordTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class InternetPasswordTest extends BaseFakerTest<BaseFaker> {
     @Test

--- a/src/test/java/net/datafaker/providers/base/OverwatchTest.java
+++ b/src/test/java/net/datafaker/providers/base/OverwatchTest.java
@@ -1,24 +1,25 @@
 package net.datafaker.providers.base;
 
 import net.datafaker.providers.videogame.VideoGameFakerTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class OverwatchTest extends VideoGameFakerTest {
 
     @Test
     void hero() {
-        Assertions.assertThat(faker.overwatch().hero()).matches("^(\\w+\\.?\\s?)+$");
+        assertThat(faker.overwatch().hero()).matches("^(\\w+\\.?\\s?)+$");
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.overwatch().location()).matches("^(.+'?:?\\s?)+$");
+        assertThat(faker.overwatch().location()).matches("^(.+'?:?\\s?)+$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.overwatch().quote()).isNotEmpty();
+        assertThat(faker.overwatch().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/base/TronTest.java
+++ b/src/test/java/net/datafaker/providers/base/TronTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TronTest extends BaseFakerTest<BaseFaker> {
 

--- a/src/test/java/net/datafaker/providers/foods/CoffeeTest.java
+++ b/src/test/java/net/datafaker/providers/foods/CoffeeTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.foods;
 import net.datafaker.providers.food.Coffee;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CoffeeTest extends FoodFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/Babylon5Test.java
+++ b/src/test/java/net/datafaker/providers/movie/Babylon5Test.java
@@ -1,18 +1,19 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class Babylon5Test extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.babylon5().character()).isNotEmpty();
+        assertThat(faker.babylon5().character()).isNotEmpty();
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.babylon5().quote()).isNotEmpty();
+        assertThat(faker.babylon5().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/DarkSoulTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DarkSoulTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.movie;
 
 import org.junit.jupiter.api.RepeatedTest;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DarkSoulTest extends MovieFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/DetectiveConanTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DetectiveConanTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.movie;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DetectiveConanTest extends net.datafaker.AbstractFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/DuneTest.java
+++ b/src/test/java/net/datafaker/providers/movie/DuneTest.java
@@ -1,46 +1,47 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class DuneTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.dune().character()).matches("[A-Za-z '\\-\"]+");
+        assertThat(faker.dune().character()).matches("[A-Za-z '\\-\"]+");
     }
 
     @Test
     void title() {
-        Assertions.assertThat(faker.dune().title()).matches("[A-Za-z ]+");
+        assertThat(faker.dune().title()).matches("[A-Za-z ]+");
     }
 
     @Test
     void planet() {
-        Assertions.assertThat(faker.dune().planet()).matches("[A-Za-z ]+");
+        assertThat(faker.dune().planet()).matches("[A-Za-z ]+");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.dune().quote()).matches("\\P{Cc}+");
+        assertThat(faker.dune().quote()).matches("\\P{Cc}+");
     }
 
     @RepeatedTest(100)
     void randomQuote() {
-        Assertions.assertThat(
+        assertThat(
             faker.dune().quote(faker.options().option(Dune.Quote.class))).matches("\\P{Cc}+");
     }
 
     @Test
     void saying() {
-        Assertions.assertThat(faker.dune().saying()).matches("\\P{Cc}+");
+        assertThat(faker.dune().saying()).matches("\\P{Cc}+");
     }
 
     @RepeatedTest(100)
     void randomSaying() {
-        Assertions.assertThat(
+        assertThat(
             faker.dune().saying(faker.options().option(Dune.Saying.class))).matches("\\P{Cc}+");
     }
 

--- a/src/test/java/net/datafaker/providers/movie/FinalSpaceTest.java
+++ b/src/test/java/net/datafaker/providers/movie/FinalSpaceTest.java
@@ -1,23 +1,24 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class FinalSpaceTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.finalSpace().character()).isNotEmpty();
+        assertThat(faker.finalSpace().character()).isNotEmpty();
     }
 
     @Test
     void vehicle() {
-        Assertions.assertThat(faker.finalSpace().vehicle()).isNotEmpty();
+        assertThat(faker.finalSpace().vehicle()).isNotEmpty();
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.finalSpace().quote()).isNotEmpty();
+        assertThat(faker.finalSpace().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/HeyArnoldTest.java
+++ b/src/test/java/net/datafaker/providers/movie/HeyArnoldTest.java
@@ -1,23 +1,24 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class HeyArnoldTest extends MovieFakerTest {
 
     @Test
     void characters() {
-        Assertions.assertThat(faker.heyArnold().characters()).isNotEmpty();
+        assertThat(faker.heyArnold().characters()).isNotEmpty();
     }
 
     @Test
     void locations() {
-        Assertions.assertThat(faker.heyArnold().locations()).isNotEmpty();
+        assertThat(faker.heyArnold().locations()).isNotEmpty();
     }
 
     @Test
     void quotes() {
-        Assertions.assertThat(faker.heyArnold().quotes()).isNotEmpty();
+        assertThat(faker.heyArnold().quotes()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/HitchhikersGuideToTheGalaxyTest.java
+++ b/src/test/java/net/datafaker/providers/movie/HitchhikersGuideToTheGalaxyTest.java
@@ -1,38 +1,39 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class HitchhikersGuideToTheGalaxyTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().character()).matches("^(\\w+(\\.?\\s?'?))+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().character()).matches("^(\\w+(\\.?\\s?'?))+$");
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().location()).matches("^(\\w+\\S?\\.?\\s?'?-?)+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().location()).matches("^(\\w+\\S?\\.?\\s?'?-?)+$");
     }
 
     @Test
     void marvinQuote() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().marvinQuote()).isNotEmpty();
+        assertThat(faker.hitchhikersGuideToTheGalaxy().marvinQuote()).isNotEmpty();
     }
 
     @Test
     void planet() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().planet()).matches("^(\\w+-?\\s?)+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().planet()).matches("^(\\w+-?\\s?)+$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().quote()).isNotEmpty();
+        assertThat(faker.hitchhikersGuideToTheGalaxy().quote()).isNotEmpty();
     }
 
     @Test
     void species() {
-        Assertions.assertThat(faker.hitchhikersGuideToTheGalaxy().species()).matches("^(\\w+'?\\s?)+$");
+        assertThat(faker.hitchhikersGuideToTheGalaxy().species()).matches("^(\\w+'?\\s?)+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/HobbitTest.java
+++ b/src/test/java/net/datafaker/providers/movie/HobbitTest.java
@@ -1,28 +1,29 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class HobbitTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.hobbit().character()).matches("^(\\(?\\w+\\.?\\s?\\)?)+$");
+        assertThat(faker.hobbit().character()).matches("^(\\(?\\w+\\.?\\s?\\)?)+$");
     }
 
     @Test
     void thorinsCompany() {
-        Assertions.assertThat(faker.hobbit().thorinsCompany()).matches("^(\\w+\\s?)+$");
+        assertThat(faker.hobbit().thorinsCompany()).matches("^(\\w+\\s?)+$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.hobbit().quote()).isNotEmpty();
+        assertThat(faker.hobbit().quote()).isNotEmpty();
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.hobbit().location()).matches("^(\\w+'?-?\\s?)+$");
+        assertThat(faker.hobbit().location()).matches("^(\\w+'?-?\\s?)+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/LebowskiTest.java
+++ b/src/test/java/net/datafaker/providers/movie/LebowskiTest.java
@@ -1,22 +1,23 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class LebowskiTest extends MovieFakerTest {
     @Test
     void actor() {
-        Assertions.assertThat(faker.lebowski().actor()).matches("^([\\w]+ ?){1,3}$");
+        assertThat(faker.lebowski().actor()).matches("^([\\w]+ ?){1,3}$");
     }
 
     @Test
     void character() {
-        Assertions.assertThat(faker.lebowski().character()).matches("^([\\w]+ ?){1,3}$");
+        assertThat(faker.lebowski().character()).matches("^([\\w]+ ?){1,3}$");
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.lebowski().quote()).matches("^([\\w.,!?'-]+ ?)+$");
+        assertThat(faker.lebowski().quote()).matches("^([\\w.,!?'-]+ ?)+$");
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/SeinfeldTest.java
+++ b/src/test/java/net/datafaker/providers/movie/SeinfeldTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.movie;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SeinfeldTest extends MovieFakerTest {
 

--- a/src/test/java/net/datafaker/providers/movie/SimpsonsTest.java
+++ b/src/test/java/net/datafaker/providers/movie/SimpsonsTest.java
@@ -1,23 +1,24 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class SimpsonsTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.simpsons().character()).isNotEmpty();
+        assertThat(faker.simpsons().character()).isNotEmpty();
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.simpsons().location()).isNotEmpty();
+        assertThat(faker.simpsons().location()).isNotEmpty();
     }
 
     @Test
     void quote() {
-        Assertions.assertThat(faker.simpsons().quote()).isNotEmpty();
+        assertThat(faker.simpsons().quote()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/movie/StarTrekTest.java
+++ b/src/test/java/net/datafaker/providers/movie/StarTrekTest.java
@@ -1,33 +1,34 @@
 package net.datafaker.providers.movie;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class StarTrekTest extends MovieFakerTest {
 
     @Test
     void character() {
-        Assertions.assertThat(faker.starTrek().character()).matches("^(\\w+-?'?\\.?\\s?)+$");
+        assertThat(faker.starTrek().character()).matches("^(\\w+-?'?\\.?\\s?)+$");
     }
 
     @Test
     void location() {
-        Assertions.assertThat(faker.starTrek().location()).matches("^(\\w+'?\\s?)+$");
+        assertThat(faker.starTrek().location()).matches("^(\\w+'?\\s?)+$");
     }
 
     @Test
     void species() {
-        Assertions.assertThat(faker.starTrek().species()).matches("^(\\w+-?'?\\s?)+$");
+        assertThat(faker.starTrek().species()).matches("^(\\w+-?'?\\s?)+$");
     }
 
     @Test
     void villain() {
-        Assertions.assertThat(faker.starTrek().villain()).matches("^(\\w+'?\\.?\\s?)+$");
+        assertThat(faker.starTrek().villain()).matches("^(\\w+'?\\.?\\s?)+$");
     }
 
     @Test
     void klingon() {
-        Assertions.assertThat(faker.starTrek().klingon()).isNotEmpty();
+        assertThat(faker.starTrek().klingon()).isNotEmpty();
     }
 }

--- a/src/test/java/net/datafaker/providers/sport/CricketTest.java
+++ b/src/test/java/net/datafaker/providers/sport/CricketTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.sport;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CricketTest extends SportFakerTest {
 

--- a/src/test/java/net/datafaker/providers/sport/FootballTest.java
+++ b/src/test/java/net/datafaker/providers/sport/FootballTest.java
@@ -2,7 +2,7 @@ package net.datafaker.providers.sport;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class FootballTest extends SportFakerTest {
 


### PR DESCRIPTION
Consistently use static imports for AssertJ, as a once of code change, [through OpenRewrite](https://docs.openrewrite.org/reference/recipes/java/testing/assertj/assertj).

```
mvn org.openrewrite.maven:rewrite-maven-plugin:4.36.0:run \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:1.30.0 \
  -DactiveRecipes=org.openrewrite.java.testing.assertj.Assertj
```