### PR TITLE
Speed up digit generation by using random byte array

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Number.java
+++ b/src/main/java/net/datafaker/providers/base/Number.java
@@ -131,8 +131,9 @@ public class Number extends AbstractProvider<BaseProviders> {
 
     public String digits(int count) {
         final StringBuilder tmp = new StringBuilder(count);
-        for (int i = 0; i < count; i++) {
-            tmp.append(randomDigit());
+        byte[] input = faker.random().nextRandomBytes(count);
+        for (int i = 0; i < input.length; i++) {
+            tmp.append(Math.abs(input[i]) % 10);
         }
         return tmp.toString();
     }

--- a/src/main/java/net/datafaker/providers/base/Number.java
+++ b/src/main/java/net/datafaker/providers/base/Number.java
@@ -8,6 +8,7 @@ import java.math.RoundingMode;
  */
 public class Number extends AbstractProvider<BaseProviders> {
 
+    private static final char[] DIGITS = "0123456789".toCharArray();
     protected Number(BaseProviders faker) {
         super(faker);
     }
@@ -130,12 +131,12 @@ public class Number extends AbstractProvider<BaseProviders> {
     }
 
     public String digits(int count) {
-        final StringBuilder tmp = new StringBuilder(count);
+        final char[] tmp = new char[count];
         byte[] input = faker.random().nextRandomBytes(count);
         for (int i = 0; i < input.length; i++) {
-            tmp.append(Math.abs(input[i]) % 10);
+            tmp[i] = DIGITS[Math.abs(input[i]) % 10];
         }
-        return tmp.toString();
+        return new String(tmp);
     }
 
     public String digit() {


### PR DESCRIPTION
The idea is to use generation of random byte array to generate digits.
There is an assumption allowing it to work
number of different digits is less then size of byte range and it is ok (10 vs 256)

So this allows it to speed up for about 30-40% 
digitByDigit1 - current approach for 1 digit
digitByDigit10 - current approach for 10 digits
digitByDigit100 - current approach for 100 digits
and etc.
```
Benchmark            Mode  Cnt      Score      Error   Units
byteArrayBased1     thrpt   10  49607.067 ± 6887.798  ops/ms
byteArrayBased10    thrpt   10  15848.161 ± 1568.289  ops/ms
byteArrayBased100   thrpt   10   2170.854 ±   64.167  ops/ms
byteArrayBased1000  thrpt   10    226.260 ±    0.349  ops/ms
digitByDigit1       thrpt   10  32256.580 ±  536.872  ops/ms
digitByDigit10      thrpt   10  11202.666 ±  858.150  ops/ms
digitByDigit100     thrpt   10   1511.857 ±  253.636  ops/ms
digitByDigit1000    thrpt   10    185.054 ±    0.618  ops/ms
```