### PR TITLE
Simplify tests for driving license, remove useless regexify call

### DIFF
--- a/src/main/java/net/datafaker/providers/base/DrivingLicense.java
+++ b/src/main/java/net/datafaker/providers/base/DrivingLicense.java
@@ -12,6 +12,6 @@ public class DrivingLicense extends AbstractProvider<BaseProviders> {
     }
 
     public String drivingLicense(String stateAbbreviation) {
-        return faker.regexify(faker.bothify(faker.resolve("driving_license.usa." + stateAbbreviation))).toUpperCase(Locale.ROOT);
+        return faker.bothify(faker.resolve("driving_license.usa." + stateAbbreviation)).toUpperCase(Locale.ROOT);
     }
 }

--- a/src/test/java/net/datafaker/providers/base/DrivingLicenseTest.java
+++ b/src/test/java/net/datafaker/providers/base/DrivingLicenseTest.java
@@ -1,263 +1,82 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DrivingLicenseTest extends BaseFakerTest<BaseFaker> {
+    private final DrivingLicense drivingLicense = getFaker().drivingLicense();
 
-    @RepeatedTest(100)
-    void drivingLicense_AL() {
-        assertThat(faker.drivingLicense().drivingLicense("AL")).matches("^\\d{6,8}$");
+    private enum LicensePattern {
+        AL("AL", "^\\d{6,8}$"),
+        AK("AK", "^\\d{6,7}$"),
+        AZ("AZ", "^([A-Z]?)\\d{8,9}$"),
+        AR("AR", "^\\d{8,9}$"),
+        CA("CA", "^[A-Z]\\d{7}$"),
+        CO("CO", "(^[0-9]{9}$)|(^[A-Z]{1}[0-9]{3,6}$)|(^[A-Z]{2}[0-9]{2,5}$)"),
+        CT("CT", "^\\d{9}$"),
+        DE("DE", "^\\d{6,7}$"),
+        DC("DC", "(^\\d{7}$)|(^\\d{9}$)"),
+        FL("FL", "^[A-Z]\\d{12}$"),
+        GA("GA", "^\\d{7,9}$"),
+        HI("HI", "(^[A-Z]\\d{8}$)|(^\\d{9}$)"),
+        ID("ID", "(^[A-Z]{2}\\d{6}[A-Z]$)|(^\\d{9}$)"),
+        IL("IL", "^[A-Z]\\d{11,12}$"),
+        IN("IN", "(^[A-Z]\\d{9}$)|(^\\d{9,10}$)"),
+        IA("IA", "^(\\d{9}|(\\d{3}[A-Z]{2}\\d{4}))$"),
+        KS("KS", "(^([A-Z]\\d){2}[A-Z]$)|(^[A-Z]\\d{8}$)|(^\\d{9}$)"),
+        KY("KY", "(^[A-Z]\\d{8,9}$)|(^\\d{9}$)"),
+        LA("LA", "^\\d{8,9}$"),
+        MA("MA", "(^[A-Z]\\d{8}$)|(^\\d{9}$)"),
+        MD("MD", "^[A-Z]\\d{12}$"),
+        ME("ME", "(^\\d{7,8}$)|(^\\d{7}[A-Z]$)"),
+        MI("MI", "(^[A-Z]\\d{10}$)|(^[A-Z]\\d{12}$)"),
+        MN("MN", "^[A-Z]\\d{12}$"),
+        MO("MO", "(^[A-Z]\\d{5,9}$)|(^[A-Z]\\d{6}R$)|(^\\d{3}[A-Z]\\d{6}$)|(^\\d{8}[A-Z]{2}$)|(^\\d{9}[A-Z]$)|(^\\d{9}$)"),
+        MS("MS", "^\\d{9}$"),
+        MT("MT", "(^[A-Z]\\d{8}$)|(^\\d{13}$)|(^\\d{14}$)|(^\\d{9}$)"),
+        NC("NC", "^\\d{10,12}$"),
+        ND("ND", "(^[A-Z]{3}\\d{6}$)|(^\\d{9}$)"),
+        NE("NE", "^[A-Z]\\d{6,8}$"),
+        NH("NH", "(^\\d{2}[A-Z]{3}\\d{5}$)"),
+        NJ("NJ", "^[A-Z]\\d{14}$"),
+        NM("NM", "^\\d{8,9}$"),
+        NV("NV", "(^\\d{9,10}$)|(^\\d{12}$)|(^X\\d{8}$)"),
+        NY("NY", "(^[A-Z]\\d{7}$)|(^[A-Z]\\d{18}$)|(^\\d{8}$)|(^\\d{9}$)|(^\\d{16}$)|(^[A-Z]{8}$)"),
+        OH("OH", "(^[A-Z]\\d{8}$)|(^[A-Z]{2}\\d{7}$)|(^\\d{8}$)"),
+        OK("OK", "(^[A-Z]\\d{9}$)|(^\\d{9}$)"),
+        OR("OR", "^\\d{8,9}$"),
+        PA("PA", "^\\d{8}$"),
+        RI("RI", "^(\\d{7}$)|(^[A-Z]\\d{6}$)"),
+        SC("SC", "^\\d{8,11}$"),
+        SD("SD", "(^\\d{8,10}$)|(^\\d{12}$)"),
+        TN("TN", "^\\d{7,9}$"),
+        TX("TX", "^\\d{7,8}$"),
+        UT("UT", "^\\d{9,10}$"),
+        VA("VA", "(^[A-Z]\\d{8,11}$)|(^\\d{9}$)"),
+        VT("VT", "(^\\d{8}$)|(^\\d{7}A$)"),
+        WA("WA", "(^[A-Z]{7}\\d{5}$)|(^[A-Z]{8}\\d{4}$)|(^[A-Z]{9}\\d{3}$)|(^[A-Z]{10}\\d{2}$)|(^[A-Z]{11}\\d$)|(^[A-Z]{12}$)|(^[A-Z]{7}\\d[A-Z]\\d[A-Z]\\d$)|(^[A-Z]{7}\\d{2}[A-Z]{2}\\d$)"),
+        WI("WI", "^[A-Z]\\d{13}$"),
+        WV("WV", "(^\\d{7}$)|(^[A-Z]{1,2}\\d{5,6}$)"),
+        WY("WY", "^\\d{9,10}$");
+        private final String abbv;
+        private final Pattern pattern;
+
+        LicensePattern(String abbv, String regex) {
+            this.abbv = abbv;
+            this.pattern = Pattern.compile(regex);
+        }
     }
 
-    @RepeatedTest(100)
-    void drivingLicense_AK() {
-        assertThat(faker.drivingLicense().drivingLicense("AK")).matches("^\\d{6,7}$");
-    }
 
-    @RepeatedTest(100)
-    void drivingLicense_AZ() {
-        assertThat(faker.drivingLicense().drivingLicense("AZ")).matches("^([A-Z]?)\\d{8,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_AR() {
-        assertThat(faker.drivingLicense().drivingLicense("AR")).matches("^\\d{8,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_CA() {
-        assertThat(faker.drivingLicense().drivingLicense("CA")).matches("^[A-Z]\\d{7}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_CO() {
-        assertThat(faker.drivingLicense().drivingLicense("CO")).matches("(^[0-9]{9}$)|(^[A-Z]{1}[0-9]{3,6}$)|(^[A-Z]{2}[0-9]{2,5}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_CT() {
-        assertThat(faker.drivingLicense().drivingLicense("CT")).matches("^\\d{9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_DE() {
-        assertThat(faker.drivingLicense().drivingLicense("DE")).matches("^\\d{6,7}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_DC() {
-        assertThat(faker.drivingLicense().drivingLicense("DC")).matches("(^\\d{7}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_FL() {
-        assertThat(faker.drivingLicense().drivingLicense("FL")).matches("^[A-Z]\\d{12}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_GA() {
-        assertThat(faker.drivingLicense().drivingLicense("GA")).matches("^\\d{7,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_HI() {
-        assertThat(faker.drivingLicense().drivingLicense("HI")).matches("(^[A-Z]\\d{8}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_ID() {
-        assertThat(faker.drivingLicense().drivingLicense("ID")).matches("(^[A-Z]{2}\\d{6}[A-Z]$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_IL() {
-        assertThat(faker.drivingLicense().drivingLicense("IL")).matches("^[A-Z]\\d{11,12}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_IN() {
-        assertThat(faker.drivingLicense().drivingLicense("IN")).matches("(^[A-Z]\\d{9}$)|(^\\d{9,10}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_IA() {
-        assertThat(faker.drivingLicense().drivingLicense("IA")).matches("^(\\d{9}|(\\d{3}[A-Z]{2}\\d{4}))$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_KS() {
-        assertThat(faker.drivingLicense().drivingLicense("KS")).matches("(^([A-Z]\\d){2}[A-Z]$)|(^[A-Z]\\d{8}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_KY() {
-        assertThat(faker.drivingLicense().drivingLicense("KY")).matches("(^[A-Z]\\d{8,9}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_LA() {
-        assertThat(faker.drivingLicense().drivingLicense("LA")).matches("^\\d{8,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_ME() {
-        assertThat(faker.drivingLicense().drivingLicense("ME")).matches("(^\\d{7,8}$)|(^\\d{7}[A-Z]$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MD() {
-        assertThat(faker.drivingLicense().drivingLicense("MD")).matches("^[A-Z]\\d{12}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MA() {
-        assertThat(faker.drivingLicense().drivingLicense("MA")).matches("(^[A-Z]\\d{8}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MI() {
-        assertThat(faker.drivingLicense().drivingLicense("MI")).matches("(^[A-Z]\\d{10}$)|(^[A-Z]\\d{12}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MN() {
-        assertThat(faker.drivingLicense().drivingLicense("MN")).matches("^[A-Z]\\d{12}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MS() {
-        assertThat(faker.drivingLicense().drivingLicense("MS")).matches("^\\d{9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MO() {
-        assertThat(faker.drivingLicense().drivingLicense("MO")).matches("(^[A-Z]\\d{5,9}$)|(^[A-Z]\\d{6}R$)|(^\\d{3}[A-Z]\\d{6}$)|(^\\d{8}[A-Z]{2}$)|(^\\d{9}[A-Z]$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_MT() {
-        assertThat(faker.drivingLicense().drivingLicense("MT")).matches("(^[A-Z]\\d{8}$)|(^\\d{13}$)|(^\\d{14}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NE() {
-        assertThat(faker.drivingLicense().drivingLicense("NE")).matches("^[A-Z]\\d{6,8}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NV() {
-        assertThat(faker.drivingLicense().drivingLicense("NV")).matches("(^\\d{9,10}$)|(^\\d{12}$)|(^X\\d{8}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NH() {
-        assertThat(faker.drivingLicense().drivingLicense("NH")).matches("(^\\d{2}[A-Z]{3}\\d{5}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NJ() {
-        assertThat(faker.drivingLicense().drivingLicense("NJ")).matches("^[A-Z]\\d{14}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NM() {
-        assertThat(faker.drivingLicense().drivingLicense("NM")).matches("^\\d{8,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NY() {
-        assertThat(faker.drivingLicense().drivingLicense("NY")).matches("(^[A-Z]\\d{7}$)|(^[A-Z]\\d{18}$)|(^\\d{8}$)|(^\\d{9}$)|(^\\d{16}$)|(^[A-Z]{8}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_NC() {
-        assertThat(faker.drivingLicense().drivingLicense("NC")).matches("^\\d{10,12}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_ND() {
-        assertThat(faker.drivingLicense().drivingLicense("ND")).matches("(^[A-Z]{3}\\d{6}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_OH() {
-        assertThat(faker.drivingLicense().drivingLicense("OH")).matches("(^[A-Z]\\d{8}$)|(^[A-Z]{2}\\d{7}$)|(^\\d{8}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_OK() {
-        assertThat(faker.drivingLicense().drivingLicense("OK")).matches("(^[A-Z]\\d{9}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_OR() {
-        assertThat(faker.drivingLicense().drivingLicense("OR")).matches("^\\d{8,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_PA() {
-        assertThat(faker.drivingLicense().drivingLicense("PA")).matches("^\\d{8}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_RI() {
-        assertThat(faker.drivingLicense().drivingLicense("RI")).matches("^(\\d{7}$)|(^[A-Z]\\d{6}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_SC() {
-        assertThat(faker.drivingLicense().drivingLicense("SC")).matches("^\\d{8,11}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_SD() {
-        assertThat(faker.drivingLicense().drivingLicense("SD")).matches("(^\\d{8,10}$)|(^\\d{12}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_TN() {
-        assertThat(faker.drivingLicense().drivingLicense("TN")).matches("^\\d{7,9}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_TX() {
-        assertThat(faker.drivingLicense().drivingLicense("TX")).matches("^\\d{7,8}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_UT() {
-        assertThat(faker.drivingLicense().drivingLicense("UT")).matches("^\\d{9,10}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_VT() {
-        assertThat(faker.drivingLicense().drivingLicense("VT")).matches("(^\\d{8}$)|(^\\d{7}A$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_VA() {
-        assertThat(faker.drivingLicense().drivingLicense("VA")).matches("(^[A-Z]\\d{8,11}$)|(^\\d{9}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_WA() {
-        assertThat(faker.drivingLicense().drivingLicense("WA")).matches("(^[A-Z]{7}\\d{5}$)|(^[A-Z]{8}\\d{4}$)|(^[A-Z]{9}\\d{3}$)|(^[A-Z]{10}\\d{2}$)|(^[A-Z]{11}\\d$)|(^[A-Z]{12}$)|(^[A-Z]{7}\\d[A-Z]\\d[A-Z]\\d$)|(^[A-Z]{7}\\d{2}[A-Z]{2}\\d$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_WV() {
-        assertThat(faker.drivingLicense().drivingLicense("WV")).matches("(^\\d{7}$)|(^[A-Z]{1,2}\\d{5,6}$)");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_WI() {
-        assertThat(faker.drivingLicense().drivingLicense("WI")).matches("^[A-Z]\\d{13}$");
-    }
-
-    @RepeatedTest(100)
-    void drivingLicense_WY() {
-        assertThat(faker.drivingLicense().drivingLicense("WY")).matches("^\\d{9,10}$");
+    @ParameterizedTest
+    @EnumSource(LicensePattern.class)
+    void drivingLicense(LicensePattern licensePattern) {
+        for (int i = 0; i < 100; i++) {
+            assertThat(drivingLicense.drivingLicense(licensePattern.abbv)).matches(licensePattern.pattern);
+        }
     }
 }


### PR DESCRIPTION
since there is no regexp expresion in driverlicense resource file=> there is no need for `regexify` call