### PR TITLE
20x times speed up Aws and Azure by using hex

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Aws.java
+++ b/src/main/java/net/datafaker/providers/base/Aws.java
@@ -70,6 +70,6 @@ public class Aws extends AbstractProvider<BaseProviders> {
     }
 
     private String randHex() {
-        return faker.regexify("[a-f0-9]{16}");
+        return faker.random().hex(16, false);
     }
 }

--- a/src/main/java/net/datafaker/providers/base/Azure.java
+++ b/src/main/java/net/datafaker/providers/base/Azure.java
@@ -19,11 +19,11 @@ public class Azure extends AbstractProvider<BaseProviders> {
     }
 
     public String subscriptionId() {
-        return faker.regexify("[a-f0-9]{8}") + '-' +
-            faker.regexify("[a-f0-9]{4}") + '-' +
-            faker.regexify("[a-f0-9]{4}") + '-' +
-            faker.regexify("[a-f0-9]{4}") + '-' +
-            faker.regexify("[a-f0-9]{12}");
+        return faker.random().hex(8, false) + '-' +
+            faker.random().hex(4, false) + '-' +
+            faker.random().hex(4, false) + '-' +
+            faker.random().hex(4, false) + '-' +
+            faker.random().hex(12, false);
     }
 
     public String tenantId() {
@@ -142,6 +142,6 @@ public class Azure extends AbstractProvider<BaseProviders> {
     }
 
     private String randHex() {
-        return faker.regexify("[a-f0-9]{16}");
+        return faker.random().hex(16, false);
     }
 }


### PR DESCRIPTION
Usage of `hex` instead of `regexify` makes about 20x times faster
```
Benchmark                         Mode  Cnt      Score     Error   Units
DatafakerSimpleMethods.hex       thrpt   10  22772.434 ± 178.039  ops/ms
DatafakerSimpleMethods.regexify  thrpt   10   1034.842 ± 157.265  ops/ms
```

for tests
```java
    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void regexify(Blackhole blackhole) {
        blackhole.consume(DATA_FAKER.regexify("[a-f0-9]{16}"));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void hex(Blackhole blackhole) {
        blackhole.consume(DATA_FAKER.random().hex(16, false));
    }
```