### PR TITLE
Speed up hex by using getRandomByteArray

### DIFF
--- a/src/main/java/net/datafaker/service/RandomService.java
+++ b/src/main/java/net/datafaker/service/RandomService.java
@@ -3,6 +3,7 @@ package net.datafaker.service;
 import java.util.Random;
 
 public class RandomService {
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
     private static final Random SHARED_RANDOM = new Random();
     private final Random random;
 
@@ -88,13 +89,9 @@ public class RandomService {
             return ""; // Keep the existing behavior instead of throwing an error.
         }
         final char[] hexChars = new char[length];
+        final byte[] randomBytes = nextRandomBytes(length);
         for (int i = 0; i < length; i++) {
-            final int nextHex = nextInt(16);
-            if (nextHex < 10) {
-                hexChars[i] = (char) ('0' + nextHex);
-            } else {
-                hexChars[i] = (char) ('A' + nextHex - 10);
-            }
+            hexChars[i] = HEX[Math.abs(randomBytes[i]) % HEX.length];
         }
         return new String(hexChars);
     }


### PR DESCRIPTION
The same approach as in https://github.com/datafaker-net/datafaker/pull/508
the same assumption
number of different digits is less then size of byte range and it is ok (16 vs 256)
So this allows it to speed up for about 30-40%
digitByDigit1 - current approach for 1 digit
digitByDigit10 - current approach for 10 digits
digitByDigit100 - current approach for 100 digits
and etc.

```
Benchmark            Mode  Cnt       Score       Error   Units
byteArrayBased1     thrpt   10  119909.324 ±   972.720  ops/ms
byteArrayBased10    thrpt   10   28427.346 ±  5152.356  ops/ms
byteArrayBased100   thrpt   10    4350.995 ±   276.395  ops/ms
byteArrayBased1000  thrpt   10     391.391 ±    55.684  ops/ms
digitByDigit1       thrpt   10   76420.584 ± 11843.538  ops/ms
digitByDigit10      thrpt   10   12479.871 ±   706.021  ops/ms
digitByDigit100     thrpt   10    1444.884 ±     9.320  ops/ms
digitByDigit1000    thrpt   10     143.684 ±     2.113  ops/ms
```