### PR TITLE
Add shading for generex and automaton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,8 @@
                     <artifactSet>
                         <includes>
                             <include>org.yaml:snakeyaml:*:*</include>
+                            <include>com.github.mifmif:generex:*:*</include>
+                            <include>dk.brics.automaton:automaton:*:*</include>
                         </includes>
                     </artifactSet>
                     <filters>
@@ -255,6 +257,14 @@
                         <relocation>
                             <pattern>org.yaml.snakeyaml</pattern>
                             <shadedPattern>net.datafaker.shaded.snakeyaml</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.mifmif.common.regex</pattern>
+                            <shadedPattern>net.datafaker.shaded.generex</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>dk.brics.automaton</pattern>
+                            <shadedPattern>net.datafaker.shaded.automaton</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>


### PR DESCRIPTION
It seems these 2 were missed

to double check the whole list of libs that are used during runtime and should and shaded this command could be used

```
mvn dependency:tree | grep compile
```
output
```
[INFO] +- org.yaml:snakeyaml:jar:2.0:compile
[INFO] +- com.github.mifmif:generex:jar:1.0.2:compile
[INFO] |  \- dk.brics.automaton:automaton:jar:1.11-8:compile
```