### PR TITLE
Add computer brands

### DIFF
--- a/src/main/resources/en/computer.yml
+++ b/src/main/resources/en/computer.yml
@@ -49,7 +49,10 @@ en:
         - Asus
         - Corsair
         - Dell
+        - Framework
         - Fujitsu
+        - Gateway
+        - Gigabyte
         - HP
         - Huawei
         - Lenovo


### PR DESCRIPTION
- Framework is gaining momentum (https://frame.work/)
- Gateway is a long time brand (how could we forget/miss that cow pattern logo 😉 https://gatewayusa.com/)
- Gigabyte not just motherboards and components, they do have laptops and desktops https://www.gigabyte.com/

Follow-up to: datafaker-net/datafaker#654 & datafaker-net/datafaker#652

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>