### PR TITLE
3x times speed up Aws#route53ZoneId by moving textConfig in Aws to class field

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Aws.java
+++ b/src/main/java/net/datafaker/providers/base/Aws.java
@@ -7,8 +7,12 @@ import static net.datafaker.providers.base.Text.EN_UPPERCASE;
  */
 public class Aws extends AbstractProvider<BaseProviders> {
 
+    private final Text.TextRuleConfig configForRoute53ZoneId;
+
     protected Aws(BaseProviders faker) {
         super(faker);
+        configForRoute53ZoneId = Text.TextSymbolsBuilder.builder()
+                                 .with(EN_UPPERCASE).withMaxLength(21).withMinLength(21).build(faker);
     }
 
     public String region() {
@@ -51,8 +55,7 @@ public class Aws extends AbstractProvider<BaseProviders> {
     }
 
     public String route53ZoneId() {
-        return faker.text().text(
-            Text.TextSymbolsBuilder.builder().with(EN_UPPERCASE).withMaxLength(21).withMinLength(21).build(faker));
+        return faker.text().text(configForRoute53ZoneId);
     }
 
     public String securityGroupId() {


### PR DESCRIPTION
Speed up `net.datafaker.providers.base.Aws#route53ZoneId` by moving textconfig to a class field
before
```
Benchmark                              Mode  Cnt     Score    Error   Units
DatafakerSimpleMethods.route53ZoneId  thrpt   10  1318.496 ± 11.038  ops/ms
```
after
```
Benchmark                              Mode  Cnt     Score     Error   Units
DatafakerSimpleMethods.route53ZoneId  thrpt   10  3636.202 ± 547.198  ops/ms
```