### PR TITLE
Manually relocate snakeyaml multi-release classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,8 +295,9 @@
                              needed due to a bug in the Maven Shade plugin, which only relocates the content but not
                              the package structure itself, see https://issues.apache.org/jira/browse/MSHADE-406. -->
                         <relocation>
-                            <pattern>META-INF/versions/9/org.yaml.snakeyaml</pattern>
-                            <shadedPattern>META-INF/versions/9/net.datafaker.shaded.snakeyaml</shadedPattern>
+                            <pattern>META-INF/versions/(\d+)/org/yaml/snakeyaml</pattern>
+                            <shadedPattern>META-INF/versions/$1/net/datafaker/shaded/snakeyaml</shadedPattern>
+                            <rawString>true</rawString>
                         </relocation>
                         <relocation>
                             <pattern>com.mifmif.common.regex</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,13 @@
                             <pattern>org.yaml.snakeyaml</pattern>
                             <shadedPattern>net.datafaker.shaded.snakeyaml</shadedPattern>
                         </relocation>
+                        <!-- Manually relocate shaded snakeyaml multi-release classes to the correct package. This is
+                             needed due to a bug in the Maven Shade plugin, which only relocates the content but not
+                             the package structure itself, see https://issues.apache.org/jira/browse/MSHADE-406. -->
+                        <relocation>
+                            <pattern>META-INF/versions/9/org.yaml.snakeyaml</pattern>
+                            <shadedPattern>META-INF/versions/9/net.datafaker.shaded.snakeyaml</shadedPattern>
+                        </relocation>
                         <relocation>
                             <pattern>com.mifmif.common.regex</pattern>
                             <shadedPattern>net.datafaker.shaded.generex</shadedPattern>


### PR DESCRIPTION
The multi-release classes for the relocated snakeyaml dependency need to be relocated manually due to a bug in the Maven Shade plugin. The plugin only relocates the content but not the package structure itself. See https://issues.apache.org/jira/browse/MSHADE-406. This fixes #1007.