### PR TITLE
Add caching of remove underscore result

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -52,6 +52,7 @@ public class FakeValuesService {
 
     private final Map<Locale, Map<String, Object>> key2fetchedObject = new WeakHashMap<>();
     private final Map<String, String> name2yaml = new WeakHashMap<>();
+    private final Map<String, String> removedUnderscore = new WeakHashMap<>();
 
     private final Map<Class<?>, Map<String, Map<String[], MethodAndCoercedArgs>>> mapOfMethodAndCoercedArgs = new IdentityHashMap<>();
 
@@ -851,8 +852,13 @@ public class FakeValuesService {
         return null;
     }
 
-    private static String removeUnderscoreChars(String string) {
+    private String removeUnderscoreChars(String string) {
+        String valueWithRemovedUnderscores = removedUnderscore.get(string);
+        if (valueWithRemovedUnderscores != null) {
+            return valueWithRemovedUnderscores;
+        }
         if (string.indexOf('_') == -1) {
+            removedUnderscore.put(string, string);
             return string;
         }
         char[] res = string.toCharArray();
@@ -867,7 +873,9 @@ public class FakeValuesService {
                 length++;
             }
         }
-        return String.valueOf(res, string.length() - length, length);
+        valueWithRemovedUnderscores = String.valueOf(res, string.length() - length, length);
+        removedUnderscore.put(string, valueWithRemovedUnderscores);
+        return valueWithRemovedUnderscores;
     }
 
     /**


### PR DESCRIPTION
Also brings some speed improvements for cases of methods invocations via expressions e.g.
before
```
Benchmark                                      Mode  Cnt     Score    Error   Units
DatafakerExpressions.numberbetweenExpression  thrpt   10  2806.942 ± 52.094  ops/ms
```
after
```
Benchmark                                      Mode  Cnt     Score     Error   Units
DatafakerExpressions.numberbetweenExpression  thrpt   10  3333.331 ± 246.507  ops/ms
```

test itself
```java
    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void numberbetweenExpression(Blackhole blackhole) {
        blackhole.consume(DATA_FAKER.expression("#{number.number_between '1','10'}"));
    }
```
