### PR TITLE
Use bulk append instead of symbol by symbol

### DIFF
--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -65,13 +65,16 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
 
     private void addCharSequence(StringBuilder sb, CharSequence charSequence) {
         sb.append(quote);
-        for (int j = 0; j < charSequence.length(); j++) {
+        int i = 0;
+        final int length = charSequence.length();
+        for (int j = 0; j < length; j++) {
             final char c = charSequence.charAt(j);
             if (c == quote) {
-                sb.append(quote);
+                sb.append(charSequence, i, j + 1).append(quote);
+                i = j + 1;
             }
-            sb.append(c);
         }
+        sb.append(charSequence, i, length);
         sb.append(quote);
     }
 


### PR DESCRIPTION
Every call to append leads to call of `ensureCapacity`. To minimize number of such calls we could use bulk append whenever possible
It wallows to speed up csv generation a bit 
before
```
 Benchmark                  Mode  Cnt    Score   Error   Units
 DatafakerCsvjson.csvJson  thrpt   10  183.571 ± 0.253  ops/ms
```
after
```
 Benchmark                  Mode  Cnt    Score   Error   Units
 DatafakerCsvjson.csvJson  thrpt   10  195.783 ± 1.837  ops/ms

```