### PR TITLE
Speed up cnpj

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/pt/br/DocumentFormatterUtil.java
+++ b/src/main/java/net/datafaker/idnumbers/pt/br/DocumentFormatterUtil.java
@@ -2,6 +2,8 @@ package net.datafaker.idnumbers.pt.br;
 
 public final class DocumentFormatterUtil {
 
+    public static final String D_REGEX = "\\D+";
+
     private DocumentFormatterUtil() {
     }
 
@@ -10,7 +12,13 @@ public final class DocumentFormatterUtil {
     private static final String PATTERN_CNPJ = "([0-9]{2})([0-9]{3})([0-9]{3})([0-9]{4})([0-9]{2})";
 
     public static String cnpj(String cnpj) {
-        return cnpj.replaceAll(PATTERN_CNPJ, "$1.$2.$3/$4-$5");
+        StringBuilder sb = new StringBuilder(20);
+        sb.append(cnpj, 0, 2)
+                .append('.').append(cnpj, 2, 5)
+                .append('.').append(cnpj, 5, 8)
+                .append('/').append(cnpj, 8, 12)
+                .append('-').append(cnpj, 12, cnpj.length());
+        return sb.toString();
     }
 
     public static String cpf(String cpf) {
@@ -18,7 +26,14 @@ public final class DocumentFormatterUtil {
     }
 
     public static String unmask(String doc) {
-        return doc.replaceAll("\\D+", "");
+        StringBuilder res = new StringBuilder(doc.length());
+        for (int i = 0; i < doc.length(); i++) {
+            final char c = doc.charAt(i);
+            if (Character.isDigit(c)) {
+                res.append(c);
+            }
+        }
+        return res.toString();
     }
 
 }

--- a/src/main/java/net/datafaker/idnumbers/pt/br/DocumentFormatterUtil.java
+++ b/src/main/java/net/datafaker/idnumbers/pt/br/DocumentFormatterUtil.java
@@ -2,14 +2,8 @@ package net.datafaker.idnumbers.pt.br;
 
 public final class DocumentFormatterUtil {
 
-    public static final String D_REGEX = "\\D+";
-
     private DocumentFormatterUtil() {
     }
-
-    private static final String PATTERN_CPF = "([0-9]{3})([0-9]{3})([0-9]{3})([0-9]{2})";
-
-    private static final String PATTERN_CNPJ = "([0-9]{2})([0-9]{3})([0-9]{3})([0-9]{4})([0-9]{2})";
 
     public static String cnpj(String cnpj) {
         StringBuilder sb = new StringBuilder(20);
@@ -22,7 +16,12 @@ public final class DocumentFormatterUtil {
     }
 
     public static String cpf(String cpf) {
-        return cpf.replaceAll(PATTERN_CPF, "$1.$2.$3-$4");
+        StringBuilder sb = new StringBuilder(20);
+        sb.append(cpf, 0, 3)
+                .append('.').append(cpf, 3, 6)
+                .append('.').append(cpf, 6, 9)
+                .append('-').append(cpf, 9, cpf.length());
+        return sb.toString();
     }
 
     public static String unmask(String doc) {

--- a/src/main/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtil.java
+++ b/src/main/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtil.java
@@ -32,8 +32,8 @@ public final class IdNumberGeneratorPtBrUtil {
 
             cnpj = partial.toString();
 
-            int d1 = digit(calculateWeight(cnpj.substring(4, 12), 9) + calculateWeight(cnpj.substring(0, 4), 5));
-            int d2 = digit((d1 * 2) + calculateWeight(cnpj.substring(5, 12), 9) + calculateWeight(cnpj.substring(0, 5), 6));
+            int d1 = digit(calculateWeight(cnpj, 9, 4, 12) + calculateWeight(cnpj, 5, 0, 4));
+            int d2 = digit((d1 * 2) + calculateWeight(cnpj, 9, 5, 12) + calculateWeight(cnpj, 6, 0, 5));
 
             cnpj = (cnpj + d1) + d2;
         } else {
@@ -66,8 +66,8 @@ public final class IdNumberGeneratorPtBrUtil {
             }
             cpf = partial.toString();
 
-            int d1 = digit(calculateWeight(cpf, 10));
-            int d2 = digit((d1 * 2) + calculateWeight(cpf, 11));
+            int d1 = digit(calculateWeight(cpf, 10, 0, cpf.length()));
+            int d2 = digit((d1 * 2) + calculateWeight(cpf, 11, 0, cpf.length()));
 
             cpf = (cpf + d1) + d2;
         } else {
@@ -92,16 +92,19 @@ public final class IdNumberGeneratorPtBrUtil {
      * CNPJ generator could generate a valid or invalid because, somentimes, we need to test a
      * registration with invalid number
      */
-    public static Boolean isCNPJValid(final String cnpj) {
+    public static boolean isCNPJValid(final String cnpj) {
         String cnpjUnmask = DocumentFormatterUtil.unmask(cnpj);
         String cnpjPartial = cnpjUnmask.substring(0, 12);
+        if (!cnpjUnmask.startsWith(cnpjPartial)) {
+            return false;
+        }
 
-        int d1 = digit(calculateWeight(cnpjPartial.substring(4, 12), 9) + calculateWeight(cnpjPartial.substring(0, 4), 5));
-        int d2 = digit((d1 * 2) + calculateWeight(cnpjPartial.substring(5, 12), 9) + calculateWeight(cnpjPartial.substring(0, 5), 6));
+        int d1 = digit(calculateWeight(cnpjUnmask, 9, 4, 12) + calculateWeight(cnpjUnmask, 5, 0, 4));
+        int d2 = digit((d1 * 2) + calculateWeight(cnpjUnmask, 9, 5, 12) + calculateWeight(cnpjUnmask, 6, 0, 5));
 
-        String anObject = (cnpjPartial + d1) + d2;
 
-        return cnpjUnmask.equals(anObject);
+        final String other = d1 + "" + d2;
+        return cnpjUnmask.regionMatches(cnpjPartial.length(), other, 0, other.length());
     }
 
     /**
@@ -116,19 +119,19 @@ public final class IdNumberGeneratorPtBrUtil {
 
         String cpfPartial = cpfUnmask.substring(0, 9);
 
-        int d1 = digit(calculateWeight(cpfPartial, 10));
-        int d2 = digit((d1 * 2) + calculateWeight(cpfPartial, 11));
+        int d1 = digit(calculateWeight(cpfUnmask, 10, 0, 9));
+        int d2 = digit((d1 * 2) + calculateWeight(cpfUnmask, 11, 0, 9));
 
         return cpfUnmask.equals((cpfPartial + d1) + d2);
     }
 
 
-    public static int calculateWeight(final String num, final int weight) {
+    public static int calculateWeight(final String num, final int weight, int start, int end) {
         int sum = 0;
         int weightAux = weight;
 
-        for (int index = 0; index < num.length(); index++) {
-            sum += Integer.parseInt(num.substring(index, index + 1)) * weightAux--;
+        for (int index = start; index < end; index++) {
+            sum += (num.charAt(index) - '0') * weightAux--;
         }
         return sum;
     }

--- a/src/test/java/net/datafaker/providers/base/CNPJTest.java
+++ b/src/test/java/net/datafaker/providers/base/CNPJTest.java
@@ -29,13 +29,14 @@ class CNPJTest extends BaseFakerTest<BaseFaker> {
 
     @Test
     void valid_multiBranchIsTrue_shouldGenerateCNPJWithBranchNumberGreaterThan0001() {
-        String cnpj = faker.cnpj().valid(true, true);
+        final CNPJ cnpj1 = faker.cnpj();
+        String cnpj = cnpj1.valid(true, true);
         String branch = cnpj.substring(11, 15);
 
         // branches are allowed to be 0001 even in multibranch mode. In this case,
         // we are giving the system 5 chances to generate something different than 0001.
         for (int i = 0; "0001".equals(branch) && i < 5; i++) {
-            cnpj = faker.cnpj().valid(true, true);
+            cnpj = cnpj1.valid(true, true);
             branch = cnpj.substring(11, 15);
         }
 
@@ -45,13 +46,14 @@ class CNPJTest extends BaseFakerTest<BaseFaker> {
 
     @RepeatedTest(1000)
     void invalid_multiBranchIsTrue_shouldGenerateCNPJWithBranchNumberGreaterThan0001() {
-        String cnpj = faker.cnpj().invalid(true, true);
+        final CNPJ cnpj1 = faker.cnpj();
+        String cnpj = cnpj1.invalid(true, true);
         String branch = cnpj.substring(11, 15);
 
         // branches are allowed to be 0001 even in multibranch mode. In this case,
         // we are giving the system 5 chances to generate something different than 0001.
         for (int i = 0; "0001".equals(branch) && i < 5 || "0000".equals(branch); i++) {
-            cnpj = faker.cnpj().invalid(true, true);
+            cnpj = cnpj1.invalid(true, true);
             branch = cnpj.substring(11, 15);
         }
 
@@ -73,10 +75,11 @@ class CNPJTest extends BaseFakerTest<BaseFaker> {
     void formattedCNPJ() {
         final String cnpjExpression = "(^\\d{2}\\x2E\\d{3}\\x2E\\d{3}\\x2F\\d{4}\\x2D\\d{2}$)";
 
-        assertThat(faker.cnpj().valid()).matches(cnpjExpression);
-        assertThat(faker.cnpj().valid(true)).matches(cnpjExpression);
-        assertThat(faker.cnpj().invalid()).matches(cnpjExpression);
-        assertThat(faker.cnpj().invalid(true)).matches(cnpjExpression);
+        final CNPJ cnpj = faker.cnpj();
+        assertThat(cnpj.valid()).matches(cnpjExpression);
+        assertThat(cnpj.valid(true)).matches(cnpjExpression);
+        assertThat(cnpj.invalid()).matches(cnpjExpression);
+        assertThat(cnpj.invalid(true)).matches(cnpjExpression);
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
@@ -26,9 +26,10 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
     @Test
     void testPhone_esMx() {
         final BaseFaker f = new BaseFaker(new Locale("es", "MX"));
+        final PhoneNumber phoneNumber = f.phoneNumber();
         for (int i = 0; i < 10; i++) {
-            assertThat(f.phoneNumber().cellPhone()).matches("(044 )?\\(?\\d+\\)?([- .]\\d+){1,3}");
-            assertThat(f.phoneNumber().phoneNumber()).matches("\\(?\\d+\\)?([- .]\\d+){1,3}");
+            assertThat(phoneNumber.cellPhone()).matches("(044 )?\\(?\\d+\\)?([- .]\\d+){1,3}");
+            assertThat(phoneNumber.phoneNumber()).matches("\\(?\\d+\\)?([- .]\\d+){1,3}");
         }
     }
 
@@ -40,8 +41,9 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
             final String canadianAreaCode = "403|587|780|825|236|250|604|672|778|204|431|506|"
                 + "709|782|902|226|249|289|343|365|416|437|519|548|613|647|705|807|905|367|"
                 + "418|438|450|514|579|581|819|873|306|639|867";
+            final PhoneNumber phoneNumber = f.phoneNumber();
             for (int i = 0; i < 100; i++) {
-                assertThat(f.phoneNumber().cellPhone()).matches(
+                assertThat(phoneNumber.cellPhone()).matches(
                     "((1-)?(\\(?(%s)\\)?)|(%s))[- .]\\d{3}[- .]\\d{4}".formatted(
                         canadianAreaCode, canadianAreaCode));
             }
@@ -54,8 +56,9 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         int errorCount = 0;
         final BaseFaker faker = new BaseFaker(locale);
+        final PhoneNumber phoneNumberProvider = faker.phoneNumber();
         for (int i = 0; i < 10; i++) {
-            String phoneNumber = faker.phoneNumber().phoneNumber();
+            String phoneNumber = phoneNumberProvider.phoneNumber();
             try {
                 Phonenumber.PhoneNumber proto = util.parse(phoneNumber, phoneNumberRegion);
                 if (!util.isValidNumberForRegion(proto, phoneNumberRegion)) {
@@ -74,8 +77,9 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
         final PhoneNumberUtil util = PhoneNumberUtil.getInstance();
         int errorCount = 0;
         final BaseFaker faker = new BaseFaker(locale);
+        final PhoneNumber phoneNumberProvider = faker.phoneNumber();
         for (int i = 0; i < 10; i++) {
-            String phoneNumber = faker.phoneNumber().phoneNumberInternational();
+            String phoneNumber = phoneNumberProvider.phoneNumberInternational();
             Phonenumber.PhoneNumber proto = util.parse(phoneNumber, phoneNumberRegion);
             if (!util.isValidNumberForRegion(proto, phoneNumberRegion)) {
                 errorCount++;


### PR DESCRIPTION
The idea is pretty straightforward: minimize amount of `substring` and regexps