### PR TITLE
Enforce EOL=LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-*        text=auto
+*        text=auto eol=lf
 
 *.cs     text diff=csharp
 *.java   text diff=java


### PR DESCRIPTION
Set .gitattributes to enforce the EOL as specified in editor config.

I'm developing on Windows, prior to tweaking this I was getting spotless check issues.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>