### PR TITLE
Introduce cache of suppliers and remove usage of Objects.hash to speed up

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -204,7 +204,7 @@ public class FakeValues implements FakeValuesInterface {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fakeValuesContext);
+        return Objects.hashCode(fakeValuesContext);
     }
 
     @Override

--- a/src/main/java/net/datafaker/service/FakeValuesContext.java
+++ b/src/main/java/net/datafaker/service/FakeValuesContext.java
@@ -89,13 +89,23 @@ class FakeValuesContext {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof FakeValuesContext that)) return false;
-        return sLocale == that.sLocale && Objects.equals(filename, that.filename) && Objects.equals(path, that.path) && Objects.equals(url, that.url);
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FakeValuesContext that = (FakeValuesContext) o;
+
+        if (!Objects.equals(sLocale, that.sLocale)) return false;
+        if (!Objects.equals(filename, that.filename)) return false;
+        if (!Objects.equals(path, that.path)) return false;
+        return Objects.equals(url, that.url);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sLocale, filename, path, url);
+        int result = sLocale != null ? sLocale.hashCode() : 0;
+        result = 31 * result + (filename != null ? filename.hashCode() : 0);
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/src/main/java/net/datafaker/service/FakeValuesContext.java
+++ b/src/main/java/net/datafaker/service/FakeValuesContext.java
@@ -2,6 +2,7 @@ package net.datafaker.service;
 
 import net.datafaker.internal.helper.SingletonLocale;
 
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
@@ -9,8 +10,10 @@ import java.util.Objects;
 class FakeValuesContext {
     private final SingletonLocale sLocale;
     private final String filename;
+    private final int filenameHashCode;
     private String path;
     private final URL url;
+    private final int urlHashCode;
 
     private FakeValuesContext(Locale locale) {
         this(locale, getFilename(locale), getFilename(locale), null);
@@ -29,6 +32,12 @@ class FakeValuesContext {
         this.filename = filename;
         this.path = path;
         this.url = url;
+        this.filenameHashCode = filename == null ? 0 : filename.hashCode();
+        try {
+            this.urlHashCode = url == null ? 0 : url.toURI().hashCode();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static FakeValuesContext of(Locale locale) {
@@ -101,10 +110,10 @@ class FakeValuesContext {
 
     @Override
     public int hashCode() {
-        int result = sLocale != null ? sLocale.hashCode() : 0;
-        result = 31 * result + (filename != null ? filename.hashCode() : 0);
-        result = 31 * result + (path != null ? path.hashCode() : 0);
-        result = 31 * result + (url != null ? url.hashCode() : 0);
+        int result = sLocale == null ? 0 : sLocale.hashCode();
+        result = 31 * result + filenameHashCode;
+        result = 31 * result + (path == null ? 0 : path.hashCode());
+        result = 31 * result + urlHashCode;
         return result;
     }
 

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -69,6 +70,7 @@ public class FakeValuesService {
 
     private static final Map<String, List<String>> EXPRESSION_2_SPLITTED = new WeakHashMap<>();
 
+    private static final Map<RegExpContext, Supplier<?>> map = new HashMap<>();
     public FakeValuesService() {
     }
 
@@ -560,15 +562,21 @@ public class FakeValuesService {
                 }
                 continue;
             }
-            int j = 0;
-            final int length = expr.length();
-            while (j < length && !Character.isWhitespace(expr.charAt(j))) j++;
-            String directive = expr.substring(0, j);
-            while (j < length && Character.isWhitespace(expr.charAt(j))) j++;
-            final String arguments = j == length ? "" : expr.substring(j);
-            final String[] args = splitArguments(arguments);
-
-            final Object resolved = resolveExpression(directive, args, current, root, context);
+            final RegExpContext regExpContext = RegExpContext.of(expr, current, root, context);
+            Supplier<?> val = map.get(regExpContext);
+            final Object resolved;
+            if (val != null) {
+                resolved = val.get();
+            } else {
+                int j = 0;
+                final int length = expr.length();
+                while (j < length && !Character.isWhitespace(expr.charAt(j))) j++;
+                String directive = expr.substring(0, j);
+                while (j < length && Character.isWhitespace(expr.charAt(j))) j++;
+                final String arguments = j == length ? "" : expr.substring(j);
+                final String[] args = splitArguments(arguments);
+                resolved = resExp(directive, args, current, root, context, regExpContext);
+            }
             if (resolved == null) {
                 throw new RuntimeException("Unable to resolve #{" + expr + "} directive for FakerContext " + context + ".");
             }
@@ -653,14 +661,36 @@ public class FakeValuesService {
      *
      * @return null if unable to resolve
      */
+
+    private Object resExp(String directive, String[] args, Object current, ProviderRegistration root, FakerContext context, RegExpContext regExpContext) {
+        Object res = resolveExpression(directive, args, current, root, context);
+        if (res instanceof CharSequence) return res;
+        if (res instanceof List) {
+            Iterator it = ((List) res).iterator();
+            while (it.hasNext()) {
+                Object supplier = it.next();
+                Object value;
+                if (supplier instanceof Supplier<?>) {
+                    value = ((Supplier<?>) supplier).get();
+                    if (value == null) {
+                        it.remove();
+                    } else {
+                        map.put(regExpContext, (Supplier<?>) supplier);
+                        return value;
+                    }
+                }
+            }
+            return null;
+        }
+        return res;
+    }
     private Object resolveExpression(String directive, String[] args, Object current, ProviderRegistration root, FakerContext context) {
-        // name.name (resolve locally)
-        // Name.first_name (resolve to faker.name().firstName())
         if (directive.isEmpty()) {
             return directive;
         }
         final int dotIndex = getDotIndex(directive);
 
+        List<Supplier<Object>> res = new ArrayList<>();
         Object resolved;
         if (args.length == 0) {
             // resolve method references on CURRENT object like #{number_between '1','10'} on Number or
@@ -669,28 +699,30 @@ public class FakeValuesService {
                 if (current instanceof AbstractProvider) {
                     final Method method = BaseFaker.getMethod((AbstractProvider<?>) current, directive);
                     if (method != null) {
-                        try {
-                            return method.invoke(current);
-                        } catch (Exception e) {
-                            throw new RuntimeException(e + " " + Arrays.toString(args));
-                        }
+                        res.add(() -> {
+                            try {
+                                return method.invoke(current);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e + " " + Arrays.toString(args));
+                            }
+                        });
+                        return res;
                     }
                 }
-                Supplier<Object> supplier = resolveFromMethodOn(current, directive, args);
-                if (supplier != null && (resolved = supplier.get()) != null) {
-                    //expression2function.put(expression, supplier);
-                    return resolved;
-                }
+                res.add(resolveFromMethodOn(current, directive, args));
             }
             if (dotIndex > 0) {
                 final AbstractProvider<?> ap = BaseFaker.getProvider(directive.substring(0, dotIndex), context);
                 final Method method = BaseFaker.getMethod(ap, directive.substring(dotIndex + 1));
                 if (method != null) {
-                    try {
-                        return method.invoke(ap);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e + " " + Arrays.toString(args));
-                    }
+                    res.add(() -> {
+                        try {
+                            return method.invoke(ap);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e + " " + Arrays.toString(args));
+                        }
+                    });
+                    return res;
                 }
             }
         }
@@ -700,29 +732,16 @@ public class FakeValuesService {
         // simple fetch of a value from the yaml file. the directive may have been mutated
         // such that if the current yml object is car: and directive is #{wheel} then
         // car.wheel will be looked up in the YAML file.
-        Supplier<Object> supplier = () -> safeFetch(simpleDirective, context, null);
-        resolved = supplier.get();
-        if (resolved != null) {
-            // expression2function.put(expression, supplier);
-            return resolved;
-        }
+        res.add(() -> safeFetch(simpleDirective, context, null));
 
         // resolve method references on faker object like #{regexify '[a-z]'}
         if (dotIndex == -1 && root != null && (current == null || root.getClass() != current.getClass())) {
-            supplier = resolveFromMethodOn(root, directive, args);
-            if (supplier != null && (resolved = supplier.get()) != null) {
-                //       expression2function.put(expression, supplier);
-                return resolved;
-            }
+            res.add(resolveFromMethodOn(root, directive, args));
         }
 
         // Resolve Faker Object method references like #{ClassName.method_name}
         if (dotIndex >= 0) {
-            supplier = resolveFakerObjectAndMethod(root, directive, dotIndex, args);
-            if (supplier != null && (resolved = supplier.get()) != null) {
-                // expression2function.put(expression, supplier);
-                return resolved;
-            }
+            res.add(resolveFakerObjectAndMethod(root, directive, dotIndex, args));
         }
 
         // last ditch effort.  Due to Ruby's dynamic nature, something like 'Address.street_title' will resolve
@@ -731,11 +750,11 @@ public class FakeValuesService {
         // did first but FIRST we change the Object reference Class.method_name with a yml style internal reference ->
         // class.method_name (lowercase)
         if (dotIndex >= 0) {
-            supplier = () -> safeFetch(javaNameToYamlName(simpleDirective), context, null);
-            resolved = supplier.get();
+            final String key = javaNameToYamlName(simpleDirective);
+            res.add(() -> safeFetch(key, context, null));
         }
 
-        return resolved;
+        return res;
     }
 
 

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -664,7 +664,12 @@ public class FakeValuesService {
 
     private Object resExp(String directive, String[] args, Object current, ProviderRegistration root, FakerContext context, RegExpContext regExpContext) {
         Object res = resolveExpression(directive, args, current, root, context);
-        if (res instanceof CharSequence) return res;
+        if (res instanceof CharSequence) {
+            if (((CharSequence) res).isEmpty()) {
+                map.put(regExpContext, () -> "");
+            }
+            return res;
+        }
         if (res instanceof List) {
             Iterator it = ((List) res).iterator();
             while (it.hasNext()) {
@@ -691,7 +696,6 @@ public class FakeValuesService {
         final int dotIndex = getDotIndex(directive);
 
         List<Supplier<Object>> res = new ArrayList<>();
-        Object resolved;
         if (args.length == 0) {
             // resolve method references on CURRENT object like #{number_between '1','10'} on Number or
             // #{ssn_valid} on IdNumber

--- a/src/main/java/net/datafaker/service/FakerContext.java
+++ b/src/main/java/net/datafaker/service/FakerContext.java
@@ -156,13 +156,18 @@ public class FakerContext {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         FakerContext that = (FakerContext) o;
-        return Objects.equals(sLocale, that.sLocale) && Objects.equals(randomService, that.randomService);
+
+        if (!Objects.equals(sLocale, that.sLocale)) return false;
+        return Objects.equals(randomService, that.randomService);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sLocale, randomService);
+        int result = sLocale != null ? sLocale.hashCode() : 0;
+        result = 31 * result + (randomService != null ? randomService.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/src/main/java/net/datafaker/service/RegExpContext.java
+++ b/src/main/java/net/datafaker/service/RegExpContext.java
@@ -1,0 +1,52 @@
+package net.datafaker.service;
+
+import net.datafaker.providers.base.ProviderRegistration;
+
+import java.util.Objects;
+
+public class RegExpContext {
+    private final String exp;
+    private final Object current;
+    private final ProviderRegistration root;
+    private final FakerContext context;
+
+    private RegExpContext(String exp, Object current, ProviderRegistration root, FakerContext context) {
+        this.exp = exp;
+        this.current = current;
+        this.root = root;
+        this.context = context;
+    }
+
+    public static RegExpContext of(String exp, Object current, ProviderRegistration root, FakerContext context) {
+        return new RegExpContext(exp, current, root, context);
+    }
+
+    public String getExp() {
+        return exp;
+    }
+
+    public Object getCurrent() {
+        return current;
+    }
+
+    public ProviderRegistration getRoot() {
+        return root;
+    }
+
+    public FakerContext getContext() {
+        return context;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RegExpContext that = (RegExpContext) o;
+        return Objects.equals(exp, that.exp) && Objects.equals(current, that.current) && Objects.equals(root, that.root) && Objects.equals(context, that.context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(exp, current, root, context);
+    }
+}

--- a/src/main/java/net/datafaker/service/RegExpContext.java
+++ b/src/main/java/net/datafaker/service/RegExpContext.java
@@ -41,12 +41,21 @@ public class RegExpContext {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         RegExpContext that = (RegExpContext) o;
-        return Objects.equals(exp, that.exp) && Objects.equals(current, that.current) && Objects.equals(root, that.root) && Objects.equals(context, that.context);
+
+        if (!Objects.equals(exp, that.exp)) return false;
+        if (!Objects.equals(current, that.current)) return false;
+        if (!Objects.equals(root, that.root)) return false;
+        return Objects.equals(context, that.context);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(exp, current, root, context);
+        int result = exp != null ? exp.hashCode() : 0;
+        result = 31 * result + (current != null ? current.hashCode() : 0);
+        result = 31 * result + (root != null ? root.hashCode() : 0);
+        result = 31 * result + (context != null ? context.hashCode() : 0);
+        return result;
     }
 }


### PR DESCRIPTION
The problem with `Objects.hash` is that it generates an array each time it is called.

Suppliers could be cached to avoid parsing of expressions each time

it gives speed up for a wide range of methods up to 50 %

expressions
```
before
Benchmark                        Mode  Cnt     Score     Error   Units
DatafakerExpressions.bothify    thrpt   10  5089.609 ± 112.084  ops/ms
DatafakerExpressions.letterify  thrpt   10  5706.392 ± 326.134  ops/ms
DatafakerExpressions.numerify   thrpt   10  6027.549 ±  87.064  ops/ms
DatafakerExpressions.regexify   thrpt   10  2826.806 ±  31.933  ops/ms

VS

after
Benchmark                        Mode  Cnt      Score     Error   Units
DatafakerExpressions.bothify    thrpt   10  10936.056 ±  39.143  ops/ms
DatafakerExpressions.letterify  thrpt   10  13036.411 ±  94.658  ops/ms
DatafakerExpressions.numerify   thrpt   10  13084.755 ± 423.533  ops/ms
DatafakerExpressions.regexify   thrpt   10   3541.279 ±   6.988  ops/ms
```

csv generation
```
before
Benchmark                  Mode  Cnt    Score   Error   Units
DatafakerCsvjson.csvJson  thrpt   10  301.604 ± 2.242  ops/ms

VS

after
Benchmark                  Mode  Cnt    Score    Error   Units
DatafakerCsvjson.csvJson  thrpt   10  377.927 ± 10.929  ops/ms
```


kotlin faker benchmark

```
before
Benchmark                                       Mode  Cnt    Score   Error  Units
Datafaker_KotlinFakerBenchmark.kotlinFakerTest  avgt   10  378.447 ± 1.685  ms/op

VS

after
Benchmark                                       Mode  Cnt    Score   Error  Units
Datafaker_KotlinFakerBenchmark.kotlinFakerTest  avgt   10  324.256 ± 2.438  ms/op
```

simple methods calls
```
before
Benchmark                              Mode  Cnt      Score      Error   Units
DatafakerSimpleMethods.firstname      thrpt   10   5838.567 ±  508.992  ops/ms
DatafakerSimpleMethods.fullname       thrpt   10   2429.474 ±  211.390  ops/ms
DatafakerSimpleMethods.numberBetween  thrpt   10  66001.570 ± 2144.033  ops/ms
DatafakerSimpleMethods.streetAddress  thrpt   10   1724.282 ±   62.587  ops/ms

VS

after
Benchmark                              Mode  Cnt       Score     Error   Units
DatafakerSimpleMethods.firstname      thrpt   10    8972.172 ±  99.469  ops/ms
DatafakerSimpleMethods.fullname       thrpt   10    3232.930 ± 203.367  ops/ms
DatafakerSimpleMethods.numberBetween  thrpt   10  102087.734 ± 655.514  ops/ms
DatafakerSimpleMethods.streetAddress  thrpt   10    2503.758 ±  19.876  ops/ms
```