### PR TITLE
Changes in the Json Transform

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # Quotes are here since Windows has issues with parsing of maven args with dots
-  mvn_options: --batch-mode "-Dstyle.color=always" "-Dorg.slf4j.simpleLogger.showDateTime=true" "-Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
+  mvn_options: --batch-mode -q "-Dstyle.color=always" "-Dorg.slf4j.simpleLogger.showDateTime=true" "-Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
                          locale. Turkish is a notoriously tricky locale. -->
         <surefire.argline>@{argLine} -Duser.language=TR -Duser.country=tr</surefire.argline>
         <kotlin.version>1.9.23</kotlin.version>
-        <json.version>20240303</json.version>
     </properties>
     <licenses>
         <license>
@@ -176,11 +175,6 @@
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
                          locale. Turkish is a notoriously tricky locale. -->
         <surefire.argline>@{argLine} -Duser.language=TR -Duser.country=tr</surefire.argline>
         <kotlin.version>1.9.23</kotlin.version>
+        <json.version>20240303</json.version>
     </properties>
     <licenses>
         <license>
@@ -175,6 +176,11 @@
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.version}</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -53,13 +53,11 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
 
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
         Iterator<IN> iterator = input.iterator();
-        while (iterator.hasNext()){
+        while (iterator.hasNext()) {
             data.add(apply(iterator.next(), schema) + (commaBetweenObjects && iterator.hasNext() ? "," : ""));
         }
 
-        return data.length() > 1 ? WRAPPERS[0] + LINE_SEPARATOR + data + LINE_SEPARATOR + WRAPPERS[1]
-            : data.toString();
-
+        return data.length() > 1 ? WRAPPERS[0] + LINE_SEPARATOR + data + LINE_SEPARATOR + WRAPPERS[1] : data.toString();
     }
 
     @Override
@@ -77,7 +75,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
 
     private void applyValue(IN input, StringBuilder sb, Object value) {
         if (value instanceof Collection<?>) {
-            sb.append(generate(input,(Collection) value));
+            sb.append(generate(input, (Collection) value));
         } else if (value != null && value.getClass().isArray()) {
             sb.append(generate(input, Arrays.asList((Object[]) value)));
         } else {
@@ -94,8 +92,8 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
                 sb.append(", ");
             }
             i++;
-            if (value instanceof CompositeField<?,?>) {
-                sb.append(apply(input,((CompositeField) value)));
+            if (value instanceof CompositeField<?, ?>) {
+                sb.append(apply(input, ((CompositeField) value)));
             } else {
                 applyValue(input, sb, value);
             }
@@ -190,7 +188,8 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
 
     public static class JsonTransformerBuilder<IN> {
 
-        private JsonTransformerBuilder() {}
+        private JsonTransformerBuilder() {
+        }
 
         private boolean commaBetweenObjects = true;
 

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -154,15 +154,6 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
         }
     }
 
-    /*
-     * The following entries are not added to the map because they are covered by another existing one
-     *
-     * map.put('\u0008', "\\u0008"); -> covered by map.put('\b', "\\b");
-     * map.put('\u0009', "\\u0009"); -> covered by map.put('\t', "\\t");
-     * map.put((char) 10, "\\u000A"); -> covered by map.put('\n', "\\n");
-     * map.put('\u000C', "\\u000C"); -> covered by map.put('\f', "\\f");
-     * map.put((char) 13, "\\u000D"); -> covered by map.put('\r', "\\r");
-     */
     private static Map<Character, String> createEscapeMap() {
         return Map.ofEntries(Map.entry('\\', "\\\\"),
             Map.entry('\"', "\\\""),

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -16,12 +16,12 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
     private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
     private static final char[] WRAPPERS = "[]".toCharArray();
     private final boolean commaBetweenObjects;
-    private final boolean prettPrint;
+    private final boolean prettyPrint;
 
 
     private JsonTransformer(boolean commaBetweenObjects, boolean prettyPrint) {
         this.commaBetweenObjects = commaBetweenObjects;
-        this.prettPrint = prettyPrint;
+        this.prettyPrint = prettyPrint;
     }
 
     public static <IN> JsonTransformer.JsonTransformerBuilder<IN> builder() {
@@ -41,7 +41,9 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             } else {
                 applyValue(input, sb, ((SimpleField) fields[i]).transform(input));
             }
-            if (i < fields.length - 1) sb.append(", ");
+            if (i < fields.length - 1) {
+                sb.append(", ");
+            }
         }
         sb.append("}");
         return sb.toString();
@@ -63,7 +65,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
 
         String result = size > 1 ? "" + WRAPPERS[0] + sb + WRAPPERS[1] : sb.toString();
 
-        return prettPrint ? result.startsWith("{")
+        return prettyPrint ? result.startsWith("{")
             ? new JSONObject(result).toString(2) : new JSONArray(result).toString(2) : result;
     }
 
@@ -83,7 +85,7 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
 
         String result = "" + WRAPPERS[0] + sb + WRAPPERS[1];
 
-        return prettPrint ? result.startsWith("{")
+        return prettyPrint ? result.startsWith("{")
             ? new JSONObject(result).toString(2) : new JSONArray(result).toString(2) : result;
     }
 
