### PR TITLE
Speed up json generation by minimizing of Stringbuilder append invocations

### DIFF
--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -129,10 +129,11 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             final int length = val.length();
             for (int i = 0; i < length; i++) {
                 final char c = val.charAt(i);
-                if (ESCAPING_MAP.get(c) == null) {
+                final String escapedValue = ESCAPING_MAP.get(c);
+                if (escapedValue == null) {
                     // do nothing
                 } else {
-                    sb.append(val, start, i + 1);
+                    sb.append(val, start, i).append(escapedValue);
                     start = i + 1;
                 }
             }

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -130,9 +130,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             for (int i = 0; i < length; i++) {
                 final char c = val.charAt(i);
                 final String escapedValue = ESCAPING_MAP.get(c);
-                if (escapedValue == null) {
-                    // do nothing
-                } else {
+                if (escapedValue != null) {
                     sb.append(val, start, i).append(escapedValue);
                     start = i + 1;
                 }

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -125,9 +125,18 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             if (toWrap) {
                 sb.append("\"");
             }
-            for (char c : String.valueOf(value).toCharArray()) {
-                sb.append(ESCAPING_MAP.getOrDefault(c, String.valueOf(c)));
+            int start = 0;
+            final int length = val.length();
+            for (int i = 0; i < length; i++) {
+                final char c = val.charAt(i);
+                if (ESCAPING_MAP.get(c) == null) {
+                    // do nothing
+                } else {
+                    sb.append(val, start, i + 1);
+                    start = i + 1;
+                }
             }
+            sb.append(val, start, length);
             if (toWrap) {
                 sb.append("\"");
             }


### PR DESCRIPTION
The idea is to invoke `StringBuilder` for larger peaces than just one symbol if possible to minimize amount of checks while `StringBuilder#append"