### PR TITLE
Chore: Remove duplicate 'import java util.List'

### DIFF
--- a/src/test/java/net/datafaker/formats/XmlTest.java
+++ b/src/test/java/net/datafaker/formats/XmlTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.AbstractMap;
-import java.util.List;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
+++ b/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/src/test/java/net/datafaker/integration/UkLocalDirectivesTest.java
+++ b/src/test/java/net/datafaker/integration/UkLocalDirectivesTest.java
@@ -4,7 +4,6 @@ import net.datafaker.providers.base.BaseFaker;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/net/datafaker/providers/base/LoremTest.java
+++ b/src/test/java/net/datafaker/providers/base/LoremTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;

--- a/src/test/java/net/datafaker/providers/base/OptionsTest.java
+++ b/src/test/java/net/datafaker/providers/base/OptionsTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
-import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
 


### PR DESCRIPTION
The result of migrating code from Java 8 to Java 17 syntax improvements.