### PR TITLE
implement currently passing Xlint checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,25 @@
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
+                        <compilerArgs>
+                            <arg>-Xlint:cast</arg>
+                            <arg>-Xlint:classfile</arg>
+                            <arg>-Xlint:dep-ann</arg>
+                            <arg>-Xlint:divzero</arg>
+                            <arg>-Xlint:empty</arg>
+                            <arg>-Xlint:fallthrough</arg>
+                            <arg>-Xlint:finally</arg>
+                            <arg>-Xlint:options</arg>
+                            <arg>-Xlint:overrides</arg>
+                            <arg>-Xlint:path</arg>
+                            <arg>-Xlint:processing</arg>
+                            <arg>-Xlint:rawtypes</arg>
+                            <arg>-Xlint:serial</arg>
+                            <arg>-Xlint:static</arg>
+                            <arg>-Xlint:try</arg>
+                            <arg>-Xlint:varargs</arg>
+                            <arg>-Werror</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Related to: datafaker-net/datafaker#666

It seems the only outstanding items in the project are `-Xlint:deprecation` and `-Xlint:unchecked`.

Ultimately we'll be able to replace the individual options with `Xlint:all`. But while we're building toward that we may as well prevent these from creeping in :wink:

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>