### PR TITLE
Support list of objects for JSON

### DIFF
--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -39,7 +39,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             if (fields[i] instanceof CompositeField) {
                 sb.append(apply(input, (CompositeField) fields[i], i));
             } else {
-                applyValue(input, sb, fields[i]);
+                applyValue(input, sb, ((SimpleField) fields[i]).transform(input));
             }
             if (i < fields.length - 1) {
                 sb.append(", ");
@@ -77,8 +77,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
         return limit > 1 ? wrappers[0] + LINE_SEPARATOR + sb + LINE_SEPARATOR + wrappers[1] : sb.toString();
     }
 
-    private void applyValue(IN input, StringBuilder sb, Field<?, ?> fields) {
-        Object value = ((SimpleField) fields).transform(input);
+    private void applyValue(IN input, StringBuilder sb, Object value) {
         if (value instanceof Collection<?>) {
             sb.append(generate(input,(Collection) value));
         } else if (value != null && value.getClass().isArray()) {
@@ -100,7 +99,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             if (value instanceof CompositeField<?,?>) {
                 sb.append(apply(input,((CompositeField) value)));
             } else {
-                value2String(value, sb);
+                applyValue(input, sb, value);
             }
         }
         sb.append("]");

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -12,11 +12,13 @@ import java.math.BigDecimal;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import net.datafaker.providers.base.BaseFaker;
+import net.datafaker.providers.base.Name;
 import net.datafaker.sequence.FakeSequence;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
@@ -253,6 +255,60 @@ class JsonTest {
                     entry(() -> "key", () -> "value"),
                     entry(() -> "nested", () -> map(entry(() -> "nestedkey", () -> "nestedvalue")))),
                 "{\"key\": \"value\", \"nested\": {\"nestedkey\": \"nestedvalue\"}}"));
+    }
+
+    @Test
+    void jsonWithDifferentFieldFormatsInOneObjectTest() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        final int limit = 2;
+        JsonTransformer<Object> transformer = JsonTransformer.builder().build();
+
+        String json = transformer.generate(
+            faker.collection().minLen(limit).maxLen(limit)
+                .suppliers(faker::name)
+                .build(), Schema.<Object, Object>of(
+                field("text", () -> faker.name().firstName()),
+                field("array", () ->
+                    faker
+                        .collection()
+                        .suppliers(() -> faker.phoneNumber().phoneNumber())
+                        .maxLen(3)
+                        .generate()
+                )
+            ));
+
+        int numberOfLines = 0;
+        for (int i = 0; i < json.length(); i++) {
+            if (json.regionMatches(i, "},", 0, "},".length())) {
+                numberOfLines++;
+            }
+        }
+        assertThat(numberOfLines).isEqualTo(limit - 1);
+    }
+
+    @Test
+    void jsonObjectCollectionTest() {
+        JsonTransformer<Name> transformer = JsonTransformer.<Name>builder().build();
+
+        String json = transformer.generate(
+            Schema.of(
+                field("text", () -> "Mrs. Brian Braun"),
+                field("objectCollection", () -> List.of(
+                    compositeField(null, new Field[]{
+                            field("country", () -> "Denmark"),
+                            field("city", () -> "Port Angel")
+                        }
+                    ),
+                    compositeField(null, new Field[]{
+                            field("two", () -> "Denmark"),
+                            field("one", () -> "Port Angel")
+                        }
+                    )
+                    )
+                )
+            ), 1);
+        assertThat(json).isEqualTo("{\"text\": \"Mrs. Brian Braun\", " +
+            "\"objectCollection\": [{\"country\": \"Denmark\", \"city\": \"Port Angel\"}, {\"two\": \"Denmark\", \"one\": \"Port Angel\"}]}");
     }
 
     private static Map.Entry<Supplier<String>, Supplier<Object>> entry(

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -311,6 +311,35 @@ class JsonTest {
             "\"objectCollection\": [{\"country\": \"Denmark\", \"city\": \"Port Angel\"}, {\"two\": \"Denmark\", \"one\": \"Port Angel\"}]}");
     }
 
+    @Test
+    void jsonCollectionOfCollectionsTest() {
+        JsonTransformer<Name> transformer = JsonTransformer.<Name>builder().build();
+
+        String json = transformer.generate(
+            Schema.of(
+                field("text", () -> "Mrs. Brian Braun"),
+                field("objectCollection", () -> List.of(
+                        List.of(
+                            List.of(
+                                compositeField(null, new Field[]{
+                                        field("country", () -> "Denmark"),
+                                        field("city", () -> "Port Angel")
+                                    }
+                                ),
+                                compositeField(null, new Field[]{
+                                        field("two", () -> "Denmark"),
+                                        field("one", () -> "Port Angel")
+                                    }
+                                )
+                            )
+                        )
+                    )
+                )
+            ), 1);
+        assertThat(json).isEqualTo("{\"text\": \"Mrs. Brian Braun\", " +
+            "\"objectCollection\": [[[{\"country\": \"Denmark\", \"city\": \"Port Angel\"}, {\"two\": \"Denmark\", \"one\": \"Port Angel\"}]]]}");
+    }
+
     private static Map.Entry<Supplier<String>, Supplier<Object>> entry(
         Supplier<String> key, Supplier<Object> value) {
         return new AbstractMap.SimpleEntry<>(key, value);


### PR DESCRIPTION
PR adds object list support for JSON.
An example of usage

 ```
JsonTransformer.<Name>builder().build().generate(
            Schema.of(
                field("text", () -> "Mrs. Brian Braun"),
                field("objectCollection", () -> List.of(
                        compositeField(null, new Field[]{
                                field("country", () -> "Denmark"),
                                field("city", () -> "Port Angel")
                            }
                        )
                    )
                )
            ), 1);
```

Result:
```
{"text": "Mrs. Brian Braun", "objectCollection": [{"country": "Denmark", "city": "Port Angel"}]}
```