### PR TITLE
Add tests for uncovered method in Time provider

### DIFF
--- a/src/test/java/net/datafaker/providers/base/TimeTest.java
+++ b/src/test/java/net/datafaker/providers/base/TimeTest.java
@@ -84,6 +84,15 @@ public class TimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
+    void testBetweenWithMask() {
+        String pattern = "mm:hh:ss";
+        LocalTime now = LocalTime.now();
+        LocalTime then = now.plus(1, ChronoUnit.MINUTES);
+
+        DateTimeFormatter.ofPattern(pattern).parse(faker.time().between(now, then, pattern));
+    }
+
+    @Test
     void futureWithMask() {
         String pattern = "mm:hh:ss";
         DateTimeFormatter.ofPattern(pattern).parse(faker.time().future(1, ChronoUnit.HOURS, pattern));

--- a/src/test/java/net/datafaker/providers/base/TimeTest.java
+++ b/src/test/java/net/datafaker/providers/base/TimeTest.java
@@ -67,6 +67,14 @@ public class TimeTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
+    void testBetweenWithSameLocalTime() {
+        LocalTime now = LocalTime.now();
+
+        long time = faker.time().between(now, now);
+        assertThat(LocalTime.ofNanoOfDay(time)).isEqualTo(now);
+    }
+
+    @Test
     void testBetweenThenLargerThanNow() {
         LocalTime now = LocalTime.now();
         LocalTime then = now.plus(1, ChronoUnit.SECONDS);


### PR DESCRIPTION
Coverage of `Time` provider is 100% now