### PR TITLE
Add batch support and keyword case support for sql

### DIFF
--- a/src/main/java/net/datafaker/transformations/Casing.java
+++ b/src/main/java/net/datafaker/transformations/Casing.java
@@ -8,5 +8,7 @@ public enum Casing {
     TO_UPPER,
 
     /** Identifiers are converted to lower-case. */
-    TO_LOWER
+    TO_LOWER;
+
+    public static final Casing DEFAULT_CASING = Casing.TO_UPPER;
 }

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -17,7 +17,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
   }
 
   @Override
-  public CharSequence apply(IN input, Schema<IN, ?> schema) {
+  public CharSequence apply(IN input, Schema<IN, ?> schema, int rowId) {
     Field<IN, ?>[] fields = schema.getFields();
     if (fields.length == 0) {
       return "";
@@ -39,7 +39,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     StringBuilder sb = new StringBuilder();
     generateHeader(schema, sb);
     for (int i = 0; i < input.size(); i++) {
-      sb.append(apply(input.get(i), schema));
+      sb.append(apply(input.get(i), schema, i));
       if (i < input.size() - 1) {
         sb.append(System.lineSeparator());
       }
@@ -83,7 +83,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     StringBuilder sb = new StringBuilder();
     generateHeader(schema, sb);
     for (int i = 0; i < limit; i++) {
-      sb.append(apply(null, schema));
+      sb.append(apply(null, schema, i));
       if (i < limit - 1) {
         sb.append(System.lineSeparator());
       }

--- a/src/main/java/net/datafaker/transformations/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/SqlDialect.java
@@ -1,5 +1,7 @@
 package net.datafaker.transformations;
 
+import static net.datafaker.transformations.Casing.DEFAULT_CASING;
+
 public enum SqlDialect {
     ANSI("`"),
     BIGQUERY("`", Casing.UNCHANGED),
@@ -12,7 +14,7 @@ public enum SqlDialect {
     LUCIDDB("\""),
     MARIADB("`", Casing.TO_LOWER),
     MSSQL("[]"),
-    MYSQL("`", Casing.UNCHANGED),
+    MYSQL("`", Casing.UNCHANGED, true),
     NETEZZA("\""),
     ORACLE("\""),
     PARACCEL("\""),
@@ -23,17 +25,26 @@ public enum SqlDialect {
     SNOWFLAKE("\""),
     TERADATA("\""),
     VERTICA("\"", Casing.UNCHANGED);
-
     private final String sqlQuoteIdentifier;
     private final Casing unquotedCasing;
+    private final boolean supportBulkInsert;
 
-    SqlDialect(String sqlQuoteIdentifier, Casing casing) {
+    SqlDialect(String sqlQuoteIdentifier, Casing casing, boolean supportBulkInsert) {
         this.sqlQuoteIdentifier = sqlQuoteIdentifier;
         this.unquotedCasing = casing;
+        this.supportBulkInsert = supportBulkInsert;
+    }
+
+    SqlDialect(String sqlQuoteIdentifier, boolean supportBulkInsert) {
+        this(sqlQuoteIdentifier, DEFAULT_CASING, supportBulkInsert);
+    }
+
+    SqlDialect(String sqlQuoteIdentifier, Casing casing) {
+        this(sqlQuoteIdentifier, casing, false);
     }
 
     SqlDialect(String sqlQuoteIdentifier) {
-        this(sqlQuoteIdentifier, Casing.TO_UPPER);
+        this(sqlQuoteIdentifier, DEFAULT_CASING);
     }
 
     public String getSqlQuoteIdentifier() {

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -3,7 +3,7 @@ package net.datafaker.transformations;
 import java.util.List;
 
 public interface Transformer<IN, OUT> {
-    OUT apply(IN input, Schema<IN, ?> schema);
+    OUT apply(IN input, Schema<IN, ?> schema, int rowId);
     OUT generate(List<IN> input, final Schema<IN, ?> schema);
     OUT generate(final Schema<IN, ?> schema, int limit);
 }


### PR DESCRIPTION
The PR adds support for batch insert, e.g.
```java
Faker faker = new Faker();
Schema<String, String> schema =
    Schema.of(field("firstName", () -> faker.name().firstName()),
        field("lastName", () -> faker.name().lastName()));
SqlTransformer<String> transformer =
    new SqlTransformer.SqlTransformerBuilder<String>()
        .batch(true).dialect(SqlDialect.POSTGRES).build();
final int limit = 5;
String output = transformer.generate(schema, limit);
System.out.println(output);
```
will result in something like
```sql
INSERT INTO "MyTable" ("firstName", "lastName")
VALUES ('Lyman', 'Kessler'),
       ('Loriann', 'Lowe'),
       ('Gaynell', 'Blick'),
       ('Kallie', 'Kohler'),
       ('Rosalee', 'Armstrong');
```

Also keyword case support e.g.
```java
Faker faker = new Faker();
Schema<String, String> schema =
    Schema.of(field("firstName", () -> faker.name().firstName()),
        field("lastName", () -> faker.name().lastName()));
SqlTransformer<String> transformer =
    new SqlTransformer.SqlTransformerBuilder<String>()
        .keywordUpperCase(false)
        .dialect(SqlDialect.POSTGRES).build();
System.out.println(transformer.generate(schema, 1));
```
will print sql with keywords in **lowercase**
```sql
insert into "MyTable" ("firstName", "lastName") values ('Mohammad', 'White');
```