### PR TITLE
chore(deps): Downgrade codecov/codecov-action action to v3.1.4

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3.1.4
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3.1.4
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build with Maven
         run: ./mvnw $mvn_options verify -PnoGpg --file pom.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3.1.4


### PR DESCRIPTION
Revert https://github.com/datafaker-net/datafaker/pull/964 because it isn't working. I suspect they incorrectly/temporarily had a v4 tag.