### PR TITLE
Use indexof string

### DIFF
--- a/src/main/java/net/datafaker/annotations/FakeResolver.java
+++ b/src/main/java/net/datafaker/annotations/FakeResolver.java
@@ -56,7 +56,8 @@ public class FakeResolver<T> {
     private Schema<Object, T> getSchema(String pathToSchema) {
         if (pathToSchema != null) {
             try {
-                final int sharpIndex = pathToSchema.indexOf('#');
+                // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+                final int sharpIndex = pathToSchema.indexOf("#");
                 final Class<?> classToCall;
                 final String methodName;
                 if (sharpIndex >= 0) {

--- a/src/main/java/net/datafaker/providers/base/Locality.java
+++ b/src/main/java/net/datafaker/providers/base/Locality.java
@@ -56,7 +56,8 @@ public class Locality extends AbstractProvider<BaseProviders> {
             if (langs.contains(parentFileName)) {
                 locales.add(parentFileName);
             } else {
-                locales.add(filename.substring(0, filename.indexOf('.')));
+                // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+                locales.add(filename.substring(0, filename.indexOf(".")));
             }
             return true;
         }

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -129,7 +129,8 @@ public class FakeValues implements FakeValuesInterface {
                     }
                     entryMap.putAll(nestedMap);
                 }
-                if (key.indexOf('_') != -1) {
+                // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+                if (key.contains("_")) {
                     if (map == null) {
                         map = new HashMap<>();
                     }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -544,17 +544,12 @@ public class FakeValuesService {
      * {@link BaseFaker#address()}'s {@link Address#streetName()}.
      */
     protected String resolveExpression(String expression, Object current, ProviderRegistration root, FakerContext context) {
-        int cnt = 0;
-        final int expressionLength = expression.length();
-        for (int i = 0; i < expressionLength; i++) {
-            if (expression.charAt(i) == '}') {
-                cnt++;
-            }
-        }
-        if (cnt == 0) {
+        // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+        if (!expression.contains("}")) {
             return expression;
         }
-        final String[] expressions = splitExpressions(expression, cnt, expressionLength);
+        final int expressionLength = expression.length();
+        final String[] expressions = splitExpressions(expression, expressionLength);
         final StringBuilder result = new StringBuilder(expressions.length * expressionLength);
         for (int i = 0; i < expressions.length; i++) {
             // odd are expressions, even are not expressions, just strings
@@ -622,10 +617,16 @@ public class FakeValuesService {
         return resultArray;
     }
 
-    private String[] splitExpressions(String expression, int cnt, int length) {
+    private String[] splitExpressions(String expression, int length) {
         String[] result = EXPRESSION_2_SPLITTED.get(expression);
         if (result != null) {
             return result;
+        }
+        int cnt = 0;
+        for (int i = 0; i < length; i++) {
+            if (expression.charAt(i) == '}') {
+                cnt++;
+            }
         }
         List<String> list = new ArrayList<>((cnt << 1) + 1);
         boolean isExpression = false;
@@ -787,7 +788,8 @@ public class FakeValuesService {
     }
 
     private int getDotIndex(String directive) {
-        return directive.indexOf('.');
+        // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+        return directive.indexOf(".");
     }
 
     /**
@@ -971,7 +973,8 @@ public class FakeValuesService {
         if (valueWithRemovedUnderscores != null) {
             return valueWithRemovedUnderscores;
         }
-        if (string.indexOf('_') == -1) {
+        // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+        if (!string.contains("_")) {
             REMOVED_UNDERSCORE.putIfAbsent(string, string.toLowerCase(Locale.ROOT));
             return string;
         }


### PR DESCRIPTION
Suddenly I realized that `indexOf(<String>)` is faster than `indexOf(<char>)` since the first one has jvm intrinsic...

So the PR makes use `indexOf(<String>)` 

it gives some speed e.g. could be checked with this test
```java
   private static final Name name = new Faker().name();
    @Test
    void test() {
        for (int i = 0; i < 500_000_000; i++) {
            name.lastName();
        }
    }
```

for my machine before change it took 16-18 sec
after 9-10 sec (almost 2 times)