@@ -152,6 +154,15 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
         }
     }
 
+    /*
+     * The following entries are not added to the map because they are covered by another existing one
+     *
+     * map.put('\u0008', "\\u0008"); -> covered by map.put('\b', "\\b");
+     * map.put('\u0009', "\\u0009"); -> covered by map.put('\t', "\\t");
+     * map.put((char) 10, "\\u000A"); -> covered by map.put('\n', "\\n");
+     * map.put('\u000C', "\\u000C"); -> covered by map.put('\f', "\\f");
+     * map.put((char) 13, "\\u000D"); -> covered by map.put('\r', "\\r");
+     */
     private static Map<Character, String> createEscapeMap() {
         return Map.ofEntries(Map.entry('\\', "\\\\"),
             Map.entry('\"', "\\\""),
@@ -169,7 +180,17 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
             Map.entry('\u0005', "\\u0005"),
             Map.entry('\u0006', "\\u0006"),
             Map.entry('\u0007', "\\u0007"),
+            // map.put('\u0008', "\\u0008");
+            // covered by map.put('\b', "\\b");
+            // map.put('\u0009', "\\u0009");
+            // covered by map.put('\t', "\\t");
+            // map.put((char) 10, "\\u000A");
+            // covered by map.put('\n', "\\n");
             Map.entry('\u000B', "\\u000B"),
+            // map.put('\u000C', "\\u000C");
+            // covered by map.put('\f', "\\f");
+            // map.put((char) 13, "\\u000D");
+            // covered by map.put('\r', "\\r");
             Map.entry('\u000E', "\\u000E"),
             Map.entry('\u000F', "\\u000F"),
             Map.entry('\u0010', "\\u0010"),

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -11,7 +11,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -39,14 +39,8 @@ class JsonTest {
         String json = transformer.generate(schema, 2);
         String expected = """
             [
-              {
-                "Bool": false,
-                "Text": "Willis"
-              },
-              {
-                "Bool": true,
-                "Text": "Carlena"
-              }
+            {"Text": "Willis", "Bool": false},
+            {"Text": "Carlena", "Bool": true}
             ]""";
 
         assertThat(json).isEqualTo(expected);
@@ -67,8 +61,15 @@ class JsonTest {
             .build();
 
         String json = transformer.generate(fakeSequence, schema);
+
         String expected = """
-            [{"Number": 3, "Password": "nf3"}{"Number": 6, "Password": "4b0v69"}{"Number": 7, "Password": "00827v2"}{"Number": 1, "Password": "5"}{"Number": 3, "Password": "p6x"}]""";
+            [
+            {"Number": 3, "Password": "nf3"}
+            {"Number": 6, "Password": "4b0v69"}
+            {"Number": 7, "Password": "00827v2"}
+            {"Number": 1, "Password": "5"}
+            {"Number": 3, "Password": "p6x"}
+            ]""";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -82,33 +83,20 @@ class JsonTest {
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();
-        FakeSequence<Integer> fakeSequence = faker.<Integer>collection().suppliers(() -> faker.number().randomDigit())
-            .len(5).build();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>collection()
+            .suppliers(() -> faker.number().randomDigit())
+            .len(5)
+            .build();
 
         String json = transformer.generate(fakeSequence, schema);
 
         String expected = """
             [
-              {
-                "Number": 3,
-                "Password": "nf3"
-              },
-              {
-                "Number": 6,
-                "Password": "4b0v69"
-              },
-              {
-                "Number": 7,
-                "Password": "00827v2"
-              },
-              {
-                "Number": 1,
-                "Password": "5"
-              },
-              {
-                "Number": 3,
-                "Password": "p6x"
-              }
+            {"Number": 3, "Password": "nf3"},
+            {"Number": 6, "Password": "4b0v69"},
+            {"Number": 7, "Password": "00827v2"},
+            {"Number": 1, "Password": "5"},
+            {"Number": 3, "Password": "p6x"}
             ]""";
 
         assertThat(json).isEqualTo(expected);
@@ -123,13 +111,18 @@ class JsonTest {
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().withCommaBetweenObjects(false).build();
-        FakeSequence<Integer> fakeSequence = faker.<Integer>stream().suppliers(() -> faker.number().randomDigit())
-            .len(2).build();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
+            .suppliers(() -> faker.number().randomDigit())
+            .len(2)
+            .build();
 
         String json = transformer.generate(fakeSequence, schema);
 
         String expected = """
-            [{"Number": 3, "Password": "0p4"}{"Number": 8, "Password": "714487nf"}]""";
+            [
+            {"Number": 3, "Password": "0p4"}
+            {"Number": 8, "Password": "714487nf"}
+            ]""";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -143,7 +136,9 @@ class JsonTest {
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();
-        FakeSequence<Integer> fakeSequence = faker.<Integer>stream().suppliers(() -> faker.number().randomDigit()).build();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
+            .suppliers(() -> faker.number().randomDigit())
+            .build();
 
         assertThatThrownBy(() -> transformer.generate(fakeSequence, schema))
             .isInstanceOf(IllegalArgumentException.class)
@@ -161,9 +156,9 @@ class JsonTest {
     @MethodSource("generateTestSchema")
     void outputArrayJsonTestForJsonTransformer(
         Schema<String, String> schema, String expected) {
-        JsonTransformer<String> transformer = JsonTransformer.<String>builder().prettyPrint(false).build();
+        JsonTransformer<String> transformer = JsonTransformer.<String>builder().build();
 
-        assertThat(transformer.generate(schema, 2))
+        assertThat(transformer.generate(schema, 2).replaceAll(System.lineSeparator(), ""))
             .isEqualTo("[" + expected + "," + expected + "]");
     }
 
@@ -172,11 +167,14 @@ class JsonTest {
     void outputWithoutCommaForJsonTransformer(
         Schema<String, String> schema, String expected) {
         JsonTransformer<String> transformer = JsonTransformer.<String>builder().withCommaBetweenObjects(false).build();
-        assertThat(transformer.generate(schema, 2)).isEqualTo("[" + expected + expected + "]");
+
+        assertThat(transformer.generate(schema, 2).replaceAll(System.lineSeparator(), ""))
+            .isEqualTo("[" + expected + expected + "]");
     }
 
     private static Stream<Arguments> generateTestSchema() {
         return Stream.of(
+            of(Schema.of(), "{}"),
             of(
                 Schema.of(compositeField("key", new Field[]{field("key", () -> "value")})),
                 "{\"key\": {\"key\": \"value\"}}"),

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -5,25 +5,18 @@ import net.datafaker.providers.base.Name;
 import net.datafaker.sequence.FakeSequence;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
-import net.datafaker.transformations.JsonTransformer.JsonTransformerBuilder.FormattedAs;
 import net.datafaker.transformations.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.AbstractMap;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
-import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -39,10 +32,17 @@ class JsonTest {
 
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         String json = transformer.generate(schema, 2);
-        String expected = "{" + LINE_SEPARATOR +
-            "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
-            "{\"Text\": \"Carlena\", \"Bool\": true}" + LINE_SEPARATOR +
-            "}";
+        String expected = """
+            [
+              {
+                "Bool": false,
+                "Text": "Willis"
+              },
+              {
+                "Bool": true,
+                "Text": "Carlena"
+              }
+            ]""";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -62,14 +62,8 @@ class JsonTest {
             .build();
 
         String json = transformer.generate(fakeSequence, schema);
-
-        String expected = "{" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"nf3\"}" + LINE_SEPARATOR +
-            "{\"Number\": 6, \"Password\": \"4b0v69\"}" + LINE_SEPARATOR +
-            "{\"Number\": 7, \"Password\": \"00827v2\"}" + LINE_SEPARATOR +
-            "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"p6x\"}" + LINE_SEPARATOR +
-            "}";
+        String expected = """
+            [{"Number": 3, "Password": "nf3"}{"Number": 6, "Password": "4b0v69"}{"Number": 7, "Password": "00827v2"}{"Number": 1, "Password": "5"}{"Number": 3, "Password": "p6x"}]""";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -83,25 +77,39 @@ class JsonTest {
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();
-        FakeSequence<Integer> fakeSequence = faker.<Integer>collection()
-            .suppliers(() -> faker.number().randomDigit())
-            .len(5)
-            .build();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>collection().suppliers(() -> faker.number().randomDigit())
+            .len(5).build();
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "{" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"nf3\"}," + LINE_SEPARATOR +
-            "{\"Number\": 6, \"Password\": \"4b0v69\"}," + LINE_SEPARATOR +
-            "{\"Number\": 7, \"Password\": \"00827v2\"}," + LINE_SEPARATOR +
-            "{\"Number\": 1, \"Password\": \"5\"}," + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"p6x\"}" + LINE_SEPARATOR +
-            "}";
+        String expected = """
+            [
+              {
+                "Number": 3,
+                "Password": "nf3"
+              },
+              {
+                "Number": 6,
+                "Password": "4b0v69"
+              },
+              {
+                "Number": 7,
+                "Password": "00827v2"
+              },
+              {
+                "Number": 1,
+                "Password": "5"
+              },
+              {
+                "Number": 3,
+                "Password": "p6x"
+              }
+            ]""";
 
         assertThat(json).isEqualTo(expected);
     }
 
-	@Test
+    @Test
     void testGenerateFromFakeSequenceStream() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
@@ -109,24 +117,19 @@ class JsonTest {
             field("Password", integer -> faker.internet().password(integer, integer))
         );
 
-        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder()
-            .formattedAs(FormattedAs.JSON_ARRAY).withCommaBetweenObjects(false).build();
-        FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
-            .suppliers(() -> faker.number().randomDigit())
-            .len(2)
-            .build();
+        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().withCommaBetweenObjects(false).build();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>stream().suppliers(() -> faker.number().randomDigit())
+            .len(2).build();
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "[" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"0p4\"}" + LINE_SEPARATOR +
-            "{\"Number\": 8, \"Password\": \"714487nf\"}" + LINE_SEPARATOR +
-            "]";
+        String expected = """
+            [{"Number": 3, "Password": "0p4"}{"Number": 8, "Password": "714487nf"}]""";
 
         assertThat(json).isEqualTo(expected);
     }
 
-	@Test
+    @Test
     void testGenerateFromInfiniteFakeSequence() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
@@ -134,11 +137,8 @@ class JsonTest {
             field("Password", integer -> faker.internet().password(integer, integer))
         );
 
-        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder()
-            .formattedAs(FormattedAs.JSON_ARRAY).build();
-        FakeSequence<Integer> fakeSequence = faker.<Integer>stream()
-            .suppliers(() -> faker.number().randomDigit())
-            .build();
+        JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();
+        FakeSequence<Integer> fakeSequence = faker.<Integer>stream().suppliers(() -> faker.number().randomDigit()).build();
 
         assertThatThrownBy(() -> transformer.generate(fakeSequence, schema))
             .isInstanceOf(IllegalArgumentException.class)
@@ -156,9 +156,9 @@ class JsonTest {
     @MethodSource("generateTestSchema")
     void outputArrayJsonTestForJsonTransformer(
         Schema<String, String> schema, String expected) {
-        JsonTransformer<String> transformer = JsonTransformer.<String>builder().formattedAs(FormattedAs.JSON_ARRAY).build();
+        JsonTransformer<String> transformer = JsonTransformer.<String>builder().prettyPrint(false).build();
 
-        assertThat(transformer.generate(schema, 2).replaceAll(System.lineSeparator(), ""))
+        assertThat(transformer.generate(schema, 2))
             .isEqualTo("[" + expected + "," + expected + "]");
     }
 
@@ -167,14 +167,11 @@ class JsonTest {
     void outputWithoutCommaForJsonTransformer(
         Schema<String, String> schema, String expected) {
         JsonTransformer<String> transformer = JsonTransformer.<String>builder().withCommaBetweenObjects(false).build();
-
-        assertThat(transformer.generate(schema, 2).replaceAll(System.lineSeparator(), ""))
-            .isEqualTo("{" + expected +  expected + "}");
+        assertThat(transformer.generate(schema, 2)).isEqualTo("[" + expected + expected + "]");
     }
 
     private static Stream<Arguments> generateTestSchema() {
         return Stream.of(
-            of(Schema.of(), "{}"),
             of(
                 Schema.of(compositeField("key", new Field[]{field("key", () -> "value")})),
                 "{\"key\": {\"key\": \"value\"}}"),
@@ -242,16 +239,16 @@ class JsonTest {
             Schema.of(
                 field("text", () -> "Mrs. Brian Braun"),
                 field("objectCollection", () -> List.of(
-                    compositeField(null, new Field[]{
-                            field("country", () -> "Denmark"),
-                            field("city", () -> "Port Angel")
-                        }
-                    ),
-                    compositeField(null, new Field[]{
-                            field("two", () -> "Denmark"),
-                            field("one", () -> "Port Angel")
-                        }
-                    )
+                        compositeField(null, new Field[]{
+                                field("country", () -> "Denmark"),
+                                field("city", () -> "Port Angel")
+                            }
+                        ),
+                        compositeField(null, new Field[]{
+                                field("two", () -> "Denmark"),
+                                field("one", () -> "Port Angel")
+                            }
+                        )
                     )
                 )
             ), 1);

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
+import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -37,11 +38,10 @@ class JsonTest {
 
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         String json = transformer.generate(schema, 2);
-        String expected = """
-            [
-            {"Text": "Willis", "Bool": false},
-            {"Text": "Carlena", "Bool": true}
-            ]""";
+        String expected = "[" + LINE_SEPARATOR +
+            "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
+            "{\"Text\": \"Carlena\", \"Bool\": true}" + LINE_SEPARATOR +
+            "]";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -62,14 +62,13 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = """
-            [
-            {"Number": 3, "Password": "nf3"}
-            {"Number": 6, "Password": "4b0v69"}
-            {"Number": 7, "Password": "00827v2"}
-            {"Number": 1, "Password": "5"}
-            {"Number": 3, "Password": "p6x"}
-            ]""";
+        String expected = "[" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"nf3\"}" + LINE_SEPARATOR +
+            "{\"Number\": 6, \"Password\": \"4b0v69\"}" + LINE_SEPARATOR +
+            "{\"Number\": 7, \"Password\": \"00827v2\"}" + LINE_SEPARATOR +
+            "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"p6x\"}" + LINE_SEPARATOR +
+            "]";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -90,14 +89,13 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = """
-            [
-            {"Number": 3, "Password": "nf3"},
-            {"Number": 6, "Password": "4b0v69"},
-            {"Number": 7, "Password": "00827v2"},
-            {"Number": 1, "Password": "5"},
-            {"Number": 3, "Password": "p6x"}
-            ]""";
+        String expected = "[" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"nf3\"}," + LINE_SEPARATOR +
+            "{\"Number\": 6, \"Password\": \"4b0v69\"}," + LINE_SEPARATOR +
+            "{\"Number\": 7, \"Password\": \"00827v2\"}," + LINE_SEPARATOR +
+            "{\"Number\": 1, \"Password\": \"5\"}," + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"p6x\"}" + LINE_SEPARATOR +
+            "]";
 
         assertThat(json).isEqualTo(expected);
     }
@@ -118,11 +116,10 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = """
-            [
-            {"Number": 3, "Password": "0p4"}
-            {"Number": 8, "Password": "714487nf"}
-            ]""";
+        String expected = "[" + LINE_SEPARATOR +
+            "{\"Number\": 3, \"Password\": \"0p4\"}" + LINE_SEPARATOR +
+            "{\"Number\": 8, \"Password\": \"714487nf\"}" + LINE_SEPARATOR +
+            "]";
 
         assertThat(json).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
@@ -224,7 +224,7 @@ class FakeCollectionTest extends AbstractFakerTest {
     @Test
     void toNestedJson() {
         final int limit = 2;
-        JsonTransformer<Name> transformer = JsonTransformer.<Name>builder().formattedAs(JsonTransformer.JsonTransformerBuilder.FormattedAs.JSON_ARRAY).build();
+        JsonTransformer<Name> transformer = JsonTransformer.<Name>builder().build();
 
         FakeSequence<CompositeField<Address, String>> secondaryAddresses =
             faker.<CompositeField<Address, String>>collection()

--- a/src/test/java/net/datafaker/sequence/FakeStreamTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeStreamTest.java
@@ -256,7 +256,7 @@ class FakeStreamTest extends AbstractFakerTest {
     @Test
     void toNestedJson() {
         final int limit = 3;
-        JsonTransformer<Name> transformer = JsonTransformer.<Name>builder().formattedAs(JsonTransformer.JsonTransformerBuilder.FormattedAs.JSON_ARRAY).build();
+        JsonTransformer<Name> transformer = JsonTransformer.<Name>builder().build();
 
         FakeSequence<CompositeField<Address, String>> secondaryAddresses =
             faker.<CompositeField<Address, String>>collection()


### PR DESCRIPTION
## Description

This PR changes the `JsonTransformer` by generating the output as valid JSON data (except by the without comma approach). The output will always be valid when one or more data is generated.

Added extra `prettyPrint()` method to enable a more readable output.

## Changed

- Added the `prettyPrint()` method into `JsonTransformer` class along with the `json` library
  - This is set by default and will output the JSON value in a pretty print format
  - When disabled, one line String is generated
  - When using the `withCommaBetweenObjects`, the `prettyPrint()` is "disabled" (set to `false`) due to a parse error
    - parse error when there's no comma for multiple items
- Refactored `JsonTest`, `FakeStreamTest`, and `FakeCollectionTest` for methods using the `JsonTransformer` class