### PR TITLE
Speed up EnZa number validation

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/EnZAIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/EnZAIdNumber.java
@@ -2,9 +2,9 @@ package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
 
 /**
  * Implementation based on the definition at
@@ -13,6 +13,7 @@ import java.util.Date;
 
 public class EnZAIdNumber implements IdNumbers {
 
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyMMdd");
     private static final String[] VALID_PATTERN = {"##########08#", "##########18#"};
 
     /**
@@ -72,7 +73,7 @@ public class EnZAIdNumber implements IdNumbers {
             if (parseDate(ssn)) {
                 return false;
             }
-        } catch (ParseException e) {
+        } catch (Exception e) {
             return false;
         }
 
@@ -86,14 +87,19 @@ public class EnZAIdNumber implements IdNumbers {
      *
      * @param ssn social security number
      */
-    private boolean parseDate(String ssn) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyMMdd");
+    private boolean parseDate(String ssn) {
         String dateString = ssn.substring(0, 6);
-        Date date = sdf.parse(dateString);
-
-        // want to check that the parsed date is equal to the supplied data, most of the attempts will fail
-        String reversed = sdf.format(date);
-        return !reversed.equals(dateString);
+        if (ChronoField.YEAR.range().isValidIntValue(Integer.parseInt(ssn.substring(0, 2)))) {
+            if (ChronoField.MONTH_OF_YEAR.range().isValidIntValue(Integer.parseInt(ssn.substring(2, 4)))) {
+                if (ChronoField.DAY_OF_MONTH.range().isValidIntValue(Integer.parseInt(ssn.substring(4)))) {
+                    LocalDate date = LocalDate.parse(dateString, DATE_TIME_FORMATTER);
+                    // want to check that the parsed date is equal to the supplied data, most of the attempts will fail
+                    String reversed = date.format(DATE_TIME_FORMATTER);
+                    return !reversed.equals(dateString);
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/net/datafaker/providers/entertainment/StarWars.java
+++ b/src/main/java/net/datafaker/providers/entertainment/StarWars.java
@@ -7,7 +7,7 @@ import net.datafaker.providers.base.AbstractProvider;
  */
 public class StarWars extends AbstractProvider<EntertainmentProviders> {
 
-    private final String[] CHARACTERS = {"admiral_ackbar", "ahsoka_tano", "anakin_skywalker", "asajj_ventress",
+    private static final String[] CHARACTERS = {"admiral_ackbar", "ahsoka_tano", "anakin_skywalker", "asajj_ventress",
         "bendu", "boba_fett", "c_3po", "count_dooku", "darth_caedus", "darth_vader", "emperor_palpatine", "finn",
         "general_hux", "grand_admiral_thrawn", "grand_moff_tarkin", "greedo", "han_solo", "jabba_the_hutt",
         "jar_jar_binks", "k_2so", "kylo_ren", "lando_calrissian", "leia_organa", "luke_skywalker", "mace_windu",
@@ -26,7 +26,7 @@ public class StarWars extends AbstractProvider<EntertainmentProviders> {
     }
 
     public String quotes() {
-        return resolve("star_wars.quotes." + CHARACTERS[faker.random().nextInt(CHARACTERS.length)]);
+        return resolve("star_wars.quotes." + getFaker().options().option(CHARACTERS));
     }
 
     public String vehicles() {
@@ -50,6 +50,6 @@ public class StarWars extends AbstractProvider<EntertainmentProviders> {
     }
 
     public String alternateCharacterSpelling() {
-        return resolve("star_wars.alternate_character_spellings." + CHARACTERS[faker.random().nextInt(CHARACTERS.length)]);
+        return resolve("star_wars.alternate_character_spellings." + getFaker().options().option(CHARACTERS));
     }
 }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -301,7 +301,7 @@ public class FakeValuesService {
     }
 
     private String bothify(String input, FakerContext context, boolean isUpper, boolean numerify, boolean letterify) {
-        final int baseChar = isUpper ? 65 : 97;
+        final int baseChar = isUpper ? 'A' : 'a';
         final char[] res = input.toCharArray();
         for (int i = 0; i < res.length; i++) {
             switch (res[i]) {

--- a/src/test/java/net/datafaker/providers/base/BaseFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/BaseFakerTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -75,7 +76,7 @@ public class BaseFakerTest<T extends BaseFaker> {
             return;
         }
         // Given
-        List<String> actual = getBaseList(testSpec.key);
+        Set<String> actual = new HashSet<>(getBaseList(testSpec.key));
         // When
         String item = (String) testSpec.supplier.get();
         // Then


### PR DESCRIPTION
The main issue is that during validation it generates new `SimpleDateFormat` object and throws exception too often...
The PR minimizes number of generated exception by usage of existing validations