### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,13 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: maven
+    directory: / # Location of package manifests
     schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily


### PR DESCRIPTION
It looks that github thinks it is not configured

![image](https://user-images.githubusercontent.com/403174/235356531-cd76dd3d-3ae3-4b68-81c1-717428287774.png)


while it should look like that
![image](https://user-images.githubusercontent.com/403174/235356585-b596898d-e705-4547-b2e2-87a5bc0ae110.png)


after similar changes applied for my own fork it starts working

Fixes #803 