### PR TITLE
Access the list of countries supported for IBAN

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -1,11 +1,9 @@
 package net.datafaker.providers.base;
 
+import net.datafaker.annotations.Deterministic;
+
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -50,6 +48,12 @@ public class Finance extends AbstractProvider<BaseProviders> {
 
     private static final Map<String, String> countryCodeToBasicBankAccountNumberPattern =
         createCountryCodeToBasicBankAccountNumberPatternMap();
+
+    /** Get the set of country codes supported for IBAN generation */
+    @Deterministic
+    public static Set<String> ibanSupportedCountries() {
+        return countryCodeToBasicBankAccountNumberPattern.keySet();
+    }
 
     public String creditCard(CreditCardType creditCardType) {
         final String key = "finance.credit_card." + creditCardType.toString().toLowerCase(Locale.ROOT);

--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -3,7 +3,12 @@ package net.datafaker.providers.base;
 import net.datafaker.annotations.Deterministic;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Collection;
+import java.util.Set;
 
 class FinanceTest extends BaseFakerTest<BaseFaker> {
 
@@ -53,6 +54,20 @@ class FinanceTest extends BaseFakerTest<BaseFaker> {
     @Test
     void ibanWithCountryCode() {
         assertThat(finance.iban("DE")).matches("DE\\d{20}");
+    }
+
+    @Test
+    void ibanCountryCodes() {
+        assertThat(Finance.ibanSupportedCountries()).isNotEmpty().hasSizeGreaterThan(70);
+    }
+
+    @Test
+    public void ibanWithAllCountryCodes() {
+        Set<String> ibanCountryCodes = Finance.ibanSupportedCountries();
+        for (String givenCountryCode : ibanCountryCodes) {
+            final String iban = finance.iban(givenCountryCode).toUpperCase(faker.getContext().getLocale());
+            assertThat(iban).isNotBlank();
+        }
     }
 
     @Test

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -62,7 +62,7 @@ class FinanceTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Test
-    public void ibanWithAllCountryCodes() {
+    void ibanWithAllCountryCodes() {
         Set<String> ibanCountryCodes = Finance.ibanSupportedCountries();
         for (String givenCountryCode : ibanCountryCodes) {
             final String iban = finance.iban(givenCountryCode).toUpperCase(faker.getContext().getLocale());


### PR DESCRIPTION
There is no easy way to control target country randomization when creating IBANs, because both `countryCodeToBasicBankAccountNumberPattern` and `createCountryCodeToBasicBankAccountNumberPatternMap()` are private.

This PR adds a `Finance.ibanSupportedCountries()` to allow finer control of scope.

Fixes  #1001 