### PR TITLE
Include XML files in .gitattributes as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 *.js     text
 *.sql    text
 *.q      text
+*.xml    text
 *.yml    text
 *.yaml   text
 


### PR DESCRIPTION
So that EOL don't accidentally get switched to CRLF (or mixed).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>