### PR TITLE
Add static builder method for json transformer

### DIFF
--- a/docs/documentation/schemas.md
+++ b/docs/documentation/schemas.md
@@ -136,7 +136,7 @@ Example of JSON generation:
             field("Bool", () -> faker.bool().bool())
         );
 
-        JsonTransformer<Object> transformer = new JsonTransformer<>();
+        JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         String json = transformer.generate(schema, 2);
     ```
 
@@ -148,7 +148,7 @@ Example of JSON generation:
             field("Bool", Supplier { faker.bool().bool() })
         )
 
-        val transformer = JsonTransformer<String>()
+        val transformer = JsonTransformer.builder().build();
         val json = transformer.generate(schema, 2)
     ```
 

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -51,7 +51,7 @@ public class FakeValuesService {
     private static final Map<Class<?>, Map<String, Collection<Method>>> CLASS_2_METHODS_CACHE = new IdentityHashMap<>();
     private static final Map<Class<?>, Constructor<?>> CLASS_2_CONSTRUCTOR_CACHE = new IdentityHashMap<>();
 
-    private static final JsonTransformer<Object> JSON_TRANSFORMER = new JsonTransformer.JsonTransformerBuilder<>().build();
+    private static final JsonTransformer<Object> JSON_TRANSFORMER = JsonTransformer.builder().build();
 
     private final Map<String, Generex> expression2generex = new WeakHashMap<>();
     private final Map<SingletonLocale, Map<String, String>> key2Expression = new IdentityHashMap<>();

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -24,6 +24,10 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
         this.commaBetweenObjects = commaBetweenObjects;
     }
 
+    public static <IN> JsonTransformer.JsonTransformerBuilder<IN> builder() {
+        return new JsonTransformer.JsonTransformerBuilder<>();
+    }
+
     @Override
     public String apply(IN input, Schema<IN, ?> schema) {
         Field<?, ?>[] fields = schema.getFields();
@@ -181,6 +185,8 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
                 wrappers = input.toCharArray();
             }
         }
+
+        private JsonTransformerBuilder() {}
 
         private FormattedAs formattedAs = FormattedAs.JSON_OBJECT;
         private boolean commaBetweenObjects = true;

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -20,7 +20,6 @@ import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.sequence.FakeSequence;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
-import net.datafaker.transformations.JsonTransformer.JsonTransformerBuilder;
 import net.datafaker.transformations.JsonTransformer.JsonTransformerBuilder.FormattedAs;
 import net.datafaker.transformations.Schema;
 import org.junit.jupiter.api.Test;
@@ -37,8 +36,7 @@ class JsonTest {
             field("Bool", () -> faker.bool().bool())
         );
 
-        JsonTransformerBuilder<Object> jsonTransformerBuilder = new JsonTransformerBuilder<>();
-        JsonTransformer<Object> transformer = jsonTransformerBuilder.build();
+        JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         String json = transformer.generate(schema, 2);
         String expected = "{" + LINE_SEPARATOR +
             "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
@@ -56,8 +54,7 @@ class JsonTest {
             field("Password", integer -> faker.internet().password(integer, integer))
         );
 
-        JsonTransformerBuilder<Integer> jsonTransformerBuilder = new JsonTransformerBuilder<>();
-        JsonTransformer<Integer> transformer = jsonTransformerBuilder.withCommaBetweenObjects(false).build();
+        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().withCommaBetweenObjects(false).build();
         FakeSequence<Integer> fakeSequence = faker.<Integer>collection()
             .suppliers(() -> faker.number().randomDigit())
             .len(5)
@@ -84,8 +81,7 @@ class JsonTest {
             field("Password", integer -> faker.internet().password(integer, integer))
         );
 
-        JsonTransformerBuilder<Integer> jsonTransformerBuilder = new JsonTransformerBuilder<>();
-        JsonTransformer<Integer> transformer = jsonTransformerBuilder.build();
+        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();
         FakeSequence<Integer> fakeSequence = faker.<Integer>collection()
             .suppliers(() -> faker.number().randomDigit())
             .len(5)
@@ -112,7 +108,7 @@ class JsonTest {
             field("Password", integer -> faker.internet().password(integer, integer))
         );
 
