### PR TITLE
Current shoud not be a part of context

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -566,7 +566,7 @@ public class FakeValuesService {
                 }
                 continue;
             }
-            final RegExpContext regExpContext = RegExpContext.of(expr, current, root, context);
+            final RegExpContext regExpContext = RegExpContext.of(expr, root, context);
             final Supplier<?> val = REGEXP2SUPPLIER_MAP.get(regExpContext);
             final Object resolved;
             if (val != null) {

--- a/src/main/java/net/datafaker/service/RegExpContext.java
+++ b/src/main/java/net/datafaker/service/RegExpContext.java
@@ -6,19 +6,17 @@ import java.util.Objects;
 
 public class RegExpContext {
     private final String exp;
-    private final Object current;
     private final ProviderRegistration root;
     private final FakerContext context;
 
-    private RegExpContext(String exp, Object current, ProviderRegistration root, FakerContext context) {
+    private RegExpContext(String exp, ProviderRegistration root, FakerContext context) {
         this.exp = exp;
-        this.current = current;
         this.root = root;
         this.context = context;
     }
 
-    public static RegExpContext of(String exp, Object current, ProviderRegistration root, FakerContext context) {
-        return new RegExpContext(exp, current, root, context);
+    public static RegExpContext of(String exp, ProviderRegistration root, FakerContext context) {
+        return new RegExpContext(exp, root, context);
     }
 
     @Override
@@ -29,7 +27,6 @@ public class RegExpContext {
         RegExpContext that = (RegExpContext) o;
 
         if (!Objects.equals(exp, that.exp)) return false;
-        if (!Objects.equals(current, that.current)) return false;
         if (!Objects.equals(root, that.root)) return false;
         return Objects.equals(context, that.context);
     }


### PR DESCRIPTION
`current` is a unique object each time and not used by `RegExpContext`
at the same time it participates in `equals` which could be a reson of maps growing...
This should be removed

Probably is a reason of and should fix #1019 