### PR TITLE
Speed up Number#randomNumber

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Number.java
+++ b/src/main/java/net/datafaker/providers/base/Number.java
@@ -89,13 +89,24 @@ public class Number extends AbstractProvider<BaseProviders> {
      * @param strict         whether or not the generated value should have exactly <code>numberOfDigits</code>
      */
     public long randomNumber(int numberOfDigits, boolean strict) {
-        long max = (long) Math.pow(10, numberOfDigits);
+        long max = pow(10, numberOfDigits);
         if (strict) {
-            long min = (long) Math.pow(10, numberOfDigits - 1);
+            long min = max / 10;
             return faker.random().nextLong(max - min) + min;
         }
 
         return faker.random().nextLong(max);
+    }
+
+    private long pow(long value, int d) {
+        if (d == 0) return 1;
+        if (d == 1) return value;
+        if (d % 2 == 0) {
+            long pow = pow(value, d / 2);
+            return pow * pow;
+        } else {
+            return value * pow(value, d - 1);
+        }
     }
 
     /**


### PR DESCRIPTION
Use integer `pow` instead of `Math.pow`

This brings some speed since no need to deal with fractions

before 
```
Benchmark                              Mode  Cnt      Score     Error   Units
DatafakerSimpleMethods.numberBetween  thrpt   10  32624.208 ± 873.033  ops/ms
```
after
```
Benchmark                              Mode  Cnt      Score      Error   Units
DatafakerSimpleMethods.numberBetween  thrpt   10  94411.143 ± 6192.659  ops/ms
```