### PR TITLE
[Backport-1.x] Eliminate System.out.println, speed up Finance#usRoutingNumber (#825)

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -78,10 +78,11 @@ public class Finance extends AbstractProvider<BaseProviders> {
     }
 
     public String usRoutingNumber() {
-        String base =
+        final int random = faker.random().nextInt(12) + 1;
+        final String base =
             // 01 through 12 are the "normal" routing numbers, and correspond to the 12 Federal Reserve Banks.
-            String.format("%02d", faker.random().nextInt(12) + 1)
-            + faker.regexify("\\d{6}");
+            (random < 10 ? "0" : "") + random
+            + faker.numerify("######");
         int check =
             Character.getNumericValue(base.charAt(0)) * 3
             + Character.getNumericValue(base.charAt(1)) * 7

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -84,11 +84,11 @@ class FinanceTest extends BaseFakerTest<BaseFaker> {
         assertThat(rtn).matches("\\d{9}");
         int check = 0;
         for (int index = 0; index < 3; index++) {
-            int pos = index * 3;
+            final int pos = index * 3;
             check += Character.getNumericValue(rtn.charAt(pos)) * 3;
             check += Character.getNumericValue(rtn.charAt(pos + 1)) * 7;
             check += Character.getNumericValue(rtn.charAt(pos + 2));
         }
-        assertThat(check % 10).isEqualTo(0);
+        assertThat(check % 10).isZero();
     }
 }


### PR DESCRIPTION
Backport of #825 to 1.x