### PR TITLE
Parent filename could be null for resources in jar

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Locality.java
+++ b/src/main/java/net/datafaker/providers/base/Locality.java
@@ -53,8 +53,8 @@ public class Locality extends AbstractProvider<BaseProviders> {
         final String filename = file.getFileName().toString().toLowerCase(Locale.ROOT);
         if ((filename.endsWith(".yml") || filename.endsWith(".yaml")) && Files.isRegularFile(file) && Files.isReadable(file)) {
             final Path parent = file.getParent();
-            final String parentFileName = parent == null ? null : parent.getFileName().toString();
-            if (langs.contains(parentFileName)) {
+            final String parentFileName = parent == null || parent.getFileName() == null ? null : parent.getFileName().toString();
+            if (parentFileName != null && langs.contains(parentFileName)) {
                 locales.add(parentFileName);
             } else {
                 // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic


### PR DESCRIPTION
This should fix #1170 

to reproduce use datafaker-gen, especially this PR this https://github.com/datafaker-net/datafaker-gen/pull/10

to check that it is fixed use same PR and run it with (assuming this fixed is built and installed in local maven repo)
```
./mvnw clean install -Ddatafaker.version=2.2.2-SNAPSHOT
```

