### PR TITLE
Enhance NL local company name and suffix

### DIFF
--- a/src/main/resources/nl.yml
+++ b/src/main/resources/nl.yml
@@ -50,7 +50,7 @@ nl:
       default_country: [Nederland]
 
     company:
-      suffix: [ "BV", "NV", "V.O.F.", "Group", "CV", "Mts", "en Zonen" ]
+      suffix: [ "BV", "NV", "VOF", "Groep", "CV", "Mts", "en Zonen" ]
       name:
         - "#{Name.last_name} #{suffix}"
         - "#{Name.last_name}-#{Name.last_name}"

--- a/src/main/resources/nl.yml
+++ b/src/main/resources/nl.yml
@@ -50,12 +50,11 @@ nl:
       default_country: [Nederland]
 
     company:
-      company:
-        suffix: [ "BV", "NV", "V.O.F.", "Group", "CV", "Mts", "en Zonen" ]
-        name:
-          - "#{Name.last_name} #{suffix}"
-          - "#{Name.last_name}-#{Name.last_name}"
-          - "#{Name.last_name}, #{Name.last_name} en #{Name.last_name}"
+      suffix: [ "BV", "NV", "V.O.F.", "Group", "CV", "Mts", "en Zonen" ]
+      name:
+        - "#{Name.last_name} #{suffix}"
+        - "#{Name.last_name}-#{Name.last_name}"
+        - "#{Name.last_name}, #{Name.last_name} en #{Name.last_name}"
 
     internet:
       free_email: [gmail.com, yahoo.com, hotmail.nl, live.nl, outlook.com, kpnmail.nl]

--- a/src/main/resources/nl.yml
+++ b/src/main/resources/nl.yml
@@ -50,7 +50,12 @@ nl:
       default_country: [Nederland]
 
     company:
-      suffix: [BV, V.O.F., Group, en Zonen]
+      company:
+        suffix: [ "BV", "NV", "V.O.F.", "Group", "CV", "Mts", "en Zonen" ]
+        name:
+          - "#{Name.last_name} #{suffix}"
+          - "#{Name.last_name}-#{Name.last_name}"
+          - "#{Name.last_name}, #{Name.last_name} en #{Name.last_name}"
 
     internet:
       free_email: [gmail.com, yahoo.com, hotmail.nl, live.nl, outlook.com, kpnmail.nl]


### PR DESCRIPTION
Expanding `suffix` collection + adjusting `name` patterns: we shouldn't use default (en) since and is en in Dutch, thus I added
```
        name:
          - "#{Name.last_name} #{suffix}"
          - "#{Name.last_name}-#{Name.last_name}"
          - "#{Name.last_name}, #{Name.last_name} en #{Name.last_name}"
```