### PR TITLE
Introduce FakeValuesContext and FAKE_VALUES_MAP

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesContext.java
+++ b/src/main/java/net/datafaker/service/FakeValuesContext.java
@@ -1,0 +1,110 @@
+package net.datafaker.service;
+
+import net.datafaker.internal.helper.SingletonLocale;
+
+import java.net.URL;
+import java.util.Locale;
+import java.util.Objects;
+
+class FakeValuesContext {
+    private final SingletonLocale sLocale;
+    private final String filename;
+    private String path;
+    private final URL url;
+
+    private FakeValuesContext(Locale locale) {
+        this(locale, getFilename(locale), getFilename(locale), null);
+    }
+
+    private FakeValuesContext(Locale locale, URL url) {
+        this(locale, getFilename(locale), null, url);
+    }
+
+    private FakeValuesContext(Locale locale, String filename, String path) {
+        this(locale, filename, path, null);
+    }
+
+    private FakeValuesContext(Locale locale, String filename, String path, URL url) {
+        this.sLocale = SingletonLocale.get(locale);
+        this.filename = filename;
+        this.path = path;
+        this.url = url;
+    }
+
+    public static FakeValuesContext of(Locale locale) {
+        return new FakeValuesContext(locale);
+    }
+
+    public static FakeValuesContext of(Locale locale, URL url) {
+        return new FakeValuesContext(locale, url);
+    }
+
+    public static FakeValuesContext of(Locale locale, String filename, String path) {
+        return new FakeValuesContext(locale, filename, path);
+    }
+
+    public static FakeValuesContext of(Locale locale, String filename, String path, URL url) {
+        return new FakeValuesContext(locale, filename, path, url);
+    }
+
+    private static String getFilename(Locale locale) {
+        final String lang = language(locale);
+        if ("".equals(locale.getCountry())) {
+            return lang;
+        }
+        return lang + "-" + locale.getCountry();
+    }
+
+    /**
+     * If you new up a locale with "he", it gets converted to "iw" which is old.
+     * This addresses that unfortunate condition.
+     */
+    private static String language(Locale l) {
+        if (l.getLanguage().equals("iw")) {
+            return "he";
+        }
+        return l.getLanguage();
+    }
+
+    public Locale getLocale() {
+        return sLocale.getLocale();
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FakeValuesContext that)) return false;
+        return sLocale == that.sLocale && Objects.equals(filename, that.filename) && Objects.equals(path, that.path) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sLocale, filename, path, url);
+    }
+
+    @Override
+    public String toString() {
+        return "FakeValuesContext{" +
+            "sLocale=" + sLocale +
+            ", filename='" + filename + '\'' +
+            ", path='" + path + '\'' +
+            ", url=" + url +
+            '}';
+    }
+}

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -15,7 +15,7 @@ public class FakeValuesGrouping implements FakeValuesInterface {
 
     static {
         for (EnFile file : EnFile.getFiles()) {
-            ENGLISH_FAKE_VALUE_GROUPING.add(new FakeValues(Locale.ENGLISH, file.getFile(), file.getPath()));
+            ENGLISH_FAKE_VALUE_GROUPING.add(FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, file.getFile(), file.getPath())));
         }
     }
 

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -82,7 +82,8 @@ public class FakeValuesService {
         if (DEFAULT_LOCALE == locale) {
             return FakeValuesGrouping.getEnglishFakeValueGrouping();
         }
-        return new FakeValues(locale.getLocale());
+
+        return FakeValues.of(FakeValuesContext.of(locale.getLocale()));
     }
 
     /**
@@ -116,7 +117,7 @@ public class FakeValuesService {
         if (url == null) {
             throw new IllegalArgumentException("url should be an existing readable file");
         }
-        FakeValues fakeValues = new FakeValues(locale, url);
+        FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(locale, url));
         SingletonLocale sLocale = SingletonLocale.get(locale);
         FakeValuesInterface existingFakeValues = fakeValuesInterfaceMap.get(sLocale);
         if (existingFakeValues == null) {

--- a/src/test/java/net/datafaker/service/FakeValuesGroupingTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesGroupingTest.java
@@ -15,7 +15,7 @@ class FakeValuesGroupingTest {
     @BeforeEach
     void before() {
         fakeValuesGrouping = new FakeValuesGrouping();
-        addressValues = new FakeValues(Locale.ENGLISH, "address.yml", "address");
+        addressValues = FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "address.yml", "address"));
         fakeValuesGrouping.add(addressValues);
     }
 
@@ -27,7 +27,7 @@ class FakeValuesGroupingTest {
 
     @Test
     void handlesMultipleFakeValues() {
-        FakeValues catValues = new FakeValues(Locale.ENGLISH, "cat.yml", "creature");
+        FakeValues catValues = FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "cat.yml", "creature"));
         fakeValuesGrouping.add(catValues);
 
         assertThat(fakeValuesGrouping.get("address")).isEqualTo(addressValues.get("address"))

--- a/src/test/java/net/datafaker/service/FakeValuesTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesTest.java
@@ -22,7 +22,7 @@ class FakeValuesTest {
 
     @BeforeEach
     void before() {
-        fakeValues = new FakeValues(Locale.ENGLISH, "address.yml", PATH);
+        fakeValues = FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "address.yml", PATH));
     }
 
 /*
@@ -84,37 +84,37 @@ class FakeValuesTest {
 
     @Test
     void getAValueWithANonEnglishFile() {
-        FakeValues frenchFakeValues = new FakeValues(Locale.FRENCH);
+        FakeValues frenchFakeValues = FakeValues.of(FakeValuesContext.of(Locale.FRENCH));
         assertThat(frenchFakeValues.get(PATH)).isNotNull();
     }
 
     @Test
     void getAValueForHebrewLocale() {
-        FakeValues hebrew = new FakeValues(new Locale("iw"));
+        FakeValues hebrew = FakeValues.of(FakeValuesContext.of(new Locale("iw")));
         assertThat(hebrew.get(PATH)).isNotNull();
     }
 
     @Test
     void correctPathForHebrewLanguage() {
-        FakeValues hebrew = new FakeValues(new Locale("iw"));
+        FakeValues hebrew = FakeValues.of(FakeValuesContext.of(new Locale("iw")));
         assertThat(hebrew.getPath()).isEqualTo("he");
     }
 
     @Test
     void incorrectPathForHebrewLanguage() {
-        FakeValues hebrew = new FakeValues(new Locale("iw"));
+        FakeValues hebrew = FakeValues.of(FakeValuesContext.of(new Locale("iw")));
         assertThat(hebrew.getPath()).isNotEqualTo("iw");
     }
 
     @Test
     void correctLocale() {
-        FakeValues fv = new FakeValues(new Locale("uk"));
+        FakeValues fv = FakeValues.of(FakeValuesContext.of(new Locale("uk")));
         assertThat(fv.getLocale()).isEqualTo(new Locale("uk"));
     }
 
     @Test
     void getAValueFromALocaleThatCantBeLoaded() {
-        FakeValues fakeValues = new FakeValues(new Locale("nothing"));
+        FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(new Locale("nothing")));
         assertThat(fakeValues.get(PATH)).isNull();
     }
 
@@ -131,15 +131,15 @@ class FakeValuesTest {
     static Stream<Arguments> fakeValuesProvider() throws MalformedURLException {
         Path tmp = Paths.get("tmp");
         return Stream.of(
-            of(new FakeValues(Locale.CANADA), new FakeValues(Locale.CANADA), true),
-            of(null, new FakeValues(Locale.CANADA), false),
-            of(new FakeValues(Locale.CANADA), null, false),
-            of(new FakeValues(Locale.CANADA), null, false),
-            of(new FakeValues(Locale.ENGLISH), new FakeValues(Locale.ENGLISH, "filepath", "path"), false),
-            of(new FakeValues(Locale.ENGLISH, "filepath", null), new FakeValues(Locale.ENGLISH, "filepath", "path"), false),
-            of(new FakeValues(Locale.ENGLISH, "filepath", "path"), new FakeValues(Locale.ENGLISH, "filepath", "path"), true),
-            of(new FakeValues(Locale.ENGLISH, "filepath", "path", tmp.toUri().toURL()), new FakeValues(Locale.ENGLISH, "filepath", "path", tmp.toUri().toURL()), true),
-            of(new FakeValues(Locale.ENGLISH, "filepath", "path", Paths.get("tmp2").toUri().toURL()), new FakeValues(Locale.ENGLISH, "filepath", "path", tmp.toUri().toURL()), false)
+            of(FakeValues.of(FakeValuesContext.of(Locale.CANADA)), FakeValues.of(FakeValuesContext.of(Locale.CANADA)), true),
+            of(null, FakeValues.of(FakeValuesContext.of(Locale.CANADA)), false),
+            of(FakeValues.of(FakeValuesContext.of(Locale.CANADA)), null, false),
+            of(FakeValues.of(FakeValuesContext.of(Locale.CANADA)), null, false),
+            of(FakeValues.of(FakeValuesContext.of(Locale.ENGLISH)), FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path")), false),
+            of(FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", null)), FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path")), false),
+            of(FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path")), FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path")), true),
+            of(FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path", tmp.toUri().toURL())), FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path", tmp.toUri().toURL())), true),
+            of(FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path", Paths.get("tmp2").toUri().toURL())), FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "filepath", "path", tmp.toUri().toURL())), false)
         );
     }
 }


### PR DESCRIPTION
The idea behind this PR is to init FakeValues only once per FakeValuesContext (determined by locale, path, url, filename),
right now it generates new FakeValues each time if it is not a default locale

It will allow to reduce GC/memory cost.

Also it was mentioned at #759 at these comments https://github.com/datafaker-net/datafaker/issues/759#issuecomment-1507346220 and https://github.com/datafaker-net/datafaker/issues/759#issuecomment-1507959256

The best benchmark illustrating improvement is time consumed for build (since junit5 tests in datafaker are running in concurrent mode)
e.g. here for this PR for ubuntu jdk17 it took 1 min, 0 sec[1] vs 1min 18 sec for the latest main[2]
same for jdk20 this PR [3] took 57 sec vs 1 min 14 sec for the latest main [4]
also locally `mvn clean verify` is about 10-15% faster

[1] https://github.com/datafaker-net/datafaker/actions/runs/4707215086/jobs/8348951734?pr=767#step:4:966
[2] https://github.com/datafaker-net/datafaker/actions/runs/4700592603/jobs/8335491257#step:4:967
[3] https://github.com/datafaker-net/datafaker/actions/runs/4707215086/jobs/8348951927?pr=767#step:4:970
[4] https://github.com/datafaker-net/datafaker/actions/runs/4700592603/jobs/8335491891#step:4:969