### PR TITLE
Use cast to char instead of Math.abs, use value of first symbols for hashcode

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -177,8 +177,9 @@ public class Text extends AbstractProvider<BaseProviders> {
         char[] buffer = new char[fixedNumberOfCharacters];
         int idx = 0;
         TextKey[] keys = map.keySet().toArray(new TextKey[0]);
-        int totalDiffSymbols = Arrays.stream(keys).mapToInt(t -> t.key.length).sum();
-        if (totalDiffSymbols <= 256) {
+        int maxDiffSymbols = Math.max(keys.length, Arrays.stream(keys).mapToInt(t -> t.key.length).max().getAsInt());
+        // 256 is a length of byte value range
+        if (maxDiffSymbols <= 256) {
             return textWithNotMoreThan256DiffSymbols(
                 map, faker.random().nextRandomBytes(2 * fixedNumberOfCharacters),
                 fixedNumberOfCharacters, numberOfRequiredSymbols);
@@ -222,20 +223,20 @@ public class Text extends AbstractProvider<BaseProviders> {
                 for (Map.Entry<TextKey, Integer> entry : map.entrySet()) {
                     final TextKey key = entry.getKey();
                     for (int i = 0; i < entry.getValue(); i++) {
-                        buffer[idx++] = key.key[Math.abs(bytes[bytesCounter++]) % key.key.length];
+                        buffer[idx++] = key.key[((char) (bytes[bytesCounter++])) % key.key.length];
                         numberOfRequired++;
                     }
                     map.put(key, 0);
                     if (idx == buffer.length) break;
                 }
             } else {
-                TextKey key = keys[Math.abs(bytes[bytesCounter++]) % keys.length];
+                TextKey key = keys[((char) (bytes[bytesCounter++])) % keys.length];
                 Integer curValue = map.get(key);
                 if (curValue > 0) {
                     map.put(key, curValue - 1);
                     numberOfRequired++;
                 }
-                buffer[idx++] = key.key[Math.abs(bytes[bytesCounter++]) % key.key.length];
+                buffer[idx++] = key.key[((char) bytes[bytesCounter++]) % key.key.length];
             }
         }
         return String.valueOf(buffer);
@@ -275,7 +276,8 @@ public class Text extends AbstractProvider<BaseProviders> {
             if (key.length == 0) {
                 return 1;
             }
-            return key[0] * 31 + key.length;
+            // ASSUMPTION: every TextKey contains unique symbols
+            return key[0];
         }
     }
 }

--- a/src/main/java/net/datafaker/service/RandomService.java
+++ b/src/main/java/net/datafaker/service/RandomService.java
@@ -97,7 +97,7 @@ public class RandomService {
         final char[] hexChars = new char[length];
         final byte[] randomBytes = nextRandomBytes(length);
         for (int i = 0; i < length; i++) {
-            hexChars[i] = hexArray[Math.abs(randomBytes[i]) % hexArray.length];
+            hexChars[i] = hexArray[((char) randomBytes[i]) % hexArray.length];
         }
         return new String(hexChars);
     }

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -217,11 +217,11 @@ class CsvTest extends AbstractFakerTest {
 
         String expected =
             "\"Number\",\"Password\"" + LINE_SEPARATOR
-                + "3,\"280\"" + LINE_SEPARATOR
-                + "6,\"olp2qk\"" + LINE_SEPARATOR
-                + "7,\"qiid881\"" + LINE_SEPARATOR
+                + "3,\"wo9\"" + LINE_SEPARATOR
+                + "6,\"691u00\"" + LINE_SEPARATOR
+                + "7,\"2249sil\"" + LINE_SEPARATOR
                 + "1,\"5\"" + LINE_SEPARATOR
-                + "3,\"42w\"";
+                + "3,\"mq6\"";
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -244,8 +244,8 @@ class CsvTest extends AbstractFakerTest {
 
         String expected =
             "\"Number\",\"Password\"" + LINE_SEPARATOR
-                + "3,\"og4\"" + LINE_SEPARATOR
-                + "1,\"2\"" + LINE_SEPARATOR
+                + "3,\"429\"" + LINE_SEPARATOR
+                + "1,\"4\"" + LINE_SEPARATOR
                 + "1,\"9\"";
 
         assertThat(csv).isEqualTo(expected);

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -58,11 +58,11 @@ class JsonTest {
         String json = transformer.generate(fakeSequence, schema);
 
         String expected = "{" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"280\"}" + LINE_SEPARATOR +
-            "{\"Number\": 6, \"Password\": \"olp2qk\"}" + LINE_SEPARATOR +
-            "{\"Number\": 7, \"Password\": \"qiid881\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"wo9\"}" + LINE_SEPARATOR +
+            "{\"Number\": 6, \"Password\": \"691u00\"}" + LINE_SEPARATOR +
+            "{\"Number\": 7, \"Password\": \"2249sil\"}" + LINE_SEPARATOR +
             "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"42w\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"mq6\"}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);
@@ -85,8 +85,8 @@ class JsonTest {
         String json = transformer.generate(fakeSequence, schema);
 
         String expected = "{" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"og4\"}" + LINE_SEPARATOR +
-            "{\"Number\": 1, \"Password\": \"2\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"429\"}" + LINE_SEPARATOR +
+            "{\"Number\": 1, \"Password\": \"4\"}" + LINE_SEPARATOR +
             "}";
 
         assertThat(json).isEqualTo(expected);

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -41,11 +41,11 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, '280');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, 'olp2qk');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, 'qiid881');" + LINE_SEPARATOR +
+        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'wo9');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, '691u00');" + LINE_SEPARATOR +
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, '2249sil');" + LINE_SEPARATOR +
             "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (1, '5');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, '42w');";
+            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'mq6');";
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -70,11 +70,11 @@ class SqlTest {
 
         String expected =
             "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
-                "VALUES (3, '280')," + LINE_SEPARATOR +
-                "       (6, 'olp2qk')," + LINE_SEPARATOR +
-                "       (7, 'qiid881')," + LINE_SEPARATOR +
+                "VALUES (3, 'wo9')," + LINE_SEPARATOR +
+                "       (6, '691u00')," + LINE_SEPARATOR +
+                "       (7, '2249sil')," + LINE_SEPARATOR +
                 "       (1, '5')," + LINE_SEPARATOR +
-                "       (3, '42w');";
+                "       (3, 'mq6');";
 
         assertThat(sql).isEqualTo(expected);
     }


### PR DESCRIPTION
A bit more speed up for _net.datafaker.providers.base.Text#text(net.datafaker.providers.base.Text.TextRuleConfig)_
before
```
Benchmark                        Mode  Cnt     Score     Error   Units
DatafakerSimpleMethods.text10   thrpt   10  4360.216 ± 529.892  ops/ms
DatafakerSimpleMethods.text100  thrpt   10   895.668 ±  98.985  ops/ms
```

after
```
Benchmark                        Mode  Cnt     Score      Error   Units
DatafakerSimpleMethods.text10   thrpt   10  4997.986 ± 1148.652  ops/ms
DatafakerSimpleMethods.text100  thrpt   10  1168.288 ±  155.656  ops/ms
```