### PR TITLE
Speed up text generation by removal map

### DIFF
--- a/src/test/java/net/datafaker/providers/base/TextTest.java
+++ b/src/test/java/net/datafaker/providers/base/TextTest.java
@@ -25,8 +25,9 @@ class TextTest extends BaseFakerTest<BaseFaker> {
             .with(ruLowerCase, ruCnt)
             .with(customSpecialSymbols, specSmbCnt).build();
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10; i++) {
             final String text = faker.text().text(config);
+            System.out.println(text);
             assertThat(text).matches(s -> {
                 int j = 0;
                 int curRuCnt = 0;


### PR DESCRIPTION
The result of measurement 
before
```

Benchmark           Mode  Cnt     Score     Error   Units
Text.password10   thrpt   10  3324.275 ± 207.978  ops/ms
Text.password100  thrpt   10   953.392 ±   7.367  ops/ms
```
after
```
Benchmark           Mode  Cnt     Score     Error   Units
Text.password10   thrpt   10  9167.557 ± 195.276  ops/ms
Text.password100  thrpt   10  1722.053 ±  87.599  ops/ms
```