### PR TITLE
Add support for batch insert for Oracle

### DIFF
--- a/src/main/java/net/datafaker/transformations/TriFunction.java
+++ b/src/main/java/net/datafaker/transformations/TriFunction.java
@@ -1,0 +1,7 @@
+package net.datafaker.transformations;
+
+@FunctionalInterface
+public interface TriFunction<A, B, C, R> {
+
+    R apply(A a, B b, C c);
+}


### PR DESCRIPTION
As usual one dialect could break everything...
e.g. batch insert for postgres looks like
```sql
INSERT INTO "MyTable" ("firstName", "lastName")
VALUES ('Candi', 'Kling'),
       ('Piedad', 'Fisher'),
       ('Antony', 'Brown'),
       ('Rick', 'Lueilwitz'),
       ('Tillie', 'Murazik');
```

while batch insert for Oracle looks like

```sql
INSERT ALL
    INTO "MyTable" ("firstName", "lastName") VALUES ('Lanny', 'Roob'),
    INTO "MyTable" ("firstName", "lastName") VALUES ('Vera', 'Carroll'),
    INTO "MyTable" ("firstName", "lastName") VALUES ('Rolf', 'Boyle'),
    INTO "MyTable" ("firstName", "lastName") VALUES ('Tonja', 'Bednar'),
    INTO "MyTable" ("firstName", "lastName") VALUES ('Wyatt', 'Predovic')
SELECT 1 FROM dual;
```

This PR adds this kind of support