### PR TITLE
refactor: Secure the use of SnakeYAML's constructor

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -2,6 +2,7 @@ package net.datafaker.service;
 
 import net.datafaker.internal.helper.SingletonLocale;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -198,7 +199,7 @@ public class FakeValues implements FakeValuesInterface {
 
     private Map<String, Object> readFromStream(InputStream stream) {
         if (stream == null) return null;
-        final Map<String, Object> valuesMap = new Yaml().loadAs(stream, Map.class);
+        final Map<String, Object> valuesMap = new Yaml(new SafeConstructor()).loadAs(stream, Map.class);
         Map<String, Object> localeBased = (Map<String, Object>) valuesMap.get(sLocale.getLocale().getLanguage());
         if (localeBased == null) {
             localeBased = (Map<String, Object>) valuesMap.get(filename);

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -3,6 +3,7 @@ package net.datafaker.script;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -34,7 +35,7 @@ class ProviderGenerator {
         System.out.println(files.length + " files");
 
         for (File file : filesToProcess) {
-            final Map<String, Object> valuesMap = new Yaml().loadAs(new FileReader(file), Map.class);
+            final Map<String, Object> valuesMap = new Yaml(new SafeConstructor()).loadAs(new FileReader(file), Map.class);
 
             Map<String, Object> en = (Map<String, Object>) valuesMap.get("en");
             Map<String, Object> faker = (Map<String, Object>) en.get("faker");


### PR DESCRIPTION
Based on [Secure the use of SnakeYAML's constructor](https://docs.openrewrite.org/reference/recipes/java/security/marshalling/securesnakeyamlconstructor).