### PR TITLE
Use sql quote identifier if schema or table or field name contain catalog separator

### DIFF
--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -57,7 +57,8 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
             if (casing == Casing.TO_UPPER && Character.isLowerCase(name.charAt(i))
                 || casing == Casing.TO_LOWER && Character.isUpperCase(name.charAt(i))
                 || name.charAt(i) == openSqlIdentifier
-                || name.charAt(i) == closeSqlIdentifier) {
+                || name.charAt(i) == closeSqlIdentifier
+                || name.charAt(i) == DEFAULT_CATALOG_SEPARATOR) {
                 return true;
             }
         }

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -99,6 +99,7 @@ class SqlTest {
             of(Schema.of(field("number", () -> 123.123)), null, "INSERT INTO MY_TABLE (`number`) VALUES (123.123);"),
             of(Schema.of(field("boolean", () -> true)), "", "INSERT INTO MY_TABLE (`boolean`) VALUES (true);"),
             of(Schema.of(field("nullValue", () -> null)), null, "INSERT INTO MY_TABLE (`nullValue`) VALUES (null);"),
+            of(Schema.of(field("nullValue", () -> null)), "My.SCHEMA", "INSERT INTO `My.SCHEMA`.MY_TABLE (`nullValue`) VALUES (null);"),
             of(Schema.of(field("nullValue", () -> null)), "MY_SCHEMA", "INSERT INTO MY_SCHEMA.MY_TABLE (`nullValue`) VALUES (null);"));
     }
 


### PR DESCRIPTION
There could be a weird environment when a table or schema or field name contain a catalog separator...
In this case sql quoting should be used