### PR TITLE
Start of reusable AssertJ assertions.

### DIFF
--- a/src/test/java/net/datafaker/assertj/DatafakerAssertions.java
+++ b/src/test/java/net/datafaker/assertj/DatafakerAssertions.java
@@ -1,0 +1,11 @@
+package net.datafaker.assertj;
+
+import net.datafaker.assertj.base.NameAssert;
+import org.assertj.core.api.Assertions;
+
+public class DatafakerAssertions extends Assertions {
+
+    public static NameAssert assertThat(String actual) {
+        return new NameAssert(actual);
+    }
+}

--- a/src/test/java/net/datafaker/assertj/base/NameAssert.java
+++ b/src/test/java/net/datafaker/assertj/base/NameAssert.java
@@ -1,0 +1,39 @@
+package net.datafaker.assertj.base;
+
+import org.assertj.core.api.StringAssert;
+
+public class NameAssert extends StringAssert {
+
+    public NameAssert(String s) {
+        super(s);
+    }
+
+    public static NameAssert asserThat(String actual) {
+        return new NameAssert(actual);
+    }
+
+    public NameAssert isName() {
+        isNotNull();
+
+        // check condition
+        if (!actual.matches("([\\w']+\\.?( )?){2,4}")) {
+            failWithMessage("Expected string to be a firstname, but it wasn't");
+        }
+
+        // return the current assertion for method chaining
+        return this;
+    }
+
+    public NameAssert isNameWithMiddleName() {
+        isNotNull();
+
+        // check condition
+        String regex = "^[A-Za-z.']+(?:\\s[A-Za-z.']+){2,}$";
+        if (!actual.matches(regex)) {
+            failWithMessage("Expected name with middle name to match <%s>, but was <%s>", regex, actual);
+        }
+
+        // return the current assertion for method chaining
+        return this;
+    }
+}

--- a/src/test/java/net/datafaker/providers/base/NameTest.java
+++ b/src/test/java/net/datafaker/providers/base/NameTest.java
@@ -1,10 +1,11 @@
 package net.datafaker.providers.base;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static net.datafaker.assertj.DatafakerAssertions.assertThat;
 
 class NameTest extends BaseFakerTest<BaseFaker> {
 
@@ -12,12 +13,12 @@ class NameTest extends BaseFakerTest<BaseFaker> {
 
     @Test
     void testName() {
-        assertThat(name.name()).matches("([\\w']+\\.?( )?){2,4}");
+        assertThat(name.name()).isName();
     }
 
-    @Test
+    @RepeatedTest(1000)
     void testNameWithMiddle() {
-        assertThat(name.nameWithMiddle()).matches("([\\w']+\\.?( )?){3,}");
+        assertThat(name.nameWithMiddle()).isNameWithMiddleName();
     }
 
     @Test


### PR DESCRIPTION
This is just a POC, but sometimes I just want to know if a value is a zipcode, a firstname, etc. It would be nice to have a bunch of assertions which can do this. I'm not sure if it should be like: `isFullname()` or `hasPrefix()`, but I think option 2 is more composable, like:

```
assertThat(name).hasPrefix().hasMiddleName().has....
```

Ideas opinions welcome.