### PR TITLE
Use getRandomBytes and specific hashcode to speed up text generation

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Aws.java
+++ b/src/main/java/net/datafaker/providers/base/Aws.java
@@ -1,5 +1,6 @@
 package net.datafaker.providers.base;
 
+import static net.datafaker.providers.base.Text.EN_UPPERCASE;
 
 /**
  * @since 1.3.0
@@ -50,7 +51,8 @@ public class Aws extends AbstractProvider<BaseProviders> {
     }
 
     public String route53ZoneId() {
-        return faker.regexify("[A-Z]{21}");
+        return faker.text().text(
+            Text.TextSymbolsBuilder.builder().with(EN_UPPERCASE).withMaxLength(21).withMinLength(21).build(faker));
     }
 
     public String securityGroupId() {

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -217,11 +217,11 @@ class CsvTest extends AbstractFakerTest {
 
         String expected =
             "\"Number\",\"Password\"" + LINE_SEPARATOR
-                + "3,\"l63\"" + LINE_SEPARATOR
-                + "6,\"z5s88e\"" + LINE_SEPARATOR
-                + "7,\"0b92c81\"" + LINE_SEPARATOR
+                + "3,\"280\"" + LINE_SEPARATOR
+                + "6,\"olp2qk\"" + LINE_SEPARATOR
+                + "7,\"qiid881\"" + LINE_SEPARATOR
                 + "1,\"5\"" + LINE_SEPARATOR
-                + "3,\"zy2\"";
+                + "3,\"42w\"";
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -244,9 +244,9 @@ class CsvTest extends AbstractFakerTest {
 
         String expected =
             "\"Number\",\"Password\"" + LINE_SEPARATOR
-                + "3,\"f13\"" + LINE_SEPARATOR
-                + "1,\"5\"" + LINE_SEPARATOR
-                + "6,\"3z5s88\"";
+                + "3,\"og4\"" + LINE_SEPARATOR
+                + "1,\"2\"" + LINE_SEPARATOR
+                + "1,\"9\"";
 
         assertThat(csv).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -58,11 +58,11 @@ class JsonTest {
         String json = transformer.generate(fakeSequence, schema);
 
         String expected = "{" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"l63\"}" + LINE_SEPARATOR +
-            "{\"Number\": 6, \"Password\": \"z5s88e\"}" + LINE_SEPARATOR +
-            "{\"Number\": 7, \"Password\": \"0b92c81\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"280\"}" + LINE_SEPARATOR +
+            "{\"Number\": 6, \"Password\": \"olp2qk\"}" + LINE_SEPARATOR +
+            "{\"Number\": 7, \"Password\": \"qiid881\"}" + LINE_SEPARATOR +
             "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"zy2\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"42w\"}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);
@@ -85,8 +85,8 @@ class JsonTest {
         String json = transformer.generate(fakeSequence, schema);
 
         String expected = "{" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"f13\"}" + LINE_SEPARATOR +
-            "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"og4\"}" + LINE_SEPARATOR +
+            "{\"Number\": 1, \"Password\": \"2\"}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -41,11 +41,11 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'l63');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, 'z5s88e');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, '0b92c81');" + LINE_SEPARATOR +
+        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, '280');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, 'olp2qk');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, 'qiid881');" + LINE_SEPARATOR +
             "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (1, '5');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'zy2');";
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, '42w');";
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -70,11 +70,11 @@ class SqlTest {
 
         String expected =
             "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
-                "VALUES (3, 'l63')," + LINE_SEPARATOR +
-                "       (6, 'z5s88e')," + LINE_SEPARATOR +
-                "       (7, '0b92c81')," + LINE_SEPARATOR +
+                "VALUES (3, '280')," + LINE_SEPARATOR +
+                "       (6, 'olp2qk')," + LINE_SEPARATOR +
+                "       (7, 'qiid881')," + LINE_SEPARATOR +
                 "       (1, '5')," + LINE_SEPARATOR +
-                "       (3, 'zy2');";
+                "       (3, '42w');";
 
         assertThat(sql).isEqualTo(expected);
     }


### PR DESCRIPTION
By usage of assumption that in case of number of different symbols less than or equals 256 it's possible to use generated byte array and symbols should be unique it could be drastically speed up 
before 
```

Benchmark                        Mode  Cnt     Score     Error   Units
DatafakerSimpleMethods.text10   thrpt   10  1451.104 ± 125.972  ops/ms
DatafakerSimpleMethods.text100  thrpt   10   164.296 ±  20.433  ops/ms
```

after
```
Benchmark                        Mode  Cnt     Score     Error   Units
DatafakerSimpleMethods.text10   thrpt   10  4360.216 ± 529.892  ops/ms
DatafakerSimpleMethods.text100  thrpt   10   895.668 ±  98.985  ops/ms
```

benchmark
```java
...
 private static final net.datafaker.Faker DATA_FAKER = new net.datafaker.Faker();
    Text.TextRuleConfig config10 = Text.TextSymbolsBuilder.builder()
            .with(Text.EN_LOWERCASE)
            .withMinLength(10)
            .withMaxLength(10)
            .build(DATA_FAKER);
    Text.TextRuleConfig config100 = Text.TextSymbolsBuilder.builder()
            .with(Text.EN_LOWERCASE)
            .withMinLength(100)
            .withMaxLength(100)
            .build(DATA_FAKER);
    public static void main(String[] args) throws RunnerExceptio
...
    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void text10(Blackhole blackhole) {
        blackhole.consume(DATA_FAKER.text().text(config10));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void text100(Blackhole blackhole) {
        blackhole.consume(DATA_FAKER.text().text(config100));
    }
...
```