### PR TITLE
AWS vpc/subnet/securitygroup IDs now 17char

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Aws.java
+++ b/src/main/java/net/datafaker/providers/base/Aws.java
@@ -59,22 +59,26 @@ public class Aws extends AbstractProvider<BaseProviders> {
     }
 
     public String securityGroupId() {
-        return "sg-" + randHex();
+        return "sg-" + randHex(17);
     }
 
     public String subnetId() {
-        return "subnet-" + randHex();
+        return "subnet-" + randHex(17);
     }
 
     public String vpcId() {
-        return "vpc-" + randHex();
+        return "vpc-" + randHex(17);
     }
 
     private String appName() {
         return faker.app().name().toLowerCase().replaceAll("\\W+", "");
     }
 
+    private String randHex(int length) {
+        return faker.random().hex(length, false);
+    }
+
     private String randHex() {
-        return faker.random().hex(16, false);
+        return randHex(16);
     }
 }

--- a/src/test/java/net/datafaker/providers/base/AwsTest.java
+++ b/src/test/java/net/datafaker/providers/base/AwsTest.java
@@ -33,17 +33,17 @@ class AwsTest extends BaseFakerTest<BaseFaker> {
 
     @Test
     void testSecurityGroupId() {
-        assertThat(faker.aws().securityGroupId()).matches("^sg-[0-9a-f]{16}$");
+        assertThat(faker.aws().securityGroupId()).matches("^sg-[0-9a-f]{17}$");
     }
 
     @Test
     void testSubnetId() {
-        assertThat(faker.aws().subnetId()).matches("^subnet-[0-9a-f]{16}$");
+        assertThat(faker.aws().subnetId()).matches("^subnet-[0-9a-f]{17}$");
     }
 
     @Test
     void testVpcId() {
-        assertThat(faker.aws().vpcId()).matches("^vpc-[0-9a-f]{16}$");
+        assertThat(faker.aws().vpcId()).matches("^vpc-[0-9a-f]{17}$");
     }
 
     @Test


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html

Fixes datafaker-net/datafaker#1076 