### PR TITLE
Correct custom provider example

### DIFF
--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -85,7 +85,7 @@ First, create the custom provider which loads the data from a file:
     public static class InsectFromFile extends AbstractProvider<BaseProviders> {
         private static final String KEY = "insectsfromfile";
         
-        public InsectFromFile(Faker faker) {
+        public InsectFromFile(BaseProviders faker) {
             super(faker);
             faker.addPath(Locale.ENGLISH, Paths.get("src/test/ants.yml"));
             faker.addPath(Locale.ENGLISH, Paths.get("src/test/bees.yml"));

--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -24,7 +24,7 @@ Create a custom provider of data:
     public static class Insect extends AbstractProvider<BaseProviders> {
         private static final String[] INSECT_NAMES = new String[]{"Ant", "Beetle", "Butterfly", "Wasp"};
 
-        public Insect(Faker faker) {
+        public Insect(BaseProviders faker) {
             super(faker);
         }
 


### PR DESCRIPTION
It's only possible to create a custom provider with BaseProviders instead of a Faker in it's constructor.

With Faker, it gets the following error: "reason: no instance(s) of type variable(s) exist so that BaseProviders conforms to Faker"