### PR TITLE
Use String#replace whenever possible

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Code.java
+++ b/src/main/java/net/datafaker/providers/base/Code.java
@@ -1,7 +1,6 @@
 package net.datafaker.providers.base;
 
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -17,8 +16,6 @@ public class Code extends AbstractProvider<BaseProviders> {
     private static final int[] GTIN_13_CHECK_DIGITS = {1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3};
     private static final String[] REPORTING_BODY_IDENTIFIERS
         = {"01", "10", "30", "33", "35", "44", "45", "49", "50", "51", "52", "53", "54", "86", "91", "98", "99"};
-
-    private static final Pattern HYPHEN = Pattern.compile("-");
 
     protected Code(BaseProviders faker) {
         super(faker);
@@ -147,7 +144,7 @@ public class Code extends AbstractProvider<BaseProviders> {
     }
 
     private String stripIsbnSeparator(CharSequence t) {
-        return HYPHEN.matcher(t.toString()).replaceAll("");
+        return t.toString().replace("-", "");
     }
 
     public String asin() {

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -41,7 +41,8 @@ public class Internet extends AbstractProvider<BaseProviders> {
     public String username() {
         StringBuilder result = new StringBuilder();
         final Name name = faker.name();
-        final String firstName = name.firstName().toLowerCase(faker.getContext().getLocale()) + "." + name.lastName().toLowerCase(faker.getContext().getLocale());
+        final String firstName = name.firstName().toLowerCase(faker.getContext().getLocale())
+            + "." + name.lastName().toLowerCase(faker.getContext().getLocale());
         for (int i = 0; i < firstName.length(); i++) {
             final char c = firstName.charAt(i);
             if (c == '\'' || Character.isWhitespace(c)) {
@@ -91,7 +92,8 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     public String domainWord() {
-        return FakerIDN.toASCII(faker.name().lastName().toLowerCase().replace("'", ""));
+        return FakerIDN.toASCII(
+            faker.name().lastName().toLowerCase(faker.getContext().getLocale()).replace("'", ""));
     }
 
     public String domainSuffix() {
@@ -142,11 +144,10 @@ public class Internet extends AbstractProvider<BaseProviders> {
      */
     public String webdomain() {
         return String.join("",
-            "www",
-            ".",
+            "www", ".",
             FakerIDN.toASCII(
-                faker.name().firstName().toLowerCase().replace("'", "") +
-                    "-" +
+                faker.name().firstName().toLowerCase(
+                      faker.getContext().getLocale()).replace("'", "") + "-" +
                     domainWord()
             ),
             ".",

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -17,7 +17,6 @@ import java.util.regex.Pattern;
  * @since 0.8.0
  */
 public class Internet extends AbstractProvider<BaseProviders> {
-    private static final Pattern SINGLE_QUOTE = Pattern.compile("'");
     private static final Pattern COLON = Pattern.compile(":");
     private static final List<String> HTTP_SCHEMES = List.of("http://", "https://");
 
@@ -41,7 +40,8 @@ public class Internet extends AbstractProvider<BaseProviders> {
      */
     public String username() {
         StringBuilder result = new StringBuilder();
-        final String firstName = faker.name().firstName().toLowerCase(faker.getContext().getLocale()) + "." + faker.name().lastName().toLowerCase(faker.getContext().getLocale());
+        final Name name = faker.name();
+        final String firstName = name.firstName().toLowerCase(faker.getContext().getLocale()) + "." + name.lastName().toLowerCase(faker.getContext().getLocale());
         for (int i = 0; i < firstName.length(); i++) {
             final char c = firstName.charAt(i);
             if (c == '\'' || Character.isWhitespace(c)) {
@@ -91,7 +91,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     public String domainWord() {
-        return FakerIDN.toASCII(SINGLE_QUOTE.matcher(faker.name().lastName().toLowerCase()).replaceAll(""));
+        return FakerIDN.toASCII(faker.name().lastName().toLowerCase().replace("'", ""));
     }
 
     public String domainSuffix() {
@@ -145,7 +145,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
             "www",
             ".",
             FakerIDN.toASCII(
-                SINGLE_QUOTE.matcher(faker.name().firstName().toLowerCase()).replaceAll("") +
+                faker.name().firstName().toLowerCase().replace("'", "") +
                     "-" +
                     domainWord()
             ),

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -609,7 +609,7 @@ public class FakeValuesService {
                     i++;
                 }
                 if (cnt % 2 == 1) {
-                    result.add(arguments.substring(start, i - 1).replaceAll("''", "'"));
+                    result.add(arguments.substring(start, i - 1).replace("''", "'"));
                     argsStarted = false;
                 }
             } else if (arguments.charAt(i) == '\'') {

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -22,7 +22,7 @@ class FinanceTest extends BaseFakerTest<BaseFaker> {
     }
 
     private void assertCardLuhnDigit(String creditCard) {
-        final String creditCardStripped = creditCard.replaceAll("-", "");
+        final String creditCardStripped = creditCard.replace("-", "");
         assertThat(LuhnCheckDigit.LUHN_CHECK_DIGIT.isValid(creditCardStripped)).isTrue();
     }
 

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -138,11 +138,11 @@ class ProviderGenerator {
     private String toJavaConvention(String baseName) {
 
         // replace underscores with spaces
-        String withoutUnderscore = baseName.replaceAll("_", " ");
+        String withoutUnderscore = baseName.replace("_", " ");
         // for every word in the name, capitalize the first letter
         String capitalizedWords = WordUtils.capitalize(withoutUnderscore);
         // remove all spaces
-        return capitalizedWords.replaceAll(" ", "");
+        return capitalizedWords.replace(" ", "");
     }
 }
 


### PR DESCRIPTION
If there is no need to replace by regexp then there is `String#replace` which is much faster than `replaceAll`, thus it's better to use it instead