### PR TITLE
Log error instead of throwing and catching

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -799,9 +799,7 @@ public class FakeValuesService {
             String nestedMethodName = removeUnderscoreChars(classAndMethod[1]);
             final MethodAndCoercedArgs accessor = retrieveMethodAccessor(objectWithMethodToInvoke, nestedMethodName, args);
             if (accessor == null) {
-                throw new Exception("Can't find method on "
-                    + objectWithMethodToInvoke.getClass().getSimpleName()
-                    + " called " + nestedMethodName + ".");
+                return () -> null;
             }
 
             return () -> invokeAndToString(accessor, objectWithMethodToInvoke);
@@ -826,6 +824,11 @@ public class FakeValuesService {
         final Map<String, Map<String[], MethodAndCoercedArgs>> stringMapMap = mapOfMethodAndCoercedArgs.get(clazz);
         stringMapMap.putIfAbsent(methodName, new WeakHashMap<>());
         stringMapMap.get(methodName).put(args, accessor);
+        if (accessor == null) {
+            LOG.fine("Can't find method on "
+                + object.getClass().getSimpleName()
+                + " called " + methodName + ".");
+        }
         return accessor;
     }
 


### PR DESCRIPTION
There is a useless throwing of exception in case there is no any method  found and then just log it...
Instead it should be just logged without throwing