### PR TITLE
[bug-fix] generate separated SQL statements

### DIFF
--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -17,11 +17,8 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
   }
 
   @Override
-  public CharSequence apply(IN input, Schema<IN, ?> schema, int rowId) {
+  public CharSequence apply(IN input, Schema<IN, ?> schema) {
     Field<IN, ?>[] fields = schema.getFields();
-    if (fields.length == 0) {
-      return "";
-    }
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < fields.length; i++) {
       //noinspection unchecked
@@ -41,7 +38,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     for (int i = 0; i < input.size(); i++) {
       sb.append(apply(input.get(i), schema, i));
       if (i < input.size() - 1) {
-        sb.append(System.lineSeparator());
+        sb.append(LINE_SEPARATOR);
       }
     }
     return sb.toString();
@@ -74,7 +71,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
           sb.append(separator);
         }
       }
-      sb.append(System.lineSeparator());
+      sb.append(LINE_SEPARATOR);
     }
   }
 
@@ -85,7 +82,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     for (int i = 0; i < limit; i++) {
       sb.append(apply(null, schema, i));
       if (i < limit - 1) {
-        sb.append(System.lineSeparator());
+        sb.append(LINE_SEPARATOR);
       }
     }
     return sb.toString();

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -13,7 +13,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
   private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
 
   @Override
-  public String apply(IN input, Schema<IN, ? extends Object> schema, int rowId) {
+  public String apply(IN input, Schema<IN, ?> schema) {
     Field<?, ?>[] fields = schema.getFields();
     if (fields.length == 0) {
       return "{}";

--- a/src/main/java/net/datafaker/transformations/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/SqlTransformer.java
@@ -181,7 +181,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    public String generateBatchModeStatements(Schema<IN, ?> schema, int limit) {
+    private String generateBatchModeStatements(Schema<IN, ?> schema, int limit) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < limit; i++) {
             sb.append(apply(null, schema, i));
@@ -193,7 +193,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
-    public String generateSeparatedStatements(Schema<IN, ?> schema, int limit) {
+    private String generateSeparatedStatements(Schema<IN, ?> schema, int limit) {
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
         int limitMin = Math.min(schema.getFields().length, limit);
         for (int i = 0; i < limitMin; i++) {

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -3,7 +3,16 @@ package net.datafaker.transformations;
 import java.util.List;
 
 public interface Transformer<IN, OUT> {
-    OUT apply(IN input, Schema<IN, ?> schema, int rowId);
+    String LINE_SEPARATOR = System.lineSeparator();
+
+    OUT apply(IN input, Schema<IN, ?> schema);
+
+    default OUT apply(IN input, Schema<IN, ?> schema, int rowId) {
+        // ignore rowId by default
+        return apply(input, schema);
+    }
+
     OUT generate(List<IN> input, final Schema<IN, ?> schema);
+
     OUT generate(final Schema<IN, ?> schema, int limit);
 }


### PR DESCRIPTION
## Fix the bug with generation of separated SQL statements.
For example, such code:
```java
BaseFaker faker = new BaseFaker(new Random(10L));
        Schema<Object, ?> schema = Schema.of(
            field("Text", () -> faker.name().firstName()),
            field("Bool", () -> faker.bool().bool())
        );

        SqlTransformer<Object> transformer = new SqlTransformer.SqlTransformerBuilder<>().build();
        String sql = transformer.generate(schema, 2);
```
Computes such a result:
`INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Willis', false)INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Carlena', true);`

But I'm expecting to get:
`INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Willis', false);`
`INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Carlena', true);`


Also, added some little improvement in API of Transformer interface