### PR TITLE
OscarMovie should store rules to access data but not the actual field names

### DIFF
--- a/src/main/java/net/datafaker/providers/entertainment/OscarMovie.java
+++ b/src/main/java/net/datafaker/providers/entertainment/OscarMovie.java
@@ -2,6 +2,8 @@ package net.datafaker.providers.entertainment;
 
 import net.datafaker.providers.base.AbstractProvider;
 
+import java.util.function.Supplier;
+
 /**
  * The Academy Awards, popularly known as the Oscars, are awards for artistic and technical merit in the film industry.
  *
@@ -10,10 +12,10 @@ import net.datafaker.providers.base.AbstractProvider;
  */
 public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
 
-    private final String year;
-    private final String choice;
+    private final Supplier<String> year;
+    private final Supplier<String> choice;
 
-    private final String str;
+    private final Supplier<String> str;
 
     /**
      * This is the constructor initialize faker and two other
@@ -23,23 +25,23 @@ public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
      */
     protected OscarMovie(final EntertainmentProviders faker) {
         super(faker);
-        this.year = this.faker.resolve("oscar_movie.year.years");
-        this.choice = this.faker.resolve("oscar_movie.year.choice");
-        this.str = "oscar_movie.".concat(year).concat(".").concat(choice);
+        this.year = () -> this.faker.resolve("oscar_movie.year.years");
+        this.choice = () -> this.faker.resolve("oscar_movie.year.choice");
+        this.str = () -> "oscar_movie.".concat(year.get()).concat(".").concat(choice.get());
     }
 
     /**
      * @return year
      */
     public String getYear() {
-        return year;
+        return year.get();
     }
 
     /**
      * @return choice
      */
     public String getChoice() {
-        return choice;
+        return choice.get();
     }
 
     /**
@@ -48,7 +50,7 @@ public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
      * @return random actor
      */
     public String actor() {
-        return resolve(str.concat(".actor"));
+        return resolve(str.get().concat(".actor"));
     }
 
     /**
@@ -57,7 +59,7 @@ public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
      * @return random movieName
      */
     public String movieName() {
-        return resolve(str.concat(".movieName"));
+        return resolve(str.get().concat(".movieName"));
     }
 
     /**
@@ -66,7 +68,7 @@ public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
      * @return random quote
      */
     public String quote() {
-        return resolve(str.concat(".quote"));
+        return resolve(str.get().concat(".quote"));
     }
 
     /**
@@ -75,7 +77,7 @@ public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
      * @return random character
      */
     public String character() {
-        return resolve(str.concat(".character"));
+        return resolve(str.get().concat(".character"));
     }
 
     /**
@@ -84,6 +86,6 @@ public class OscarMovie extends AbstractProvider<EntertainmentProviders> {
      * @return random releaseDate
      */
     public String releaseDate() {
-        return resolve(str.concat(".releaseDate"));
+        return resolve(str.get().concat(".releaseDate"));
     }
 }

--- a/src/test/java/net/datafaker/providers/entertainment/OscarMovieTest.java
+++ b/src/test/java/net/datafaker/providers/entertainment/OscarMovieTest.java
@@ -1,6 +1,14 @@
 package net.datafaker.providers.entertainment;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Strings.isNullOrEmpty;
@@ -32,5 +40,30 @@ class OscarMovieTest extends EntertainmentFakerTest {
     @RepeatedTest(100)
     void releaseDate() {
         assertThat(oscarMovie.releaseDate()).matches("[A-Za-z,0-9 ]+");
+    }
+
+    /**
+     * Test for <a href="https://github.com/datafaker-net/datafaker/issues/741">issue741</a>
+     */
+    @ParameterizedTest
+    @MethodSource("argsProvider")
+    void issue741(Function<OscarMovie, String> f) {
+        final OscarMovie oscarMovie = faker.oscarMovie();
+        assertThat(
+            faker.stream(() -> f.apply(oscarMovie)).len(10).build()
+                .<Stream<?>>get().collect(Collectors.toSet()))
+            .hasSizeGreaterThan(1);
+    }
+
+    static Collection<Function<OscarMovie, String>> argsProvider() {
+        return List.of(
+            OscarMovie::actor,
+            OscarMovie::character,
+            OscarMovie::getChoice,
+            OscarMovie::getYear,
+            OscarMovie::movieName,
+            OscarMovie::quote,
+            OscarMovie::releaseDate
+        );
     }
 }


### PR DESCRIPTION
The issue is that `OscarMovie` stores field names in `year`, `choice`, `str` which are used to find out the next result. 
Providers should not do that, so just replace it with suppliers storing only the rules how to get such data but not the actual field names

fixes #741 