### PR TITLE
SQL arrays and multisets could be nested

### DIFF
--- a/src/main/java/net/datafaker/transformations/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/SqlTransformer.java
@@ -170,20 +170,37 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         if (value == null) {
             result.append(NULL.getValue(keywordCase));
         } else {
-            boolean quoteRequired = !(value instanceof Number) && !(value instanceof Boolean);
-            if (quoteRequired) {
-                result.append(quote);
-            }
-
-            String strValue = value.toString();
-            for (int k = 0; k < strValue.length(); k++) {
-                if (strValue.charAt(k) == quote) {
+            if (value.getClass().isArray()) {
+                result.append(ARRAY.getValue(keywordCase)).append("[");
+                final Class<?> componentType = value.getClass().getComponentType();
+                result.append(componentType.isPrimitive()
+                    ? handlePrimitivesInArray(componentType, value)
+                    : handleObjectInArray(value));
+                result.append("]");
+            } else if (value instanceof List) {
+                result.append(ARRAY.getValue(keywordCase)).append("[");
+                result.append(handleObjectInCollection(value));
+                result.append("]");
+            } else if (value instanceof Set) {
+                result.append(MULTISET.getValue(keywordCase)).append("[");
+                result.append(handleObjectInCollection(value));
+                result.append("]");
+            } else {
+                boolean quoteRequired = !(value instanceof Number) && !(value instanceof Boolean);
+                if (quoteRequired) {
                     result.append(quote);
                 }
-                result.append(strValue.charAt(k));
-            }
-            if (quoteRequired) {
-                result.append(quote);
+
+                String strValue = value.toString();
+                for (int k = 0; k < strValue.length(); k++) {
+                    if (strValue.charAt(k) == quote) {
+                        result.append(quote);
+                    }
+                    result.append(strValue.charAt(k));
+                }
+                if (quoteRequired) {
+                    result.append(quote);
+                }
             }
         }
         return result.toString();

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -308,6 +308,17 @@ class SqlTest {
             of(Schema.of(field("names_list", () -> Arrays.asList("hello", "world"))),
                 "", "INSERT INTO \"MyTable\" (\"names_list\") VALUES (ARRAY['hello', 'world']);"),
             of(Schema.of(field("names_multiset", () -> Collections.singleton("hello"))),
-                "", "INSERT INTO \"MyTable\" (\"names_multiset\") VALUES (MULTISET['hello']);"));
+                "", "INSERT INTO \"MyTable\" (\"names_multiset\") VALUES (MULTISET['hello']);"),
+            of(Schema.of(field("ints_ints", () -> new int[][]{new int[]{1}, null, new int[] {3, 4, 5}})),
+                "", "INSERT INTO \"MyTable\" (\"ints_ints\") VALUES (ARRAY[ARRAY[1], NULL, ARRAY[3, 4, 5]]);"),
+            of(Schema.of(field("ints_ints", () -> new int[][]{new int[]{1}, new int[]{2}, new int[] {3, 4, 5}})),
+                "", "INSERT INTO \"MyTable\" (\"ints_ints\") VALUES (ARRAY[ARRAY[1], ARRAY[2], ARRAY[3, 4, 5]]);"),
+            of(Schema.of(field("multiset", () -> Collections.singleton(Collections.singleton(Collections.singleton("value"))))),
+                "", "INSERT INTO \"MyTable\" (\"multiset\") VALUES (MULTISET[MULTISET[MULTISET['value']]]);"),
+            of(Schema.of(field("multiset_array", () -> Collections.singleton(new int[]{1, 2}))),
+                "", "INSERT INTO \"MyTable\" (\"multiset_array\") VALUES (MULTISET[ARRAY[1, 2]]);"),
+            of(Schema.of(field("array_multiset", () -> Collections.singletonList(Collections.singleton("value")))),
+                "", "INSERT INTO \"MyTable\" (\"array_multiset\") VALUES (ARRAY[MULTISET['value']]);")
+        );
     }
 }


### PR DESCRIPTION
Yes these things could be nested
e.g. this Schema
```java
Schema.of(field("ints_ints", () -> new int[][]{new int[]{1}, null, new int[] {3, 4, 5}}))
```
allows to generate something like that
```sql
INSERT INTO "MyTable" ("ints_ints") VALUES (ARRAY[ARRAY[1], NULL, ARRAY[3, 4, 5]]);
```

and this one
```java
Schema.of(field("array_multiset", () -> Collections.singletonList(Collections.singleton("value"))))
```
could help with generation of mix
```sql
INSERT INTO "MyTable" ("array_multiset") VALUES (ARRAY[MULTISET['value']]);
```