### PR TITLE
Speed up text generation, remove faker from text config builder

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Aws.java
+++ b/src/main/java/net/datafaker/providers/base/Aws.java
@@ -12,7 +12,7 @@ public class Aws extends AbstractProvider<BaseProviders> {
     protected Aws(BaseProviders faker) {
         super(faker);
         configForRoute53ZoneId = Text.TextSymbolsBuilder.builder()
-                                 .with(EN_UPPERCASE).withMaxLength(21).withMinLength(21).build(faker);
+                                 .with(EN_UPPERCASE).len(21).build();
     }
 
     public String region() {

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -122,18 +122,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
-        Text.TextSymbolsBuilder builder =
-            Text.TextSymbolsBuilder.builder()
-                .with(Text.EN_LOWERCASE);
-        if (includeUppercase) builder = builder.with(Text.EN_UPPERCASE, 1);
-        if (includeSpecial) builder = builder.with(Text.DEFAULT_SPECIAL, 1);
-        if (includeDigit) builder = builder.with(Text.DIGITS, 1);
-
-        Text.TextRuleConfig config = builder.withMinLength(minimumLength)
-            .withMaxLength(maximumLength)
-            .build(faker);
-
-        return faker.text().text(config);
+        return faker.text().text(minimumLength, maximumLength, includeUppercase, includeSpecial, includeDigit);
     }
 
     /**

--- a/src/test/java/net/datafaker/providers/base/TextTest.java
+++ b/src/test/java/net/datafaker/providers/base/TextTest.java
@@ -21,10 +21,9 @@ class TextTest extends BaseFakerTest<BaseFaker> {
         final int ruCnt = 3;
         final int specSmbCnt = 5;
         final Text.TextRuleConfig config = Text.TextSymbolsBuilder.builder()
-            .withMinLength(ruCnt + specSmbCnt)
-            .withMaxLength(Math.max(ruCnt + specSmbCnt, 10))
+            .len(faker.number().numberBetween(ruCnt + specSmbCnt, Math.max(ruCnt + specSmbCnt, 10)))
             .with(ruLowerCase, ruCnt)
-            .with(customSpecialSymbols, specSmbCnt).build(faker);
+            .with(customSpecialSymbols, specSmbCnt).build();
 
         for (int i = 0; i < 1000; i++) {
             final String text = faker.text().text(config);
@@ -50,13 +49,12 @@ class TextTest extends BaseFakerTest<BaseFaker> {
     void exceptionIfLengthIsShorterThanNumberOfRequiredSymbols() {
         assertThatThrownBy(() ->
             faker.text().text(Text.TextSymbolsBuilder.builder()
-                .withMinLength(1)
-                .withMaxLength(1)
+                .len(1)
                 .with(EN_LOWERCASE, 1)
                 .with(EN_UPPERCASE, 1)
                 .with(DIGITS, 1)
                 .throwIfLengthSmall(true)
-                .build(faker)))
+                .build()))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -64,11 +62,10 @@ class TextTest extends BaseFakerTest<BaseFaker> {
     void everyTextShouldContainLowerCaseUpperCaseAndDigit() {
         int count = 0;
         final Text.TextRuleConfig config = Text.TextSymbolsBuilder.builder()
-            .withMinLength(6)
-            .withMaxLength(10)
+            .len(faker.number().numberBetween(6, 10))
             .with(EN_LOWERCASE, 1)
             .with(EN_UPPERCASE, 1)
-            .with(DIGITS, 1).build(faker);
+            .with(DIGITS, 1).build();
         while (count++ < 1000) {
             String text = faker.text().text(config);
             assertThat(text).is(new Condition<>(pw -> {


### PR DESCRIPTION
Caching of text configs brings about 20% of speed
before
```
Benchmark                                         Mode  Cnt     Score    Error   Units
DatafakerPassword.password10                     thrpt   10  1293.016 ± 38.115  ops/ms
DatafakerPassword.password10WithUpper            thrpt   10  1059.780 ± 83.480  ops/ms
DatafakerPassword.password10WithUpperLower       thrpt   10   963.004 ± 79.944  ops/ms
DatafakerPassword.password10WithUpperLowerDigit  thrpt   10   992.366 ± 32.792  ops/ms
```
after
```

Benchmark                                         Mode  Cnt     Score     Error   Units
DatafakerPassword.password10                     thrpt   10  1577.841 ± 112.689  ops/ms
DatafakerPassword.password10WithUpper            thrpt   10  1262.548 ±  74.436  ops/ms
DatafakerPassword.password10WithUpperLower       thrpt   10  1212.872 ±  27.308  ops/ms
DatafakerPassword.password10WithUpperLowerDigit  thrpt   10  1203.032 ±  45.527  ops/ms
```