### PR TITLE
[Backport to 1.x] Add annotation support for data classes based on JavaObjectTransformer

### DIFF
--- a/docs/documentation/schemas.md
+++ b/docs/documentation/schemas.md
@@ -514,3 +514,148 @@ Executing the above will result in:
     </person>
 </persons>
 ```
+
+## Java Object transformation
+
+Java Object transformer could be built with help of JavaObjectTransformer. 
+
+When building JavaObjectTransformer you should provide a class to be used as a template for generated objects.
+=== "Java"
+
+    ``` java
+
+        public static class Person {
+           private String firstName;
+           private String lastName;
+           private Date birthDate;
+           private int id;
+        }
+    ```
+=== "Kotlin"
+
+    ``` kotlin
+
+        data class Person(
+            var firstName: String,
+            var lastName: String,
+            var birthDate: Date,
+            var id: Int
+        )
+    ```
+
+Then you should provide a schema for the class.
+
+=== "Java"
+
+    ``` java
+
+        JavaObjectTransformer jTransformer = new JavaObjectTransformer();
+        Schema<Object, ?> schema = Schema.of(
+            field("firstName", () -> faker.name().firstName()),
+            field("lastName", () -> faker.name().lastName()),
+            field("birthDate", () -> faker.date().birthday()),
+            field("id", () -> faker.number().positive()));
+
+        System.out.println(jTransformer.apply(Person.class, schema));
+    ```
+
+=== "Kotlin"
+
+    ``` kotlin
+
+        val jTransformer = JavaObjectTransformer()
+        val schema: Schema<Any, Any> = Schema.of(
+            field("firstName", Supplier { faker.name().firstName() }),
+            field("lastName", Supplier { faker.name().lastName() }),
+            field("birthDate", Supplier { faker.date().birthday() }),
+            field("id", Supplier { faker.number().positive() }))
+
+        println(jTransformer.apply(Person::class.java, schema))
+    ```
+
+will generate object with fields populated with random values based on specified suppliers.
+
+### Populating Java Object with predefined Schema
+
+You can use predefined schema to populate Java Object or default schema for the class.
+Schema should be declared as a static method with return type `Schema<Object, ?>`.
+
+=== "Java"
+
+    ```java
+          public static Schema<Object, ?> defaultSchema() {
+            var faker = new Faker(Locale.forLanguageTag("fr-en"), new RandomService(new Random(1)));
+            return Schema.of(field("name", () -> faker.name().fullName()));
+          }
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+        fun defaultSchema(): Schema<Any, Any> {
+            val faker = Faker(Locale.forLanguageTag("fr-en"), RandomService(Random(1)))
+            return Schema.of(field("name", Supplier { faker.name().fullName() }))
+        }
+    ```
+
+Then you should provide a class to be used as a template for generated objects. Class should be annotated with `@FakeForSchema` annotation with path to the schema method as a value.
+
+> Note: If default schema and class template are in the same class, you can omit full path to the method and use only method name.
+ 
+=== "Java"
+
+    ```java
+        @FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
+        public class Person {
+            private String fullName;
+        
+            public String getFullName() {
+                return fullName;
+            }
+        
+            public void setFullName(String fullName) {
+                this.fullName = fullName;
+            }
+        }
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+        @FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
+        data class Person(
+            var fullName: String
+        )
+    ```
+
+Then you can use `net.datafaker.providers.base.BaseFaker.populate(java.lang.Class<T>)` to populate object with default predefined schema.
+
+=== "Java"
+
+    ```java
+        BaseFaker faker = new BaseFaker();
+        Person person = faker.populate(Person.class);
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+        val faker = BaseFaker()
+        val person = faker.populate(Person::class.java)
+    ```
+
+Or you can use `net.datafaker.providers.base.BaseFaker.populate(java.lang.Class<T>, net.datafaker.schema.Schema<java.lang.Object, ?>)` to populate object with custom schema.
+
+=== "Java"
+
+    ```java
+        BaseFaker faker = new BaseFaker();
+        Person person = faker.populate(Person.class, Schema.of(field("name", () -> faker.superhero().name())));
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+        val faker = BaseFaker()
+        val person = faker.populate(Person::class.java, Schema.of(field("name", Supplier { faker.superhero().name() })))
+    ```

--- a/src/main/java/net/datafaker/annotations/FakeForSchema.java
+++ b/src/main/java/net/datafaker/annotations/FakeForSchema.java
@@ -1,0 +1,16 @@
+package net.datafaker.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation specifies the default schema used to populate an object.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FakeForSchema {
+
+    String[] value() default {""};
+}

--- a/src/main/java/net/datafaker/annotations/FakeResolver.java
+++ b/src/main/java/net/datafaker/annotations/FakeResolver.java
@@ -1,0 +1,61 @@
+package net.datafaker.annotations;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import net.datafaker.transformations.JavaObjectTransformer;
+import net.datafaker.transformations.Schema;
+
+public class FakeResolver<T> {
+
+    private final Class<T> clazz;
+
+    public FakeResolver(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    public T generate(Schema<Object, ?> schema) {
+        checkFakeAnnotation(clazz);
+
+        FakeForSchema fakeForSchemaAnnotation = clazz.getAnnotation(FakeForSchema.class);
+        Schema<Object, ?> useSchema = getSchema(schema, fakeForSchemaAnnotation.value());
+
+        JavaObjectTransformer jTransformer = new JavaObjectTransformer();
+        return (T) jTransformer.apply(clazz, useSchema);
+    }
+
+    private Schema<Object, ?> getSchema(Schema<Object, ?> schema, String[] pathToSchema) {
+        if (schema != null) {
+            return schema;
+        } else if (pathToSchema.length != 0) {
+            try {
+                final int sharpIndex = pathToSchema[0].indexOf('#');
+                final Class<?> classToCall;
+                final String methodName;
+                if (sharpIndex >= 0) {
+                    classToCall = Class.forName(pathToSchema[0].substring(0, sharpIndex));
+                    methodName = pathToSchema[0].substring(sharpIndex + 1);
+                } else {
+                    classToCall = this.clazz.getEnclosingClass();
+                    methodName = pathToSchema[0];
+                }
+                Method myStaticMethod = classToCall.getMethod(methodName);
+                myStaticMethod.setAccessible(true);
+                return (Schema<Object, ?>) myStaticMethod.invoke(null);
+            } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private void checkFakeAnnotation(Class<T> clazz) {
+        Objects.requireNonNull(clazz, "The class is null.");
+
+        if (!clazz.isAnnotationPresent(FakeForSchema.class)) {
+            throw new RuntimeException("The class " + clazz.getSimpleName() + " is not annotated with Fake");
+        }
+    }
+}

--- a/src/main/java/net/datafaker/providers/base/BaseFaker.java
+++ b/src/main/java/net/datafaker/providers/base/BaseFaker.java
@@ -1,11 +1,13 @@
 package net.datafaker.providers.base;
 
+import net.datafaker.annotations.FakeResolver;
 import net.datafaker.sequence.FakeCollection;
 import net.datafaker.sequence.FakeSequence;
 import net.datafaker.sequence.FakeStream;
 import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.FakerContext;
 import net.datafaker.service.RandomService;
+import net.datafaker.transformations.Schema;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -331,6 +333,16 @@ public class BaseFaker implements BaseProviders {
      */
     public void addPath(Locale locale, Path path) {
         fakeValuesService().addPath(locale, path);
+    }
+
+    public static <T> T populate(Class<T> clazz) {
+        FakeResolver fakeFactory = new FakeResolver<>(clazz);
+        return (T) fakeFactory.generate(null);
+    }
+
+    public static <T> T populate(Class<T> clazz, Schema<Object, ?> schema) {
+        FakeResolver fakeFactory = new FakeResolver<>(clazz);
+        return (T) fakeFactory.generate(schema);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/net/datafaker/annotations/FakeAnnotationTest.java
+++ b/src/test/java/net/datafaker/annotations/FakeAnnotationTest.java
@@ -1,0 +1,56 @@
+package net.datafaker.annotations;
+
+import java.util.Locale;
+import java.util.Random;
+
+import net.datafaker.Faker;
+import net.datafaker.annotations.dto.Person;
+import net.datafaker.service.RandomService;
+import net.datafaker.transformations.Schema;
+import org.junit.jupiter.api.Test;
+
+import static net.datafaker.transformations.Field.field;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FakeAnnotationTest {
+
+    @Test
+    void shouldGenerateEntityWithDefaultSchema() {
+        Person person = Faker.populate(Person.class);
+
+        assertThat(person).isNotNull();
+        assertThat(person.getName()).isEqualTo("Dr Alexis Noël");
+    }
+
+    @Test
+    void shouldGenerateEntityWithCustomSchema() {
+        Person person = Faker.populate(Person.class, customSchema());
+
+        assertThat(person).isNotNull();
+        assertThat(person.getName()).isEqualTo("Wildfire Woman");
+    }
+
+    @Test
+    void shouldGenerateEntityWithDefaultSchemaAndInDefaultSchemaInCurrentClass() {
+        DefaultPerson person = Faker.populate(DefaultPerson.class);
+
+        assertThat(person).isNotNull();
+        assertThat(person.name).isNotNull();
+    }
+
+    public static Schema<Object, ?> defaultSchema() {
+        Faker faker = new Faker(Locale.forLanguageTag("fr-en"), new RandomService(new Random(1)));
+        return Schema.of(field("name", () -> faker.name().fullName()));
+    }
+
+    public static Schema<Object, ?> customSchema() {
+        Faker faker = new Faker(Locale.forLanguageTag("de-en"), new RandomService(new Random(1)));
+        return Schema.of(field("name", () -> faker.superhero().name()));
+    }
+
+    @FakeForSchema("defaultSchema")
+    public static class DefaultPerson {
+
+        private String name;
+    }
+}

--- a/src/test/java/net/datafaker/annotations/dto/Person.java
+++ b/src/test/java/net/datafaker/annotations/dto/Person.java
@@ -1,0 +1,16 @@
+package net.datafaker.annotations.dto;
+
+import net.datafaker.annotations.FakeForSchema;
+
+@FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
+public class Person {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
This is a backport of https://github.com/datafaker-net/datafaker/pull/754
to 1.x which would be nice to have there for some projects