### PR TITLE
Add support for force usage of sql quote identifiers

### DIFF
--- a/src/main/java/net/datafaker/transformations/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/SqlTransformer.java
@@ -21,10 +21,11 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
 
     private final boolean withBatchMode;
     private final boolean keywordUpperCase;
+    private final boolean forceSqlQuoteIdentifierUsage;
 
     private final SqlDialect dialect;
 
-    private SqlTransformer(String schemaName, String tableName, char quote, SqlDialect dialect, String sqlIdentifier, Casing casing, boolean withBatchMode, boolean keywordUpperCase) {
+    private SqlTransformer(String schemaName, String tableName, char quote, SqlDialect dialect, String sqlIdentifier, Casing casing, boolean withBatchMode, boolean keywordUpperCase, boolean forceSqlQuoteIdentifierUsage) {
         this.schemaName = schemaName;
         this.quote = quote;
         this.dialect = dialect;
@@ -34,9 +35,11 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         this.casing = casing;
         this.withBatchMode = withBatchMode;
         this.keywordUpperCase = keywordUpperCase;
+        this.forceSqlQuoteIdentifierUsage = forceSqlQuoteIdentifierUsage;
     }
 
     private boolean isSqlQuoteIdentifierRequiredFor(String name) {
+        if (forceSqlQuoteIdentifierUsage) return true;
         for (int i = 0; i < name.length(); i++) {
             if (casing == Casing.TO_UPPER && Character.isLowerCase(name.charAt(i))
                 || casing == Casing.TO_LOWER && Character.isUpperCase(name.charAt(i))
@@ -211,6 +214,8 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         private Casing casing = Casing.TO_UPPER;
         private boolean withBatchMode = false;
         private boolean keywordUpperCase = true;
+        private boolean forceSqlQuoteIdentifierUsage = false;
+
 
         private SqlDialect dialect;
 
@@ -246,24 +251,29 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
             return this;
         }
 
-        public SqlTransformerBuilder<IN> batch(boolean withBatchMode) {
-            this.withBatchMode = withBatchMode;
+        public SqlTransformerBuilder<IN> batch() {
+            this.withBatchMode = true;
             return this;
         }
 
-        public SqlTransformerBuilder<IN> keywordUpperCase(boolean keywordUpperCase) {
-            this.keywordUpperCase = keywordUpperCase;
+        public SqlTransformerBuilder<IN> keywordLowerCase() {
+            this.keywordUpperCase = false;
+            return this;
+        }
+
+        public SqlTransformerBuilder<IN> forceUseSqlQuoteIdentifier() {
+            this.forceSqlQuoteIdentifierUsage = true;
             return this;
         }
 
         public SqlTransformer<IN> build() {
             if (dialect == null) {
                 return new SqlTransformer<>(
-                    schemaName, tableName, quote, dialect, sqlQuoteIdentifier, casing, withBatchMode, keywordUpperCase);
+                    schemaName, tableName, quote, dialect, sqlQuoteIdentifier, casing, withBatchMode, keywordUpperCase, forceSqlQuoteIdentifierUsage);
             }
             return new SqlTransformer<>(
                 schemaName, tableName, quote, dialect, dialect.getSqlQuoteIdentifier(), dialect.getUnquotedCasing(),
-                withBatchMode, keywordUpperCase);
+                withBatchMode, keywordUpperCase, forceSqlQuoteIdentifierUsage);
         }
     }
 }

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -46,12 +46,33 @@ class SqlTest {
         );
 
         SqlTransformer<Object> transformer = new SqlTransformer.SqlTransformerBuilder<>()
-            .batch(true)
+            .batch()
             .build();
         String sql = transformer.generate(schema, 2);
 
         String expected =
             "INSERT INTO \"MyTable\" (\"Text\", \"Bool\")\n" +
+            "VALUES ('Willis', false),\n" +
+            "       ('Carlena', true);";
+
+        assertThat(sql).isEqualTo(expected);
+    }
+
+    @Test
+    void testForceQuotedWithSqlIdentifiers() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        Schema<Object, ?> schema = Schema.of(
+            field("TEXT", () -> faker.name().firstName()),
+            field("BOOL", () -> faker.bool().bool()));
+
+        SqlTransformer<Object> forceQuotedTransformer = new SqlTransformer.SqlTransformerBuilder<>()
+            .tableName("MY_TABLE")
+            .forceUseSqlQuoteIdentifier()
+            .batch()
+            .build();
+        String sql = forceQuotedTransformer.generate(schema, 2);
+
+        String expected = "INSERT INTO \"MY_TABLE\" (\"TEXT\", \"BOOL\")\n" +
             "VALUES ('Willis', false),\n" +
             "       ('Carlena', true);";
 
@@ -171,7 +192,9 @@ class SqlTest {
                 field("lastName", () -> faker.name().lastName()));
         SqlTransformer<String> transformer =
             new SqlTransformer.SqlTransformerBuilder<String>()
-                .batch(true).dialect(SqlDialect.POSTGRES).build();
+            .batch()
+            .dialect(SqlDialect.POSTGRES)
+            .build();
         final int limit = 5;
         String output = transformer.generate(schema, limit);
         assertThat(output.split("\\n")).hasSize(limit + 1);
@@ -185,7 +208,7 @@ class SqlTest {
                 field("lastName", () -> faker.name().lastName()));
         SqlTransformer<String> transformer =
             new SqlTransformer.SqlTransformerBuilder<String>()
-                .keywordUpperCase(false)
+            .keywordLowerCase()
                 .dialect(SqlDialect.POSTGRES).build();
         final int limit = 1;
         assertThat(transformer.generate(schema, limit))
@@ -203,8 +226,7 @@ class SqlTest {
                 field("lastName", () -> faker.name().lastName()));
         SqlTransformer<String> transformerUpper =
             new SqlTransformer.SqlTransformerBuilder<String>()
-                .batch(true)
-                .keywordUpperCase(true)
+            .batch()
                 .dialect(SqlDialect.ORACLE).build();
         final int limit = 5;
         String output = transformerUpper.generate(schema, limit);
@@ -216,8 +238,8 @@ class SqlTest {
             .contains("SELECT 1 FROM dual;");
         SqlTransformer<String> transformerLower =
             new SqlTransformer.SqlTransformerBuilder<String>()
-                .batch(true)
-                .keywordUpperCase(false)
+            .batch()
+            .keywordLowerCase()
                 .dialect(SqlDialect.ORACLE).build();
         output = transformerLower.generate(schema, limit);
         assertThat(output.split("\\n")).hasSize(limit + 2);


### PR DESCRIPTION
The usecase is that sometimes column name could be a reserved word and we don't have a chance to know about it without including lots of db specific implementation into this repo e.g. column names like `sum`, `avg`, `abs` and so on