### PR TITLE
Improve unit testing

### DIFF
--- a/src/test/java/net/datafaker/providers/base/AbstractBasicProviderTest.java
+++ b/src/test/java/net/datafaker/providers/base/AbstractBasicProviderTest.java
@@ -1,0 +1,54 @@
+package net.datafaker.providers.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractBasicProviderTest<T extends BaseFaker> extends BaseFakerTest<BaseFaker> {
+    @SuppressWarnings("unchecked")
+    protected List<String> getBaseList(String key) {
+        return (List<String>) faker.fakeValuesService().fetchObject(key, faker.getContext());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("providerListTest")
+    protected void testProviderList(TestSpec testSpec) {
+        // Given
+        List<String> actual = getBaseList(testSpec.key);
+        // When
+        String item = (String) testSpec.supplier.get();
+        // Then
+        assertThat(item).as("Check item isn't empty").isNotEmpty();
+        assertThat(actual).as("Check actual list isn't empty and contains the item").isNotEmpty()
+                .anyMatch(item::equals);
+    }
+
+    protected abstract Collection<TestSpec> providerListTest();
+
+    protected static class TestSpec {
+        private final Supplier<?> supplier;
+        private final String key;
+
+        private TestSpec(Supplier<?> supplier, String key) {
+            this.supplier = supplier;
+            this.key = key;
+        }
+
+        public static TestSpec of(Supplier<?> supplier, String key) {
+            return new TestSpec(supplier, key);
+        }
+
+        @Override
+        public String toString() {
+            // The result of this toString will be used by IDE in test report
+            return "Key: " + key;
+        }
+    }
+}

--- a/src/test/java/net/datafaker/providers/base/ApplianceTest.java
+++ b/src/test/java/net/datafaker/providers/base/ApplianceTest.java
@@ -4,15 +4,18 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ApplianceTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
+
+class ApplianceTest extends AbstractBasicProviderTest<BaseFaker> {
 
     @Test
     void brand() {
         assertThat(faker.appliance().brand()).matches("[A-Za-z .-]+");
     }
 
-    @Test
-    void equipment() {
-        assertThat(faker.appliance().equipment()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.appliance().equipment(), "appliance.equipment"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/AustraliaTest.java
+++ b/src/test/java/net/datafaker/providers/base/AustraliaTest.java
@@ -1,23 +1,15 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class AustraliaTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class AustraliaTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void locations() {
-        assertThat(faker.australia().locations()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.australia().locations(), "australia.locations"),
+            TestSpec.of(() -> faker.australia().animals(), "australia.animals"),
+            TestSpec.of(() -> faker.australia().states(), "australia.states"));
     }
 
-    @Test
-    void animals() {
-        assertThat(faker.australia().animals()).isNotEmpty();
-    }
-
-    @Test
-    void states() {
-        assertThat(faker.australia().states()).isNotEmpty();
-    }
 }

--- a/src/test/java/net/datafaker/providers/base/AviationTest.java
+++ b/src/test/java/net/datafaker/providers/base/AviationTest.java
@@ -4,21 +4,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AviationTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
+
+class AviationTest extends AbstractBasicProviderTest<BaseFaker> {
 
     @Test
     void airport() {
         assertThat(faker.aviation().airport()).matches("\\w{4}");
-    }
-
-    @Test
-    void aircraft() {
-        assertThat(faker.aviation().aircraft()).isNotEmpty();
-    }
-
-    @Test
-    void metar() {
-        assertThat(faker.aviation().METAR()).isNotEmpty();
     }
 
     @Test
@@ -36,8 +29,10 @@ class AviationTest extends BaseFakerTest<BaseFaker> {
         assertThat(faker.aviation().flight()).matches("[A-Z]{2}[0-9]+");
     }
 
-    @Test
-    void airline() {
-        assertThat(faker.aviation().airline()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.aviation().aircraft(), "aviation.aircraft"),
+            TestSpec.of(() -> faker.aviation().METAR(), "aviation.metar"),
+            TestSpec.of(() -> faker.aviation().airline(), "aviation.airline"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/BusinessTest.java
+++ b/src/test/java/net/datafaker/providers/base/BusinessTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class BusinessTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
+
+class BusinessTest extends AbstractBasicProviderTest<BaseFaker> {
 
     @Test
     void creditCardNumber() {
@@ -12,17 +15,21 @@ class BusinessTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void creditCardType() {
-        assertThat(faker.business().creditCardType()).isNotEmpty();
-    }
-
-    @Test
     void creditCardExpiry() {
-        assertThat(faker.business().creditCardExpiry()).isNotEmpty();
+        // Given / When
+        String date = faker.business().creditCardExpiry();
+        // Then
+        assertThat(date).isNotEmpty();
+        assertThat(date).matches("\\d{4}-\\d{2}-\\d{2}");
     }
 
     @Test
     void securityCode() {
         assertThat(faker.business().securityCode()).isNotEmpty();
+    }
+
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.business().creditCardType(), "business.credit_card_types"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CannabisTest.java
+++ b/src/test/java/net/datafaker/providers/base/CannabisTest.java
@@ -1,58 +1,22 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class CannabisTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class CannabisTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void strains() {
-        assertThat(faker.cannabis().strains()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.cannabis().strains(), "cannabis.strains"),
+                TestSpec.of(() -> faker.cannabis().cannabinoidAbbreviations(), "cannabis.cannabinoid_abbreviations"),
+                TestSpec.of(() -> faker.cannabis().cannabinoids(), "cannabis.cannabinoids"),
+                TestSpec.of(() -> faker.cannabis().terpenes(), "cannabis.terpenes"),
+                TestSpec.of(() -> faker.cannabis().medicalUses(), "cannabis.medical_uses"),
+                TestSpec.of(() -> faker.cannabis().healthBenefits(), "cannabis.health_benefits"),
+                TestSpec.of(() -> faker.cannabis().categories(), "cannabis.categories"),
+                TestSpec.of(() -> faker.cannabis().types(), "cannabis.types"),
+                TestSpec.of(() -> faker.cannabis().buzzwords(), "cannabis.buzzwords"),
+                TestSpec.of(() -> faker.cannabis().brands(), "cannabis.brands"));
     }
 
-    @Test
-    void cannabinoidAbbreviations() {
-        assertThat(faker.cannabis().cannabinoidAbbreviations()).isNotEmpty();
-    }
-
-    @Test
-    void cannabinoids() {
-        assertThat(faker.cannabis().cannabinoids()).isNotEmpty();
-    }
-
-    @Test
-    void terpenes() {
-        assertThat(faker.cannabis().terpenes()).isNotEmpty();
-    }
-
-    @Test
-    void medicalUses() {
-        assertThat(faker.cannabis().medicalUses()).isNotEmpty();
-    }
-
-    @Test
-    void healthBenefits() {
-        assertThat(faker.cannabis().healthBenefits()).isNotEmpty();
-    }
-
-    @Test
-    void categories() {
-        assertThat(faker.cannabis().categories()).isNotEmpty();
-    }
-
-    @Test
-    void types() {
-        assertThat(faker.cannabis().types()).isNotEmpty();
-    }
-
-    @Test
-    void buzzwords() {
-        assertThat(faker.cannabis().buzzwords()).isNotEmpty();
-    }
-
-    @Test
-    void brands() {
-        assertThat(faker.cannabis().brands()).isNotEmpty();
-    }
 }

--- a/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
+++ b/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
@@ -1,29 +1,16 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class ChiquitoTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class ChiquitoTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void expressions() {
-        assertThat(faker.chiquito().expressions()).isNotEmpty();
-    }
-
-    @Test
-    void terms() {
-        assertThat(faker.chiquito().terms()).isNotEmpty();
-    }
-
-    @Test
-    void sentences() {
-        assertThat(faker.chiquito().sentences()).isNotEmpty();
-    }
-
-    @Test
-    void jokes() {
-        assertThat(faker.chiquito().jokes()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.chiquito().expressions(), "chiquito.expressions"),
+            TestSpec.of(() -> faker.chiquito().terms(), "chiquito.terms"),
+            TestSpec.of(() -> faker.chiquito().sentences(), "chiquito.sentences"),
+            TestSpec.of(() -> faker.chiquito().jokes(), "chiquito.jokes"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/CommunityTest.java
+++ b/src/test/java/net/datafaker/providers/base/CommunityTest.java
@@ -1,18 +1,13 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+public class CommunityTest extends AbstractBasicProviderTest<BaseFaker> {
 
-public class CommunityTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void testCharacter() {
-        assertThat(faker.community().character()).isNotEmpty();
-    }
-
-    @Test
-    void testQuote() {
-        assertThat(faker.community().quote()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.community().character(), "community.characters"),
+                TestSpec.of(() -> faker.community().quote(), "community.quotes"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/ComputerTest.java
+++ b/src/test/java/net/datafaker/providers/base/ComputerTest.java
@@ -4,40 +4,23 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ComputerTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
 
-    @Test
-    void testType() {
-        assertThat(faker.computer().type()).isNotEmpty();
-    }
-
-    @Test
-    void testPlatform() {
-        assertThat(faker.computer().platform()).isNotEmpty();
-    }
+class ComputerTest extends AbstractBasicProviderTest<BaseFaker> {
 
     @Test
     void testOperatingSystem() {
         assertThat(faker.computer().operatingSystem()).isNotEmpty();
     }
 
-    @Test
-    void testLinux() {
-        assertThat(faker.computer().linux()).isNotEmpty();
-    }
-
-    @Test
-    void testMacos() {
-        assertThat(faker.computer().macos()).isNotEmpty();
-    }
-
-    @Test
-    void testWindows() {
-        assertThat(faker.computer().windows()).isNotEmpty();
-    }
-
-    @Test
-    void testBrand() {
-        assertThat(faker.computer().brand()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.computer().type(), "computer.type"),
+                TestSpec.of(() -> faker.computer().platform(), "computer.platform"),
+                TestSpec.of(() -> faker.computer().linux(), "computer.os.linux"),
+                TestSpec.of(() -> faker.computer().macos(), "computer.os.macos"),
+                TestSpec.of(() -> faker.computer().windows(), "computer.os.windows"),
+                TestSpec.of(() -> faker.computer().brand(), "computer.brand"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/ConstructionTest.java
+++ b/src/test/java/net/datafaker/providers/base/ConstructionTest.java
@@ -1,38 +1,17 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class ConstructionTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class ConstructionTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void heavyEquipment() {
-        assertThat(faker.construction().heavyEquipment()).isNotEmpty();
-    }
-
-    @Test
-    void materials() {
-        assertThat(faker.construction().materials()).isNotEmpty();
-    }
-
-    @Test
-    void subcontractCategories() {
-        assertThat(faker.construction().subcontractCategories()).isNotEmpty();
-    }
-
-    @Test
-    void roles() {
-        assertThat(faker.construction().roles()).isNotEmpty();
-    }
-
-    @Test
-    void trades() {
-        assertThat(faker.construction().trades()).isNotEmpty();
-    }
-
-    @Test
-    void standardCostCodes() {
-        assertThat(faker.construction().standardCostCodes()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.construction().heavyEquipment(), "construction.heavy_equipment"),
+                TestSpec.of(() -> faker.construction().materials(), "construction.materials"),
+                TestSpec.of(() -> faker.construction().subcontractCategories(), "construction.subcontract_categories"),
+                TestSpec.of(() -> faker.construction().roles(), "construction.roles"),
+                TestSpec.of(() -> faker.construction().trades(), "construction.trades"),
+                TestSpec.of(() -> faker.construction().standardCostCodes(), "construction.standard_cost_codes"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CosmereTest.java
+++ b/src/test/java/net/datafaker/providers/base/CosmereTest.java
@@ -1,60 +1,24 @@
 package net.datafaker.providers.base;
 
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+class CosmereTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class CosmereTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void aons() {
-        assertThat(faker.cosmere().aons()).isNotEmpty();
-    }
-
-    @Test
-    void shardWorlds() {
-        assertThat(faker.cosmere().shardWorlds()).isNotEmpty();
-    }
-
-    @Test
-    void shards() {
-        assertThat(faker.cosmere().shards()).isNotEmpty();
-    }
-
-    @Test
-    void surges() {
-        assertThat(faker.cosmere().surges()).isNotEmpty();
-    }
-
-    @Test
-    void knightsRadiant() {
-        assertThat(faker.cosmere().knightsRadiant()).isNotEmpty();
-    }
-
-    @Test
-    void metals() {
-        assertThat(faker.cosmere().metals()).isNotEmpty();
-    }
-
-    @Test
-    void allomancers() {
-        assertThat(faker.cosmere().allomancers()).isNotEmpty();
-    }
-
-    @Test
-    void feruchemists() {
-        assertThat(faker.cosmere().feruchemists()).isNotEmpty();
-    }
-
-    @Test
-    void heralds() {
-        assertThat(faker.cosmere().heralds()).isNotEmpty();
-    }
-
-    @Test
-    void sprens() {
-        assertThat(faker.cosmere().sprens()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.cosmere().aons(), "cosmere.aons"),
+                TestSpec.of(() -> faker.cosmere().shardWorlds(), "cosmere.shard_worlds"),
+                TestSpec.of(() -> faker.cosmere().shards(), "cosmere.shards"),
+                TestSpec.of(() -> faker.cosmere().surges(), "cosmere.surges"),
+                TestSpec.of(() -> faker.cosmere().knightsRadiant(), "cosmere.knights_radiant"),
+                TestSpec.of(() -> faker.cosmere().metals(), "cosmere.metals"),
+                TestSpec.of(() -> faker.cosmere().allomancers(), "cosmere.allomancers"),
+                TestSpec.of(() -> faker.cosmere().feruchemists(), "cosmere.feruchemists"),
+                TestSpec.of(() -> faker.cosmere().heralds(), "cosmere.heralds"),
+                TestSpec.of(() -> faker.cosmere().sprens(), "cosmere.sprens")
+                );
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/CountryTest.java
+++ b/src/test/java/net/datafaker/providers/base/CountryTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CountryTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
+
+class CountryTest extends AbstractBasicProviderTest<BaseFaker> {
 
     @RepeatedTest(10)
     void testFlag() {
@@ -38,8 +41,8 @@ class CountryTest extends BaseFakerTest<BaseFaker> {
         assertThat(faker.country().currencyCode()).matches("([\\w-’í]+ ?)+");
     }
 
-    @Test
-    void testName() {
-        assertThat(faker.country().name()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.country().name(), "country.name"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CryptoCoinTest.java
+++ b/src/test/java/net/datafaker/providers/base/CryptoCoinTest.java
@@ -1,13 +1,12 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class CryptoCoinTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class CryptoCoinTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void coin() {
-        assertThat(faker.cryptoCoin().coin()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.cryptoCoin().coin(), "crypto_coin.coin"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/CultureSeriesTest.java
+++ b/src/test/java/net/datafaker/providers/base/CultureSeriesTest.java
@@ -1,39 +1,18 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+class CultureSeriesTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class CultureSeriesTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void books() {
-        assertThat(faker.cultureSeries().books()).isNotEmpty();
-    }
-
-    @Test
-    void cultureShips() {
-        assertThat(faker.cultureSeries().cultureShips()).isNotEmpty();
-    }
-
-    @Test
-    void cultureShipClasses() {
-        assertThat(faker.cultureSeries().cultureShipClasses()).isNotEmpty();
-    }
-
-    @Test
-    void cultureShipClassAbvs() {
-        assertThat(faker.cultureSeries().cultureShipClassAbvs()).isNotEmpty();
-    }
-
-    @Test
-    void civs() {
-        assertThat(faker.cultureSeries().civs()).isNotEmpty();
-    }
-
-    @Test
-    void planets() {
-        assertThat(faker.cultureSeries().planets()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.cultureSeries().books(), "culture_series.books"),
+                TestSpec.of(() -> faker.cultureSeries().cultureShips(), "culture_series.culture_ships"),
+                TestSpec.of(() -> faker.cultureSeries().cultureShipClasses(), "culture_series.culture_ship_classes"),
+                TestSpec.of(() -> faker.cultureSeries().cultureShipClassAbvs(), "culture_series.culture_ship_class_abvs"),
+                TestSpec.of(() -> faker.cultureSeries().civs(), "culture_series.civs"),
+                TestSpec.of(() -> faker.cultureSeries().planets(), "culture_series.planets"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/DcComicsTest.java
+++ b/src/test/java/net/datafaker/providers/base/DcComicsTest.java
@@ -1,34 +1,17 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+public class DcComicsTest extends AbstractBasicProviderTest<BaseFaker> {
 
-public class DcComicsTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void hero() {
-        assertThat(faker.dcComics().hero()).isNotEmpty();
-    }
-
-    @Test
-    void heroine() {
-        assertThat(faker.dcComics().heroine()).isNotEmpty();
-    }
-
-    @Test
-    void villain() {
-        assertThat(faker.dcComics().villain()).isNotEmpty();
-    }
-
-    @Test
-    void name() {
-        assertThat(faker.dcComics().name()).isNotEmpty();
-    }
-
-    @Test
-    void title() {
-        assertThat(faker.dcComics().title()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.dcComics().hero(), "dc_comics.hero"),
+                TestSpec.of(() -> faker.dcComics().heroine(), "dc_comics.heroine"),
+                TestSpec.of(() -> faker.dcComics().villain(), "dc_comics.villain"),
+                TestSpec.of(() -> faker.dcComics().name(), "dc_comics.name"),
+                TestSpec.of(() -> faker.dcComics().title(), "dc_comics.title"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/DeviceTest.java
+++ b/src/test/java/net/datafaker/providers/base/DeviceTest.java
@@ -1,28 +1,16 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class DeviceTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class DeviceTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void modelName() {
-        assertThat(faker.device().modelName()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.device().modelName(), "device.model_name"),
+                TestSpec.of(() -> faker.device().platform(), "device.platform"),
+                TestSpec.of(() -> faker.device().manufacturer(), "device.manufacturer"),
+                TestSpec.of(() -> faker.device().serial(), "device.serial"));
     }
 
-    @Test
-    void platform() {
-        assertThat(faker.device().platform()).isNotEmpty();
-    }
-
-    @Test
-    void manufacturer() {
-        assertThat(faker.device().manufacturer()).isNotEmpty();
-    }
-
-    @Test
-    void serial() {
-        assertThat(faker.device().serial()).isNotEmpty();
-    }
 }

--- a/src/test/java/net/datafaker/providers/base/DiseaseTest.java
+++ b/src/test/java/net/datafaker/providers/base/DiseaseTest.java
@@ -5,7 +5,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class DiseaseTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
+
+class DiseaseTest extends AbstractBasicProviderTest<BaseFaker> {
+
     @Test
     void testInternalDisease() {
         assertThat(faker.disease().internalDisease()).matches("[\\p{L}'()., 0-9-’]+");
@@ -82,5 +86,15 @@ class DiseaseTest extends BaseFakerTest<BaseFaker> {
     @RepeatedTest(10000)
     void testDermatoloryWith10000Times() {
         assertThat(faker.disease().dermatolory()).isNotEmpty();
+    }
+
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.disease().neurology(), "disease.neurology"),
+                TestSpec.of(() -> faker.disease().surgery(), "disease.surgery"),
+                TestSpec.of(() -> faker.disease().paediatrics(), "disease.paediatrics"),
+                TestSpec.of(() -> faker.disease().gynecologyAndObstetrics(), "disease.gynecology_and_obstetrics"),
+                TestSpec.of(() -> faker.disease().ophthalmologyAndOtorhinolaryngology(), "disease.ophthalmology_and_otorhinolaryngology"),
+                TestSpec.of(() -> faker.disease().dermatolory(), "disease.dermatolory"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/DroneTest.java
+++ b/src/test/java/net/datafaker/providers/base/DroneTest.java
@@ -5,11 +5,21 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-class DroneTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
 
-    @Test
-    void name() {
-        assertThat(faker.drone().name()).isNotEmpty();
+class DroneTest extends AbstractBasicProviderTest<BaseFaker> {
+
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.drone().name(), "drone.name"),
+                TestSpec.of(() -> faker.drone().batteryType(), "drone.battery_type"),
+                TestSpec.of(() -> faker.drone().iso(), "drone.iso"),
+                TestSpec.of(() -> faker.drone().photoFormat(), "drone.photo_format"),
+                TestSpec.of(() -> faker.drone().videoFormat(), "drone.video_format"),
+                TestSpec.of(() -> faker.drone().maxShutterSpeed(), "drone.max_shutter_speed"),
+                TestSpec.of(() -> faker.drone().minShutterSpeed(), "drone.min_shutter_speed"),
+                TestSpec.of(() -> faker.drone().shutterSpeedUnits(), "drone.shutter_speed_units"));
     }
 
     @Test
@@ -78,11 +88,6 @@ class DroneTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void batteryType() {
-        assertThat(faker.drone().batteryType()).isNotEmpty();
-    }
-
-    @Test
     void batteryWeight() {
         assertThat(faker.drone().batteryWeight()).isNotEmpty().doesNotContain("#");
     }
@@ -98,38 +103,8 @@ class DroneTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    void iso() {
-        assertThat(faker.drone().iso()).isNotEmpty();
-    }
-
-    @Test
     void maxResolution() {
         assertThat(faker.drone().maxResolution()).isNotEmpty().doesNotContain("#");
-    }
-
-    @Test
-    void photoFormat() {
-        assertThat(faker.drone().photoFormat()).isNotEmpty();
-    }
-
-    @Test
-    void videoFormat() {
-        assertThat(faker.drone().videoFormat()).isNotEmpty();
-    }
-
-    @Test
-    void maxShutterSpeed() {
-        assertThat(faker.drone().maxShutterSpeed()).isNotEmpty();
-    }
-
-    @Test
-    void minShutterSpeed() {
-        assertThat(faker.drone().minShutterSpeed()).isNotEmpty();
-    }
-
-    @Test
-    void shutterSpeedUnits() {
-        assertThat(faker.drone().shutterSpeedUnits()).isNotEmpty();
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/GarmentSizeTest.java
+++ b/src/test/java/net/datafaker/providers/base/GarmentSizeTest.java
@@ -1,25 +1,14 @@
 package net.datafaker.providers.base;
 
 
-import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+public class GarmentSizeTest extends AbstractBasicProviderTest<BaseFaker> {
 
-public class GarmentSizeTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void testSize() {
-        // Given
-        List<String> actualSizes = getActualSizes();
-        // When
-        String size = faker.garmentSize().size();
-        // Then
-        assertThat(actualSizes).anyMatch(size::equals);
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of((() -> faker.garmentSize().size()), "garments_sizes.sizes"));
     }
 
-    @SuppressWarnings("unchecked")
-    private List<String> getActualSizes() {
-        return (List<String>) faker.fakeValuesService().fetchObject("garments_sizes.sizes", faker.getContext());
-    }
 }

--- a/src/test/java/net/datafaker/providers/base/HobbyTest.java
+++ b/src/test/java/net/datafaker/providers/base/HobbyTest.java
@@ -1,13 +1,12 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class HobbyTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class HobbyTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void activity() {
-        assertThat(faker.hobby().activity()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.hobby().activity(), "hobby.activity"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/HorseTest.java
+++ b/src/test/java/net/datafaker/providers/base/HorseTest.java
@@ -1,19 +1,14 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class HorseTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class HorseTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void name() {
-        assertThat(faker.horse().name()).isNotEmpty();
-    }
-
-    @Test
-    void breed() {
-        assertThat(faker.horse().breed()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.horse().name(), "creature.horse.name"),
+                TestSpec.of(() -> faker.horse().breed(), "creature.horse.breed"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/IndustrySegmentsTest.java
+++ b/src/test/java/net/datafaker/providers/base/IndustrySegmentsTest.java
@@ -1,28 +1,15 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+public class IndustrySegmentsTest extends AbstractBasicProviderTest<BaseFaker> {
 
-public class IndustrySegmentsTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void testIndustry() {
-        assertThat(faker.industrySegments().industry()).isNotEmpty();
-    }
-
-    @Test
-    void testSuperSector() {
-        assertThat(faker.industrySegments().superSector()).isNotEmpty();
-    }
-
-    @Test
-    void testSector() {
-        assertThat(faker.industrySegments().sector()).isNotEmpty();
-    }
-
-    @Test
-    void testSubSector() {
-        assertThat(faker.industrySegments().subSector()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.industrySegments().industry(), "industry_segments.industry"),
+                TestSpec.of(() -> faker.industrySegments().superSector(), "industry_segments.super_sector"),
+                TestSpec.of(() -> faker.industrySegments().sector(), "industry_segments.sector"),
+                TestSpec.of(() -> faker.industrySegments().subSector(), "industry_segments.sub_sector"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/KpopTest.java
+++ b/src/test/java/net/datafaker/providers/base/KpopTest.java
@@ -1,40 +1,18 @@
 
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class KpopTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class KpopTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void iGroups() {
-        assertThat(faker.kpop().iGroups()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.kpop().iGroups(), "kpop.i_groups"),
+                TestSpec.of(() -> faker.kpop().iiGroups(), "kpop.ii_groups"),
+                TestSpec.of(() -> faker.kpop().iiiGroups(), "kpop.iii_groups"),
+                TestSpec.of(() -> faker.kpop().girlGroups(), "kpop.girl_groups"),
+                TestSpec.of(() -> faker.kpop().boyBands(), "kpop.boy_bands"),
+                TestSpec.of(() -> faker.kpop().solo(), "kpop.solo"));
     }
-
-    @Test
-    void iiGroups() {
-        assertThat(faker.kpop().iiGroups()).isNotEmpty();
-    }
-
-    @Test
-    void iiiGroups() {
-        assertThat(faker.kpop().iiiGroups()).isNotEmpty();
-    }
-
-    @Test
-    void girlGroups() {
-        assertThat(faker.kpop().girlGroups()).isNotEmpty();
-    }
-
-    @Test
-    void boyBands() {
-        assertThat(faker.kpop().boyBands()).isNotEmpty();
-    }
-
-    @Test
-    void solo() {
-        assertThat(faker.kpop().solo()).isNotEmpty();
-    }
-
 }

--- a/src/test/java/net/datafaker/providers/base/LoremTest.java
+++ b/src/test/java/net/datafaker/providers/base/LoremTest.java
@@ -5,13 +5,20 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class LoremTest extends BaseFakerTest<BaseFaker> {
+class LoremTest extends AbstractBasicProviderTest<BaseFaker> {
+
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.lorem().word(), "lorem.words"));
+    }
 
     @Test
     void shouldCreateFixedLengthString() {
@@ -19,11 +26,6 @@ class LoremTest extends BaseFakerTest<BaseFaker> {
         assertThat(faker.lorem().fixedString(50)).hasSize(50);
         assertThat(faker.lorem().fixedString(0)).isEmpty();
         assertThat(faker.lorem().fixedString(-1)).isEmpty();
-    }
-
-    @Test
-    void wordShouldNotBeNullOrEmpty() {
-        assertThat(faker.lorem().word()).isNotEmpty();
     }
 
     @Test

--- a/src/test/java/net/datafaker/providers/base/MarketingTest.java
+++ b/src/test/java/net/datafaker/providers/base/MarketingTest.java
@@ -1,14 +1,13 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class MarketingTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class MarketingTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void buzzwords() {
-        assertThat(faker.marketing().buzzwords()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.marketing().buzzwords(), "marketing.buzzwords"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/MatzTest.java
+++ b/src/test/java/net/datafaker/providers/base/MatzTest.java
@@ -1,13 +1,12 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class MatzTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class MatzTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void quote() {
-        assertThat(faker.matz().quote()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.matz().quote(), "matz.quotes"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/MedicalTest.java
+++ b/src/test/java/net/datafaker/providers/base/MedicalTest.java
@@ -3,30 +3,20 @@ package net.datafaker.providers.base;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class MedicalTest extends BaseFakerTest<BaseFaker> {
+class MedicalTest extends AbstractBasicProviderTest<BaseFaker> {
 
-    @Test
-    void testMedicineName() {
-        assertThat(faker.medical().medicineName()).isNotEmpty();
-    }
-
-    @Test
-    void testDiseaseName() {
-        assertThat(faker.medical().diseaseName()).isNotEmpty();
-    }
-
-    @Test
-    void testHospitalName() {
-        assertThat(faker.medical().hospitalName()).isNotEmpty();
-    }
-
-    @Test
-    void testSymptom() {
-        assertThat(faker.medical().symptoms()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.medical().medicineName(), "medical.medicine_name"),
+                TestSpec.of(() -> faker.medical().diseaseName(), "medical.disease_name"),
+                TestSpec.of(() -> faker.medical().hospitalName(), "medical.hospital_name"),
+                TestSpec.of(() -> faker.medical().symptoms(), "medical.symptoms"));
     }
 
     @Test

--- a/src/test/java/net/datafaker/providers/base/MilitaryTest.java
+++ b/src/test/java/net/datafaker/providers/base/MilitaryTest.java
@@ -1,34 +1,17 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class MilitaryTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class MilitaryTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void armyRank() {
-        assertThat(faker.military().armyRank()).isNotEmpty();
-    }
-
-    @Test
-    void marinesRank() {
-        assertThat(faker.military().marinesRank()).isNotEmpty();
-    }
-
-    @Test
-    void navyRank() {
-        assertThat(faker.military().navyRank()).isNotEmpty();
-    }
-
-    @Test
-    void airForceRank() {
-        assertThat(faker.military().airForceRank()).isNotEmpty();
-    }
-
-    @Test
-    void dodPaygrade() {
-        assertThat(faker.military().dodPaygrade()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.military().armyRank(), "military.army_rank"),
+                TestSpec.of(() -> faker.military().marinesRank(), "military.marines_rank"),
+                TestSpec.of(() -> faker.military().navyRank(), "military.navy_rank"),
+                TestSpec.of(() -> faker.military().airForceRank(), "military.air_force_rank"),
+                TestSpec.of(() -> faker.military().dodPaygrade(), "military.dod_paygrade"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/MountainTest.java
+++ b/src/test/java/net/datafaker/providers/base/MountainTest.java
@@ -1,20 +1,13 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class MountainTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class MountainTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void testMountainName() {
-        String mountainName = faker.mountain().name();
-        assertThat(mountainName).isNotEmpty();
-    }
-
-    @Test
-    void testMountainLeague() {
-        String mountainLeague = faker.mountain().range();
-        assertThat(mountainLeague).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.mountain().name(), "mountain.name"),
+                TestSpec.of(() -> faker.mountain().range(), "mountain.range"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/MountaineeringTest.java
+++ b/src/test/java/net/datafaker/providers/base/MountaineeringTest.java
@@ -1,14 +1,12 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class MountaineeringTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class MountaineeringTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void mountaineer() {
-        assertThat(faker.mountaineering().mountaineer()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.mountaineering().mountaineer(), "mountaineering.mountaineer"));
     }
 }
-

--- a/src/test/java/net/datafaker/providers/base/NatoPhoneticAlphabetTest.java
+++ b/src/test/java/net/datafaker/providers/base/NatoPhoneticAlphabetTest.java
@@ -1,14 +1,13 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class NatoPhoneticAlphabetTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class NatoPhoneticAlphabetTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void codeWord() {
-        assertThat(faker.natoPhoneticAlphabet().codeWord()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.natoPhoneticAlphabet().codeWord(), "nato_phonetic_alphabet.code_word"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/NigeriaTest.java
+++ b/src/test/java/net/datafaker/providers/base/NigeriaTest.java
@@ -1,33 +1,16 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class NigeriaTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class NigeriaTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void places() {
-        assertThat(faker.nigeria().places()).isNotEmpty();
-    }
-
-    @Test
-    void food() {
-        assertThat(faker.nigeria().food()).isNotEmpty();
-    }
-
-    @Test
-    void names() {
-        assertThat(faker.nigeria().name()).isNotEmpty();
-    }
-
-    @Test
-    void schools() {
-        assertThat(faker.nigeria().schools()).isNotEmpty();
-    }
-
-    @Test
-    void celebrities() {
-        assertThat(faker.nigeria().celebrities()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.nigeria().places(), "nigeria.places"),
+                TestSpec.of(() -> faker.nigeria().food(), "nigeria.food"),
+                TestSpec.of(() -> faker.nigeria().name(), "nigeria.name"),
+                TestSpec.of(() -> faker.nigeria().schools(), "nigeria.schools"),
+                TestSpec.of(() -> faker.nigeria().celebrities(), "nigeria.celebrities"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/OlympicSportTest.java
+++ b/src/test/java/net/datafaker/providers/base/OlympicSportTest.java
@@ -1,38 +1,18 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.util.Arrays;
+import java.util.Collection;
 
-class OlympicSportTest extends BaseFakerTest<BaseFaker> {
+class OlympicSportTest extends AbstractBasicProviderTest<BaseFaker> {
 
-    @Test
-    void summerOlympics() {
-        assertThat(faker.olympicSport().summerOlympics()).isNotEmpty();
-    }
-
-    @Test
-    void winterOlympics() {
-        assertThat(faker.olympicSport().winterOlympics()).isNotEmpty();
-    }
-
-    @Test
-    void summerParalympics() {
-        assertThat(faker.olympicSport().summerParalympics()).isNotEmpty();
-    }
-
-    @Test
-    void winterParalympics() {
-        assertThat(faker.olympicSport().winterParalympics()).isNotEmpty();
-    }
-
-    @Test
-    void ancientOlympics() {
-        assertThat(faker.olympicSport().ancientOlympics()).isNotEmpty();
-    }
-
-    @Test
-    void unusual() {
-        assertThat(faker.olympicSport().unusual()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.olympicSport().summerOlympics(), "olympic_sport.summer_olympics"),
+                TestSpec.of(() -> faker.olympicSport().winterOlympics(), "olympic_sport.winter_olympics"),
+                TestSpec.of(() -> faker.olympicSport().summerParalympics(), "olympic_sport.summer_paralympics"),
+                TestSpec.of(() -> faker.olympicSport().winterParalympics(), "olympic_sport.winter_paralympics"),
+                TestSpec.of(() -> faker.olympicSport().ancientOlympics(), "olympic_sport.ancient_olympics"),
+                TestSpec.of(() -> faker.olympicSport().unusual(), "olympic_sport.unusual"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/RelationshipTest.java
+++ b/src/test/java/net/datafaker/providers/base/RelationshipTest.java
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-class RelationshipTest extends BaseFakerTest<BaseFaker> {
+class RelationshipTest extends AbstractBasicProviderTest<BaseFaker> {
 
     private BaseFaker mockFaker;
 
@@ -26,34 +28,14 @@ class RelationshipTest extends BaseFakerTest<BaseFaker> {
         assertThat(faker.relationships().any()).isNotEmpty();
     }
 
-    @Test
-    void directTest() {
-        assertThat(faker.relationships().direct()).isNotEmpty();
-    }
-
-    @Test
-    void extendedTest() {
-        assertThat(faker.relationships().extended()).isNotEmpty();
-    }
-
-    @Test
-    void inLawTest() {
-        assertThat(faker.relationships().inLaw()).isNotEmpty();
-    }
-
-    @Test
-    void spouseTest() {
-        assertThat(faker.relationships().spouse()).isNotEmpty();
-    }
-
-    @Test
-    void parentTest() {
-        assertThat(faker.relationships().parent()).isNotEmpty();
-    }
-
-    @Test
-    void siblingTest() {
-        assertThat(faker.relationships().sibling()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.relationships().direct(), "relationship.familial.direct"),
+                TestSpec.of(() -> faker.relationships().extended(), "relationship.familial.extended"),
+                TestSpec.of(() -> faker.relationships().inLaw(), "relationship.in_law"),
+                TestSpec.of(() -> faker.relationships().spouse(), "relationship.spouse"),
+                TestSpec.of(() -> faker.relationships().parent(), "relationship.parent"),
+                TestSpec.of(() -> faker.relationships().sibling(), "relationship.sibling"));
     }
 
     @Test

--- a/src/test/java/net/datafaker/providers/base/RestaurantTest.java
+++ b/src/test/java/net/datafaker/providers/base/RestaurantTest.java
@@ -1,12 +1,20 @@
 package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RestaurantTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
 
+class RestaurantTest extends AbstractBasicProviderTest<BaseFaker> {
+
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.restaurant().nameSuffix(), "restaurant.name_suffix"),
+                TestSpec.of(() -> faker.restaurant().type(), "restaurant.type"),
+                TestSpec.of(() -> faker.restaurant().description(), "restaurant.description"),
+                TestSpec.of(() -> faker.restaurant().review(), "restaurant.review"));
+    }
     @RepeatedTest(100)
     void namePrefix() {
         assertThat(faker.restaurant().namePrefix())
@@ -15,32 +23,12 @@ class RestaurantTest extends BaseFakerTest<BaseFaker> {
             .matches("[A-Z0-9].*");   // and that bothify only uses uppercase characters
     }
 
-    @Test
-    void nameSuffix() {
-        assertThat(faker.restaurant().nameSuffix()).isNotEmpty();
-    }
-
     @RepeatedTest(100)
     void name() {
         assertThat(faker.restaurant().name())
             .isNotEmpty()
             .doesNotContain("#", "?") // make sure bothify is applied
             .matches("[A-Z0-9].*");   // and that bothify only uses uppercase characters
-    }
-
-    @Test
-    void type() {
-        assertThat(faker.restaurant().type()).isNotEmpty();
-    }
-
-    @Test
-    void description() {
-        assertThat(faker.restaurant().description()).isNotEmpty();
-    }
-
-    @Test
-    void review() {
-        assertThat(faker.restaurant().review()).isNotEmpty();
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/ScienceTest.java
+++ b/src/test/java/net/datafaker/providers/base/ScienceTest.java
@@ -1,12 +1,18 @@
 package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ScienceTest extends BaseFakerTest<BaseFaker> {
+import java.util.Arrays;
+import java.util.Collection;
 
+class ScienceTest extends AbstractBasicProviderTest<BaseFaker> {
+
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.science().unit(), "science.unit"));
+    }
     @RepeatedTest(10)
     void element() {
         assertThat(faker.science().element()).matches("[A-Za-z ]+");
@@ -20,11 +26,6 @@ class ScienceTest extends BaseFakerTest<BaseFaker> {
     @RepeatedTest(10)
     void scientist() {
         assertThat(faker.science().scientist()).matches("[A-Za-z. -]+");
-    }
-
-    @Test
-    void testUnit() {
-        assertThat(faker.science().unit()).isNotEmpty();
     }
 
     @RepeatedTest(10)

--- a/src/test/java/net/datafaker/providers/base/StockTest.java
+++ b/src/test/java/net/datafaker/providers/base/StockTest.java
@@ -1,19 +1,14 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class StockTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class StockTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void testNasdaq() {
-        assertThat(faker.stock().nsdqSymbol()).isNotEmpty();
-    }
-
-    @Test
-    void testNYSE() {
-        assertThat(faker.stock().nyseSymbol()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.stock().nsdqSymbol(), "stock.symbol_nsdq"),
+                TestSpec.of(() -> faker.stock().nyseSymbol(), "stock.symbol_nyse"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/SubscriptionTest.java
+++ b/src/test/java/net/datafaker/providers/base/SubscriptionTest.java
@@ -1,34 +1,17 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class SubscriptionTest extends AbstractBasicProviderTest<BaseFaker> {
 
-class SubscriptionTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void plans() {
-        assertThat(faker.subscription().plans()).isNotEmpty();
-    }
-
-    @Test
-    void statuses() {
-        assertThat(faker.subscription().statuses()).isNotEmpty();
-    }
-
-    @Test
-    void paymentMethods() {
-        assertThat(faker.subscription().paymentMethods()).isNotEmpty();
-    }
-
-    @Test
-    void subscriptionTerms() {
-        assertThat(faker.subscription().subscriptionTerms()).isNotEmpty();
-    }
-
-    @Test
-    void paymentTerms() {
-        assertThat(faker.subscription().paymentTerms()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.subscription().plans(), "subscription.plans"),
+                TestSpec.of(() -> faker.subscription().statuses(), "subscription.statuses"),
+                TestSpec.of(() -> faker.subscription().paymentMethods(), "subscription.payment_methods"),
+                TestSpec.of(() -> faker.subscription().subscriptionTerms(), "subscription.subscription_terms"),
+                TestSpec.of(() -> faker.subscription().paymentTerms(), "subscription.payment_terms"));
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/YodaTest.java
+++ b/src/test/java/net/datafaker/providers/base/YodaTest.java
@@ -1,16 +1,15 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * @author Luka Obradovic (luka@vast.com)
  */
-class YodaTest extends BaseFakerTest<BaseFaker> {
+class YodaTest extends AbstractBasicProviderTest<BaseFaker> {
 
-    @Test
-    void quote() {
-        assertThat(faker.yoda().quote()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of(() -> faker.yoda().quote(), "yoda.quotes"));
     }
 }

--- a/src/test/java/net/datafaker/providers/base/ZodiacTest.java
+++ b/src/test/java/net/datafaker/providers/base/ZodiacTest.java
@@ -1,14 +1,12 @@
 package net.datafaker.providers.base;
 
+import java.util.Arrays;
+import java.util.Collection;
 
-import org.junit.jupiter.api.Test;
+class ZodiacTest extends AbstractBasicProviderTest<BaseFaker> {
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class ZodiacTest extends BaseFakerTest<BaseFaker> {
-
-    @Test
-    void testSign() {
-        assertThat(faker.zodiac().sign()).isNotEmpty();
+    @Override
+    protected Collection<TestSpec> providerListTest() {
+        return Arrays.asList(TestSpec.of((() -> faker.zodiac().sign()), "zodiac.signs"));
     }
 }

--- a/src/test/java/net/datafaker/providers/videogame/OverwatchTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/OverwatchTest.java
@@ -1,6 +1,5 @@
-package net.datafaker.providers.base;
+package net.datafaker.providers.videogame;
 
-import net.datafaker.providers.videogame.VideoGameFakerTest;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
- AbstractBasicProviderTest > Added so that applicable tests could extend it in order to ensure that the values the providers return are actually within the expected list.
- various > Updated Unit Test classes to leverage the new abstract.
- Overwatch > moved to the videogame package.

This is in follow-up to: atafaker-net/datafaker#657.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>