### PR TITLE
Support transformation schema for YAML

### DIFF
--- a/src/main/java/net/datafaker/formats/Yaml.java
+++ b/src/main/java/net/datafaker/formats/Yaml.java
@@ -3,6 +3,7 @@ package net.datafaker.formats;
 import java.util.*;
 import java.util.function.Supplier;
 
+@Deprecated
 public class Yaml {
     private static final String INDENTATION = "  ";
     private final Map<Supplier<String>, Supplier<Object>> map;

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -1,0 +1,100 @@
+package net.datafaker.transformations;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import net.datafaker.sequence.FakeSequence;
+
+public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
+
+    private static final String INDENTATION = "  ";
+
+    @Override
+    public CharSequence apply(IN input, Schema<IN, ?> schema) {
+        Field<IN, ?>[] fields = schema.getFields();
+
+        if (fields.length == 0) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        return apply(sb, input, fields, "");
+    }
+
+    @Override
+    public String generate(FakeSequence<IN> input, Schema<IN, ?> schema) {
+        if (input.isInfinite()) {
+            throw new IllegalArgumentException("The sequence should be finite of size");
+        }
+
+        StringJoiner data = new StringJoiner(LINE_SEPARATOR);
+        for (IN in : input) {
+            data.add(apply(in, schema));
+        }
+
+        return data.toString();
+    }
+
+    @Override
+    public String generate(Schema<IN, ?> schema, int limit) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < limit; i++) {
+            sb.append(apply(null, schema));
+            if (i < limit - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String apply(final StringBuilder sb, final IN input, final Field<IN, ?>[] fields, final String offset) {
+        Set<String> keys = new HashSet<>();
+        for (Field<IN, ?> field : fields) {
+            String key = field.getName().trim();
+            if (!keys.add(key)) continue;
+            Object value = field.transform(input);
+            sb.append(offset).append(key).append(":");
+            if (value instanceof Schema) {
+                sb.append(System.lineSeparator());
+                value2String(value, sb, offset + INDENTATION);
+            } else {
+                value2String(value, sb, offset);
+            }
+
+
+            if (sb.lastIndexOf(System.lineSeparator()) != sb.length() - System.lineSeparator().length()) {
+                sb.append(System.lineSeparator());
+            }
+
+        }
+        return sb.toString();
+    }
+
+    private void addCollection(StringBuilder sb, Collection<Object> collection, String offset) {
+        for (Object value : collection) {
+            value2String(value, sb, offset + "-");
+            sb.append(System.lineSeparator());
+        }
+    }
+    private void value2String(Object value, StringBuilder sb, String offset) {
+        if (value instanceof Schema) {
+            Field<IN, ?>[] fields = ((Schema<IN, ?>) value).getFields();
+            apply(sb, null, fields, offset);
+        } else if (value instanceof Collection) {
+            sb.append(System.lineSeparator());
+            offset += INDENTATION;
+            addCollection(sb, (Collection) value, offset);
+        } else if (value != null && value.getClass().isArray()) {
+            sb.append(System.lineSeparator());
+            offset += INDENTATION;
+            addCollection(sb, Arrays.asList((Object[]) value), offset);
+        } else {
+            if (sb.charAt(sb.length() - 1) != ':') {
+                sb.append(offset);
+            }
+            sb.append(" ").append(String.valueOf(value).trim());
+        }
+    }
+}

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -43,7 +43,7 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
         for (int i = 0; i < limit; i++) {
             sb.append(apply(null, schema));
             if (i < limit - 1) {
-                sb.append("\n");
+                sb.append(LINE_SEPARATOR);
             }
         }
         return sb.toString();

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -108,7 +108,6 @@ class YamlTest {
                 faker.<Name>collection().suppliers(faker::name).maxLen(1).build(),
                 schema);
 
-        System.out.println(yaml);
         int numberOfLines = 0;
         for (int i = 0; i < yaml.length(); i++) {
             if (yaml.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -13,8 +13,11 @@ import java.math.BigDecimal;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.field;
@@ -90,6 +93,30 @@ class YamlTest {
         }
 
         assertThat(numberOfLines).isEqualTo((limit * (schema.getFields().length + 1)) - 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 4, 8})
+    void generateFromFakeSequenceWithCollection(int limit) {
+        final BaseFaker faker = new BaseFaker();
+        Schema<Name, List<String>> schema = Schema.of(field("firstNames", name -> IntStream.rangeClosed(1, limit)
+            .mapToObj(it -> name.firstName()).collect(Collectors.toList())));
+
+        YamlTransformer<Name> transformer = new YamlTransformer<>();
+        String yaml =
+            transformer.generate(
+                faker.<Name>collection().suppliers(faker::name).maxLen(1).build(),
+                schema);
+
+        System.out.println(yaml);
+        int numberOfLines = 0;
+        for (int i = 0; i < yaml.length(); i++) {
+            if (yaml.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            }
+        }
+
+        assertThat(numberOfLines).isEqualTo(limit + 1);
     }
 
     @ParameterizedTest

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -1,8 +1,13 @@
 package net.datafaker.formats;
 
+import net.datafaker.providers.base.BaseFaker;
+import net.datafaker.providers.base.Name;
+import net.datafaker.transformations.Schema;
+import net.datafaker.transformations.YamlTransformer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.AbstractMap;
@@ -12,9 +17,81 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 class YamlTest {
+
+    @ParameterizedTest
+    @MethodSource("generateTestSchema")
+    void simpleYamlTest(Schema<String, String> schema, String expected) {
+        YamlTransformer<String> yamlTransformer = new YamlTransformer<>();
+        assertThat(yamlTransformer.generate(schema, 1)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateTestSchema() {
+        return Stream.of(
+            of(Schema.of(), ""),
+            of(Schema.of(field("key", () -> "value")), "key: value" + System.lineSeparator()),
+            of(Schema.of(field("number", () -> 123)), "number: 123" + System.lineSeparator()),
+            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.0))), "number: 123.0" + System.lineSeparator()),
+            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), "number: 123.123" + System.lineSeparator()),
+            of(Schema.of(field("boolean", () -> true)), "boolean: true" + System.lineSeparator()),
+            of(Schema.of(field("nullValue", () -> null)), "nullValue: null" + System.lineSeparator()),
+            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+                "array:" + System.lineSeparator()
+                    + "  - null" + System.lineSeparator()
+                    + "  - test" + System.lineSeparator()
+                    + "  - 123" + System.lineSeparator()),
+            of(Schema.of(field("array", () -> new Integer[]{123, 456, 789})),
+                "array:" + System.lineSeparator()
+                    + "  - 123" + System.lineSeparator()
+                    + "  - 456" + System.lineSeparator()
+                    + "  - 789" + System.lineSeparator()),
+            of(Schema.of(field("array", () -> new Object[]{"test", 456, true})),
+                "array:" + System.lineSeparator()
+                    + "  - test" + System.lineSeparator()
+                    + "  - 456" + System.lineSeparator()
+                    + "  - true" + System.lineSeparator()),
+            of(Schema.of(field("emptyarray", () -> new Long[]{})), "emptyarray:" + System.lineSeparator()),
+            of(Schema.of(field("emptyarray", Collections::emptyList)), "emptyarray:" + System.lineSeparator()),
+            of(Schema.of(field("key", () -> "value"),
+                    field("nested", () -> Schema.of(field("nestedkey", () -> "nestedvalue")))),
+                "key: value" + System.lineSeparator() + "nested:" + System.lineSeparator() + "  nestedkey: nestedvalue" + System.lineSeparator()),
+            of(Schema.of(field("key", () -> "value"),
+                    field("nested",
+                        () -> Schema.of(field("nestedkey", () -> "nestedvalue"),
+                            field("nested2", () -> Schema.of(field("nestedkey2", () -> "nestedvalue2")))))),
+                "key: value" + System.lineSeparator()
+                    + "nested:" + System.lineSeparator() + "  nestedkey: nestedvalue" + System.lineSeparator()
+                    + "  nested2:" + System.lineSeparator()
+                    + "    nestedkey2: nestedvalue2" + System.lineSeparator())
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 4, 8})
+    void generateFromFakeSequence(int limit) {
+        final BaseFaker faker = new BaseFaker();
+        Schema<Name, String> schema = Schema.of(field("firstName", Name::firstName));
+
+        YamlTransformer<Name> transformer = new YamlTransformer<>();
+        String yaml =
+            transformer.generate(
+                faker.<Name>collection().suppliers(faker::name).maxLen(limit).build(),
+                schema);
+
+        int numberOfLines = 0;
+        for (int i = 0; i < yaml.length(); i++) {
+            if (yaml.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            }
+        }
+
+        assertThat(numberOfLines).isEqualTo((limit * (schema.getFields().length + 1)) - 1);
+    }
+
     @ParameterizedTest
     @MethodSource("generateTestYaml")
     void simpleYamlTest(Map<Supplier<String>, Supplier<Object>> input, String expected) {


### PR DESCRIPTION
The PR introduces yaml transformer.
An example of usage

```
Faker faker = new Faker();
System.out.println(
    new YamlTransformer<Name>().generate(
        faker.collection(faker::name).len(1).build(),
        Schema.of(field("name", Name::fullName), field("username", Name::username))));
```

Result:
```
name: Mabelle Prohaska
username: clara.lemke
```