### PR TITLE
Aviation provider: ICAO special type designator and engine type.

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Aviation.java
+++ b/src/main/java/net/datafaker/providers/base/Aviation.java
@@ -88,6 +88,22 @@ public class Aviation extends AbstractProvider<BaseProviders> {
     }
 
     /**
+     * Provides an aircraft special type designator.
+     * Source: <a href="https://www.icao.int/publications/DOC8643/Pages/SpecialDesignators.aspx">ICAO publications</a>
+     */
+    public String specialTypeDesignator() {
+        return resolve("aviation.aircraft_type_special_designator");
+    }
+
+    /**
+     * Provides engine type name.
+     * Source: <a href="https://www.icao.int/publications/DOC8643/Pages/Search.aspx">ICAO publications</a>
+     */
+    public String engineType() {
+        return resolve("aviation.engine_type");
+    }
+
+    /**
      * Returns a flight number (IATA or ICAO format).
      *
      * @return A random flight number with IATA or ICAO format in a String.

--- a/src/main/resources/en/aviation.yml
+++ b/src/main/resources/en/aviation.yml
@@ -1,6 +1,24 @@
 en:
   faker:
     aviation:
+      aircraft_type_special_designator:
+      - "ZZZZ"
+      - "SHIP"
+      - "BALL"
+      - "GLID"
+      - "ULAC"
+      - "GYRO"
+      - "UHEL"
+      - "PARA"
+      - "GLID"
+      - "FFLO"
+      - "VFHC"
+      engine_type:
+      - "Electric"
+      - "Jet"
+      - "Piston"
+      - "Rocket"
+      - "Turboprop/Turboshaft"
       manufacturer:
       - "AERO SYSTEMS WEST"
       - "AQUILINE DRONES"

--- a/src/test/java/net/datafaker/providers/base/AviationTest.java
+++ b/src/test/java/net/datafaker/providers/base/AviationTest.java
@@ -43,6 +43,8 @@ class AviationTest extends BaseFakerTest<BaseFaker> {
             TestSpec.of(aviation::armyHelicopter, "aviation.aircraft.army_helicopter"),
             TestSpec.of(aviation::METAR, "aviation.metar"),
             TestSpec.of(aviation::manufacturer, "aviation.manufacturer"),
+            TestSpec.of(aviation::specialTypeDesignator, "aviation.aircraft_type_special_designator"),
+            TestSpec.of(aviation::engineType, "aviation.engine_type"),
             TestSpec.of(aviation::airline, "aviation.airline"));
     }
 }


### PR DESCRIPTION
Aviation provider, added:
 - ICAO special type designator. Source: https://www.icao.int/publications/DOC8643/Pages/SpecialDesignators.aspx 
 - ICAO engine type. Source: https://www.icao.int/publications/DOC8643/Pages/Search.aspx