### PR TITLE
Eliminate System.out.println, speed up Finance#usRoutingNumber

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -97,10 +97,11 @@ public class Finance extends AbstractProvider<BaseProviders> {
     }
 
     public String usRoutingNumber() {
-        String base =
+        final int random = faker.random().nextInt(12) + 1;
+        final String base =
             // 01 through 12 are the "normal" routing numbers, and correspond to the 12 Federal Reserve Banks.
-            String.format("%02d", faker.random().nextInt(12) + 1)
-            + faker.regexify("\\d{6}");
+            (random < 10 ? "0" : "") + random
+            + faker.numerify("#".repeat(6));
         int check =
            Character.getNumericValue(base.charAt(0)) * 3
             + Character.getNumericValue(base.charAt(1)) * 7

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -86,15 +86,14 @@ class FinanceTest extends BaseFakerTest<BaseFaker> {
     @RepeatedTest(100)
     void usRoutingNumber() {
         String rtn = finance.usRoutingNumber();
-        System.out.println(rtn);
         assertThat(rtn).matches("\\d{9}");
         int check = 0;
         for (int index = 0; index < 3; index++) {
-            int pos = index * 3;
+            final int pos = index * 3;
             check += Character.getNumericValue(rtn.charAt(pos)) * 3;
             check += Character.getNumericValue(rtn.charAt(pos + 1)) * 7;
             check += Character.getNumericValue(rtn.charAt(pos + 2));
         }
-        assertThat(check % 10).isEqualTo(0);
+        assertThat(check % 10).isZero();
     }
 }


### PR DESCRIPTION
1. remove useless `System.out.println`
2. `regexify` and `String.format` are slow, so it's better avoid them if possible