### PR TITLE
10x times speed up Code#isbnGroup and Code#isbnGs1 by usage of Options

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Code.java
+++ b/src/main/java/net/datafaker/providers/base/Code.java
@@ -35,7 +35,7 @@ public class Code extends AbstractProvider<BaseProviders> {
      * @return a GS1 code for an ISBN13, currently is only 978 and 979
      */
     public String isbnGs1() {
-        return faker.regexify("978|979");
+        return faker.options().option("978", "979");
     }
 
     /**
@@ -49,7 +49,7 @@ public class Code extends AbstractProvider<BaseProviders> {
      * @return an ISBN group number
      */
     public String isbnGroup() {
-        return faker.regexify("[0-1]");
+        return faker.options().option("0", "1");
     }
 
     /**


### PR DESCRIPTION
The PR speeds `Code#isbnGroup` and `Code#isbnGs1` by usage `Options` instead regexify
comparison
```
Benchmark                         Mode  Cnt      Score      Error   Units
DatafakerSimpleMethods.option    thrpt   10  50185.955 ± 5028.459  ops/ms
DatafakerSimpleMethods.regexify  thrpt   10   6889.025 ±  379.912  ops/ms
```