### PR TITLE
Generating US routing number (ABA RTN) in Finance provider.

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -1,7 +1,11 @@
 package net.datafaker.providers.base;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -90,6 +94,25 @@ public class Finance extends AbstractProvider<BaseProviders> {
         String basicBankAccountNumber = faker.regexify(countryCodeToBasicBankAccountNumberPattern.get(countryCode));
         String checkSum = calculateIbanChecksum(countryCode, basicBankAccountNumber);
         return countryCode + checkSum + basicBankAccountNumber;
+    }
+
+    public String usRoutingNumber() {
+        String base =
+            // 01 through 12 are the "normal" routing numbers, and correspond to the 12 Federal Reserve Banks.
+            String.format("%02d", faker.random().nextInt(12) + 1)
+            + faker.regexify("\\d{6}");
+        int check =
+           Character.getNumericValue(base.charAt(0)) * 3
+            + Character.getNumericValue(base.charAt(1)) * 7
+            + Character.getNumericValue(base.charAt(2))
+            + Character.getNumericValue(base.charAt(3)) * 3
+            + Character.getNumericValue(base.charAt(4)) * 7
+            + Character.getNumericValue(base.charAt(5))
+            + Character.getNumericValue(base.charAt(6)) * 3
+            + Character.getNumericValue(base.charAt(7)) * 7;
+        check = Math.abs(check % 10 - 10) % 10;
+
+        return base + check;
     }
 
     private CreditCardType randomCreditCardType() {

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -82,4 +82,19 @@ class FinanceTest extends BaseFakerTest<BaseFaker> {
         String creditCard = finance.creditCard(CreditCardType.DISCOVER).replace("-", "");
         assertThat(creditCard).startsWith("6").hasSize(16);
     }
+
+    @RepeatedTest(100)
+    void usRoutingNumber() {
+        String rtn = finance.usRoutingNumber();
+        System.out.println(rtn);
+        assertThat(rtn).matches("\\d{9}");
+        int check = 0;
+        for (int index = 0; index < 3; index++) {
+            int pos = index * 3;
+            check += Character.getNumericValue(rtn.charAt(pos)) * 3;
+            check += Character.getNumericValue(rtn.charAt(pos + 1)) * 7;
+            check += Character.getNumericValue(rtn.charAt(pos + 2));
+        }
+        assertThat(check % 10).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## ABA RTN Format 

```
XXXXYYYYC
where XXXX is Federal Reserve Routing Symbol, YYYY is ABA Institution Identifier, and C is the check digit.
...
The first two digits of the nine digit RTN must be in the ranges 00 through 12, 21 through 32, 61 through 72, or 80.
- 00 is used by the [United States Government](https://en.wikipedia.org/wiki/Federal_government_of_the_United_States)
- 01 through 12 are the "normal" routing numbers, and correspond to the 12 [Federal Reserve Banks](https://en.wikipedia.org/wiki/Federal_Reserve_Bank). For example, 0260-0959-3 is the routing number for Bank of America incoming wires in New York, with the initial "02" indicating the [Federal Reserve Bank of New York](https://en.wikipedia.org/wiki/Federal_Reserve_Bank_of_New_York).
- 21 through 32 were assigned only to [thrift institutions](https://en.wikipedia.org/wiki/Cooperative_banking) (e.g. [credit unions](https://en.wikipedia.org/wiki/Credit_union) and savings banks) through 1985, but are no longer assigned (thrifts are assigned normal 01–12 numbers). Currently they are still used by the thrift institutions, or their successors, and correspond to the normal routing number, plus 20. (For example, 2260-7352-3 is the routing number for Grand Adirondack Federal Credit Union in New York, with the initial "22" corresponding to "02" (New York Fed) plus "20" (thrift).)
- 61 through 72 are special purpose routing numbers designated for use by non-bank payment processors and clearinghouses and are termed Electronic Transaction Identifiers (ETIs), and correspond to the normal routing number, plus 60.
- 80 is used for [traveler's checks](https://en.wikipedia.org/wiki/Traveler%27s_check)
...
Check digit
The ninth, check digit provides a checksum test using a position-weighted sum of each of the digits. High-speed check-sorting equipment will typically verify the checksum and if it fails, route the item to a reject pocket for manual examination, repair, and re-sorting. Mis-routings to an incorrect bank are thus greatly reduced.
The following condition must hold:
(3*(d1 + d4 + d7) + 7*(d2 + d5 + d8) + 1*(d3 + d6 + d9)) mod 10 = 0
```

## References
- American Bankers Association (ABA) https://www.aba.com/news-research/analysis-guides/routing-number-policy-procedures
- Wikipedia https://en.wikipedia.org/wiki/ABA_routing_transit_number
- List of banks with the most US ACH Routing Numbers https://bank.codes/us-routing-number/bank/