-        JsonTransformer<Integer> transformer = new JsonTransformer.JsonTransformerBuilder<Integer>()
+        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder()
             .formattedAs(FormattedAs.JSON_ARRAY).withCommaBetweenObjects(false).build();
         FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
             .suppliers(() -> faker.number().randomDigit())
@@ -137,7 +133,7 @@ class JsonTest {
             field("Password", integer -> faker.internet().password(integer, integer))
         );
 
-        JsonTransformer<Integer> transformer = new JsonTransformer.JsonTransformerBuilder<Integer>()
+        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder()
             .formattedAs(FormattedAs.JSON_ARRAY).build();
         FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
             .suppliers(() -> faker.number().randomDigit())
@@ -151,8 +147,7 @@ class JsonTest {
     @ParameterizedTest
     @MethodSource("generateTestSchema")
     void simpleJsonTestForJsonTransformer(Schema<String, String> schema, String expected) {
-        JsonTransformerBuilder<String> jsonTransformerBuilder = new JsonTransformerBuilder<>();
-        JsonTransformer<String> transformer = jsonTransformerBuilder.build();
+        JsonTransformer<String> transformer = JsonTransformer.<String>builder().build();
         assertThat(transformer.generate(schema, 1)).isEqualTo(expected);
     }
 
@@ -160,8 +155,7 @@ class JsonTest {
     @MethodSource("generateTestSchema")
     void outputArrayJsonTestForJsonTransformer(
         Schema<String, String> schema, String expected) {
-        JsonTransformerBuilder<String> jsonTransformerBuilder = new JsonTransformerBuilder<>();
-        JsonTransformer<String> transformer = jsonTransformerBuilder.formattedAs(FormattedAs.JSON_ARRAY).build();
+        JsonTransformer<String> transformer = JsonTransformer.<String>builder().formattedAs(FormattedAs.JSON_ARRAY).build();
 
         assertThat(transformer.generate(schema, 2).replaceAll(System.lineSeparator(), ""))
             .isEqualTo("[" + expected + "," + expected + "]");
@@ -171,8 +165,7 @@ class JsonTest {
     @MethodSource("generateTestSchema")
     void outputWithoutCommaForJsonTransformer(
         Schema<String, String> schema, String expected) {
-        JsonTransformerBuilder<String> jsonTransformerBuilder = new JsonTransformerBuilder<>();
-        JsonTransformer<String> transformer = jsonTransformerBuilder.withCommaBetweenObjects(false).build();
+        JsonTransformer<String> transformer = JsonTransformer.<String>builder().withCommaBetweenObjects(false).build();
 
         assertThat(transformer.generate(schema, 2).replaceAll(System.lineSeparator(), ""))
             .isEqualTo("{" + expected +  expected + "}");

--- a/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
@@ -211,8 +211,7 @@ class FakeCollectionTest extends AbstractFakerTest {
     void toJson() {
         int limit = 10;
 
-        JsonTransformer.JsonTransformerBuilder<Data> jsonTransformerBuilder = new JsonTransformer.JsonTransformerBuilder<>();
-        JsonTransformer<Data> transformer = jsonTransformerBuilder.build();
+        JsonTransformer<Data> transformer = JsonTransformer.<Data>builder().build();
 
         String json = transformer.generate(
             faker.<Data>collection().minLen(limit).maxLen(limit)

--- a/src/test/java/net/datafaker/sequence/FakeStreamTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeStreamTest.java
@@ -256,8 +256,7 @@ class FakeStreamTest extends AbstractFakerTest {
             .suppliers(BloodPressure::new, Glucose::new, Temperature::new)
             .build();
 
-        JsonTransformer.JsonTransformerBuilder<Data> jsonTransformerBuilder = new JsonTransformer.JsonTransformerBuilder<>();
-        JsonTransformer<Data> transformer = jsonTransformerBuilder.build();
+        JsonTransformer<Data> transformer = JsonTransformer.<Data>builder().build();
 
         String json = transformer.generate(stream, Schema.of(
             field("name", Data::name),


### PR DESCRIPTION
Simplify invocation of json transformer builder in the same way like it is already done for sql transformer:
static builder method