### PR TITLE
BaseFakerTest - Assert that provider lists should not have blank entries

### DIFF
--- a/src/test/java/net/datafaker/providers/base/BaseFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/BaseFakerTest.java
@@ -69,8 +69,10 @@ public class BaseFakerTest<T extends BaseFaker> {
         String item = (String) testSpec.supplier.get();
         // Then
         assertThat(item).as("Check item isn't empty").isNotEmpty();
-        assertThat(actual).as("Check actual list isn't empty and contains the item for the key \"" + testSpec.key + "\"").isNotEmpty()
+        String collection = "\"" + testSpec.key + "\"";
+        assertThat(actual).as("Check actual list isn't empty and contains the item for the key " + collection).isNotEmpty()
             .anyMatch(item::equals);
+        assertThat(actual).as("Actual should not have empty entries. " + collection).noneMatch(single -> single.isBlank());
         if (!testSpec.regex.isEmpty()) {
             assertThat(item).as("Check item matches regex").matches(Pattern.compile(testSpec.regex));
         }


### PR DESCRIPTION
As discussed in: https://github.com/datafaker-net/datafaker/pull/762

Tested with entries such as:
`""` (empty)
`" "` (space)
`"	"` (tab)
`"\n"` (new line literal)