### PR TITLE
Generate from FakeSequence instead of List + bug fix in sql generator

### DIFF
--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -1,6 +1,8 @@
 package net.datafaker.transformations;
 
-import java.util.List;
+import net.datafaker.sequence.FakeSequence;
+
+import java.util.StringJoiner;
 
 public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
   private static final String DEFAULT_SEPARATOR = ";";
@@ -32,15 +34,20 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
   }
 
   @Override
-  public String generate(List<IN> input, Schema<IN, ?> schema) {
+  public String generate(FakeSequence<IN> input, Schema<IN, ?> schema) {
+    if (input.isInfinite()) {
+      throw new IllegalArgumentException("The sequence should be finite of size");
+    }
+
     StringBuilder sb = new StringBuilder();
     generateHeader(schema, sb);
-    for (int i = 0; i < input.size(); i++) {
-      sb.append(apply(input.get(i), schema, i));
-      if (i < input.size() - 1) {
-        sb.append(LINE_SEPARATOR);
-      }
+
+    StringJoiner data = new StringJoiner(LINE_SEPARATOR);
+    for (IN in : input) {
+      data.add(apply(in, schema));
     }
+
+    sb.append(data);
     return sb.toString();
   }
 

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -1,6 +1,6 @@
 package net.datafaker.transformations;
 
-import java.util.List;
+import net.datafaker.sequence.FakeSequence;
 
 public interface Transformer<IN, OUT> {
     String LINE_SEPARATOR = System.lineSeparator();
@@ -12,7 +12,7 @@ public interface Transformer<IN, OUT> {
         return apply(input, schema);
     }
 
-    OUT generate(List<IN> input, final Schema<IN, ?> schema);
+    OUT generate(FakeSequence<IN> input, final Schema<IN, ?> schema);
 
     OUT generate(final Schema<IN, ?> schema, int limit);
 }

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -1,5 +1,7 @@
 package net.datafaker.transformations.sql;
 
+import net.datafaker.sequence.FakeSequence;
+import net.datafaker.sequence.FakeStream;
 import net.datafaker.transformations.CompositeField;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.Schema;
@@ -9,6 +11,8 @@ import net.datafaker.transformations.Transformer;
 import java.util.Collection;
 import java.util.List;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.ARRAY;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.INSERT_INTO;
@@ -21,6 +25,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     private static final char DEFAULT_QUOTE = '\'';
     private static final char DEFAULT_CATALOG_SEPARATOR = '.';
     private static final String DEFAULT_SQL_IDENTIFIER = "\"\"";
+    private static final String EMPTY_RESULT = "";
 
     private final Casing casing;
     private final char quote;
@@ -75,7 +80,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         //noinspection unchecked
         Field<?, ? extends CharSequence>[] fields = (Field<?, ? extends CharSequence>[]) schema.getFields();
         if (fields.length == 0) {
-            return "";
+            return EMPTY_RESULT;
         }
         StringBuilder sb = new StringBuilder();
         if (withBatchMode) {
@@ -291,33 +296,49 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     @Override
-    public String generate(List<IN> input, Schema<IN, ?> schema) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < input.size(); i++) {
-            sb.append(apply(input.get(i), schema, i));
-            if (i == input.size() - 1 && sb.length() > 0 || i % (batchSize - 1) == 0) {
-                if (withBatchMode) {
-                    sb.append(SqlDialect.getLastRowSuffix(dialect, keywordCase));
-                }
-                sb.append(";");
-            }
+    public String generate(FakeSequence<IN> input, Schema<IN, ?> schema) {
+        if (schema.getFields().length == 0){
+            return EMPTY_RESULT;
         }
-        return sb.toString();
+        if (input.isInfinite()) {
+            throw new IllegalArgumentException("The sequence should be finite of size");
+        }
+
+        List<IN> inputs;
+        if (input instanceof FakeStream) {
+            Stream<IN> stream = input.get();
+            inputs = stream.collect(Collectors.toList());
+        } else {
+            inputs = input.get();
+        }
+
+        int limit = inputs.size();
+        if (withBatchMode) {
+            return generateBatchModeStatements(schema, inputs, limit);
+        } else {
+            return generateSeparatedStatements(schema, inputs, limit);
+        }
     }
 
     @Override
     public String generate(Schema<IN, ?> schema, int limit) {
+        if (schema.getFields().length == 0){
+            return EMPTY_RESULT;
+        }
+
         if (withBatchMode) {
-            return generateBatchModeStatements(schema, limit);
+            return generateBatchModeStatements(schema, null, limit);
         } else {
-            return generateSeparatedStatements(schema, limit);
+            return generateSeparatedStatements(schema, null, limit);
         }
     }
 
-    private String generateBatchModeStatements(Schema<IN, ?> schema, int limit) {
+    private String generateBatchModeStatements(Schema<IN, ?> schema, List<IN> inputs, int limit) {
         StringBuilder sb = new StringBuilder();
+        limit = inputs != null ? Math.min(limit, inputs.size()) : limit;
         for (int i = 0; i < limit; i++) {
-            sb.append(apply(null, schema, i));
+            IN input = inputs != null ? inputs.get(i) : null;
+            sb.append(apply(input, schema, i));
             if (i == limit - 1 && sb.length() > 0 || batchSize > 0 && (i + 1) % batchSize == 0) {
                 sb.append(SqlDialect.getLastRowSuffix(dialect, keywordCase));
                 sb.append(";");
@@ -329,13 +350,13 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
-    private String generateSeparatedStatements(Schema<IN, ?> schema, int limit) {
+    private String generateSeparatedStatements(Schema<IN, ?> schema, List<IN> inputs, int limit) {
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
-        int limitMin = Math.min(schema.getFields().length, limit);
-        for (int i = 0; i < limitMin; i++) {
-            data.add(apply(null, schema) + ";");
+        limit = inputs != null ? Math.min(limit, inputs.size()) : limit;
+        for (int i = 0; i < limit; i++) {
+            IN input = inputs != null ? inputs.get(i) : null;
+            data.add(apply(input, schema) + ";");
         }
-
         return data.toString();
     }
 

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -89,7 +89,8 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                     SqlDialect.getFirstRow(
                         dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase));
             } else {
-                sb.append(",").append(LINE_SEPARATOR)
+                sb.append(",")
+                    .append(LINE_SEPARATOR)
                     .append(
                         SqlDialect.getOtherRow(
                             dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase));

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Random;
 
 import static net.datafaker.transformations.Field.field;
+import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -38,7 +39,7 @@ class CsvTest extends AbstractFakerTest {
         int numberOfLines = 0;
         int numberOfSeparator = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             } else if (csv.regionMatches(i, separator, 0, separator.length())) {
                 numberOfSeparator++;
@@ -67,7 +68,7 @@ class CsvTest extends AbstractFakerTest {
         int numberOfLines = 0;
         int numberOfSeparator = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             } else if (csv.regionMatches(i, separator, 0, separator.length())) {
                 numberOfSeparator++;
@@ -98,7 +99,7 @@ class CsvTest extends AbstractFakerTest {
         int numberOfLines = 0;
         int numberOfSeparator = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             } else if (csv.regionMatches(i, separator, 0, separator.length())) {
                 numberOfSeparator++;
@@ -126,7 +127,7 @@ class CsvTest extends AbstractFakerTest {
         int numberOfLines = 0;
         int numberOfSeparator = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             } else if (csv.regionMatches(i, separator, 0, separator.length())) {
                 numberOfSeparator++;
@@ -152,10 +153,8 @@ class CsvTest extends AbstractFakerTest {
                 .get();
 
         String expected =
-            "\"values\",\"title\""
-                + System.lineSeparator()
-                + "\"1,2,3\",\"The \"\"fabulous\"\" artist\""
-                + System.lineSeparator();
+            "\"values\",\"title\"" + LINE_SEPARATOR +
+                "\"1,2,3\",\"The \"\"fabulous\"\" artist\"" + LINE_SEPARATOR;
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -170,8 +169,7 @@ class CsvTest extends AbstractFakerTest {
         String csv = transformer.generate(schema, 1);
 
         String expected =
-            "\"values\",\"title\""
-                + System.lineSeparator()
+            "\"values\",\"title\"" + LINE_SEPARATOR
                 + "\"1,2,3\",\"The \"\"fabulous\"\" artist\"";
 
         assertThat(csv).isEqualTo(expected);
@@ -192,14 +190,10 @@ class CsvTest extends AbstractFakerTest {
         String csv = transformer.generate(schema, 4);
 
         String expected =
-            "\"Number\",\"Bool\",\"String\",\"Text\""
-                + System.lineSeparator()
-                + "3,false,\"Flor\",\"The, \"\"fabulous\"\" artist'\""
-                + System.lineSeparator()
-                + "6,true,\"Stephnie\",\"The, \"\"fabulous\"\" artist'\""
-                + System.lineSeparator()
-                + "1,false,\"Edythe\",\"The, \"\"fabulous\"\" artist'\""
-                + System.lineSeparator()
+            "\"Number\",\"Bool\",\"String\",\"Text\"" + LINE_SEPARATOR
+                + "3,false,\"Flor\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
+                + "6,true,\"Stephnie\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
+                + "1,false,\"Edythe\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
                 + "1,true,\"Dwight\",\"The, \"\"fabulous\"\" artist'\"";
 
         assertThat(csv).isEqualTo(expected);
@@ -222,16 +216,11 @@ class CsvTest extends AbstractFakerTest {
         String csv = transformer.generate(fakeSequence, schema);
 
         String expected =
-            "\"Number\",\"Password\""
-                + System.lineSeparator()
-                + "3,\"l63\""
-                + System.lineSeparator()
-                + "6,\"z5s88e\""
-                + System.lineSeparator()
-                + "7,\"0b92c81\""
-                + System.lineSeparator()
-                + "1,\"5\""
-                + System.lineSeparator()
+            "\"Number\",\"Password\"" + LINE_SEPARATOR
+                + "3,\"l63\"" + LINE_SEPARATOR
+                + "6,\"z5s88e\"" + LINE_SEPARATOR
+                + "7,\"0b92c81\"" + LINE_SEPARATOR
+                + "1,\"5\"" + LINE_SEPARATOR
                 + "3,\"zy2\"";
 
         assertThat(csv).isEqualTo(expected);
@@ -254,13 +243,10 @@ class CsvTest extends AbstractFakerTest {
         String csv = transformer.generate(fakeSequence, schema);
 
         String expected =
-                "\"Number\",\"Password\""
-                        + System.lineSeparator()
-                        + "3,\"f13\""
-                        + System.lineSeparator()
-                        + "1,\"5\""
-                        + System.lineSeparator()
-                        + "6,\"3z5s88\"";
+            "\"Number\",\"Password\"" + LINE_SEPARATOR
+                + "3,\"f13\"" + LINE_SEPARATOR
+                + "1,\"5\"" + LINE_SEPARATOR
+                + "6,\"3z5s88\"";
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -300,7 +286,7 @@ class CsvTest extends AbstractFakerTest {
 
         int numberOfLines = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             }
         }
@@ -324,7 +310,7 @@ class CsvTest extends AbstractFakerTest {
 
         int numberOfLines = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             }
         }
@@ -348,7 +334,7 @@ class CsvTest extends AbstractFakerTest {
 
         int numberOfLines = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             }
         }
@@ -372,7 +358,7 @@ class CsvTest extends AbstractFakerTest {
 
         int numberOfLines = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             }
         }
@@ -418,7 +404,7 @@ class CsvTest extends AbstractFakerTest {
 
         int numberOfLines = 0;
         for (int i = 0; i < csv.length(); i++) {
-            if (csv.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+            if (csv.regionMatches(i, LINE_SEPARATOR, 0, LINE_SEPARATOR.length())) {
                 numberOfLines++;
             }
         }

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
+import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
@@ -32,12 +33,9 @@ class JsonTest {
         JsonTransformer<Object> transformer = new JsonTransformer<>();
         String json = transformer.generate(schema, 2);
 
-        String expected = "{" +
-            System.lineSeparator() +
-            "{\"Text\": \"Willis\", \"Bool\": false}," +
-            System.lineSeparator() +
-            "{\"Text\": \"Carlena\", \"Bool\": true}" +
-            System.lineSeparator() +
+        String expected = "{" + LINE_SEPARATOR +
+            "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
+            "{\"Text\": \"Carlena\", \"Bool\": true}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);
@@ -59,18 +57,12 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "{" +
-            System.lineSeparator() +
-            "{\"Number\": 3, \"Password\": \"l63\"}" +
-            System.lineSeparator() +
-            "{\"Number\": 6, \"Password\": \"z5s88e\"}" +
-            System.lineSeparator() +
-            "{\"Number\": 7, \"Password\": \"0b92c81\"}" +
-            System.lineSeparator() +
-            "{\"Number\": 1, \"Password\": \"5\"}" +
-            System.lineSeparator() +
-            "{\"Number\": 3, \"Password\": \"zy2\"}" +
-            System.lineSeparator() +
+        String expected = "{" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"l63\"}" + LINE_SEPARATOR +
+            "{\"Number\": 6, \"Password\": \"z5s88e\"}" + LINE_SEPARATOR +
+            "{\"Number\": 7, \"Password\": \"0b92c81\"}" + LINE_SEPARATOR +
+            "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"zy2\"}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);
@@ -92,12 +84,9 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "{" +
-            System.lineSeparator() +
-            "{\"Number\": 3, \"Password\": \"f13\"}" +
-            System.lineSeparator() +
-            "{\"Number\": 1, \"Password\": \"5\"}" +
-            System.lineSeparator() +
+        String expected = "{" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"f13\"}" + LINE_SEPARATOR +
+            "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -1,27 +1,125 @@
 package net.datafaker.formats;
 
+import net.datafaker.providers.base.BaseFaker;
+import net.datafaker.sequence.FakeSequence;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
 import net.datafaker.transformations.Schema;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
-import java.util.AbstractMap;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 class JsonTest {
+    @Test
+    void testGenerateFromSchemaWithLimit() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        Schema<Object, ?> schema = Schema.of(
+            field("Text", () -> faker.name().firstName()),
+            field("Bool", () -> faker.bool().bool())
+        );
+
+        JsonTransformer<Object> transformer = new JsonTransformer<>();
+        String json = transformer.generate(schema, 2);
+
+        String expected = "{" +
+            System.lineSeparator() +
+            "{\"Text\": \"Willis\", \"Bool\": false}," +
+            System.lineSeparator() +
+            "{\"Text\": \"Carlena\", \"Bool\": true}" +
+            System.lineSeparator() +
+            "}";
+
+        assertThat(json).isEqualTo(expected);
+    }
+
+    @Test
+    void testGenerateFromFakeSequenceCollection() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        Schema<Integer, ?> schema = Schema.of(
+            field("Number", integer -> integer),
+            field("Password", integer -> faker.internet().password(integer, integer))
+        );
+
+        JsonTransformer<Integer> transformer = new JsonTransformer<>();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>collection()
+            .suppliers(() -> faker.number().randomDigit())
+            .len(5)
+            .build();
+
+        String json = transformer.generate(fakeSequence, schema);
+
+        String expected = "{" +
+            System.lineSeparator() +
+            "{\"Number\": 3, \"Password\": \"l63\"}" +
+            System.lineSeparator() +
+            "{\"Number\": 6, \"Password\": \"z5s88e\"}" +
+            System.lineSeparator() +
+            "{\"Number\": 7, \"Password\": \"0b92c81\"}" +
+            System.lineSeparator() +
+            "{\"Number\": 1, \"Password\": \"5\"}" +
+            System.lineSeparator() +
+            "{\"Number\": 3, \"Password\": \"zy2\"}" +
+            System.lineSeparator() +
+            "}";
+
+        assertThat(json).isEqualTo(expected);
+    }
+
+	@Test
+    void testGenerateFromFakeSequenceStream() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        Schema<Integer, ?> schema = Schema.of(
+            field("Number", integer -> integer),
+            field("Password", integer -> faker.internet().password(integer, integer))
+        );
+
+        JsonTransformer<Integer> transformer = new JsonTransformer<>();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
+            .suppliers(() -> faker.number().randomDigit())
+            .len(2)
+            .build();
+
+        String json = transformer.generate(fakeSequence, schema);
+
+        String expected = "{" +
+            System.lineSeparator() +
+            "{\"Number\": 3, \"Password\": \"f13\"}" +
+            System.lineSeparator() +
+            "{\"Number\": 1, \"Password\": \"5\"}" +
+            System.lineSeparator() +
+            "}";
+
+        assertThat(json).isEqualTo(expected);
+    }
+
+	@Test
+    void testGenerateFromInfiniteFakeSequence() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        Schema<Integer, ?> schema = Schema.of(
+            field("Number", integer -> integer),
+            field("Password", integer -> faker.internet().password(integer, integer))
+        );
+
+        JsonTransformer<Integer> transformer = new JsonTransformer<>();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
+            .suppliers(() -> faker.number().randomDigit())
+            .build();
+
+        assertThatThrownBy(() -> transformer.generate(fakeSequence, schema))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The sequence should be finite of size");
+    }
 
     @ParameterizedTest
     @MethodSource("generateTestSchema")

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -41,14 +41,10 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'l63');" +
-            System.lineSeparator() +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, 'z5s88e');" +
-            System.lineSeparator() +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, '0b92c81');" +
-            System.lineSeparator() +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (1, '5');" +
-            System.lineSeparator() +
+        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'l63');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, 'z5s88e');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, '0b92c81');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (1, '5');" + LINE_SEPARATOR +
             "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'zy2');";
 
         assertThat(sql).isEqualTo(expected);
@@ -72,17 +68,13 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" +
-            System.lineSeparator() +
-            "VALUES (3, 'l63')," +
-            System.lineSeparator() +
-            "       (6, 'z5s88e')," +
-            System.lineSeparator() +
-            "       (7, '0b92c81')," +
-            System.lineSeparator() +
-            "       (1, '5')," +
-            System.lineSeparator() +
-            "       (3, 'zy2');";
+        String expected =
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
+                "VALUES (3, 'l63')," + LINE_SEPARATOR +
+                "       (6, 'z5s88e')," + LINE_SEPARATOR +
+                "       (7, '0b92c81')," + LINE_SEPARATOR +
+                "       (1, '5')," + LINE_SEPARATOR +
+                "       (3, 'zy2');";
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -119,8 +111,7 @@ class SqlTest {
         String sql = transformer.generate(schema, 2);
 
         String expected =
-            "INSERT INTO \"MyTable\" (\"Text\", \"Bool\") VALUES ('Willis', false);" +
-            System.lineSeparator() +
+            "INSERT INTO \"MyTable\" (\"Text\", \"Bool\") VALUES ('Willis', false);" + LINE_SEPARATOR +
             "INSERT INTO \"MyTable\" (\"Text\", \"Bool\") VALUES ('Carlena', true);";
 
         assertThat(sql).isEqualTo(expected);


### PR DESCRIPTION
1. Changed `List<IN>` to `FakeSequence<IN>` in generate function of Transformer interface.
2. Fix bug in SQL Transformer:
Example:
```java
BaseFaker faker = new BaseFaker(new Random(10L));
Schema<Integer, ?> schema = Schema.of(
    field("Number", integer -> integer),
    field("Password", integer -> faker.internet().password(integer, integer))
);

SqlTransformer<Integer> transformer = new SqlTransformer.SqlTransformerBuilder<Integer>().build();
// inputs = List or FakeSequence of size 5

String sql = transformer.generate(inputs, schema);
```

Expected to get **5** (size of inputs) SQL statements, but actual result is **2** (length of schema fields).