### PR TITLE
Move FakerIntegrationTest to integration test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/FakerRepeatabilityIntegrationTest.java</exclude>
+                        <exclude>**/FakerIntegrationTest.java</exclude>
                     </excludes>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <argLine>${surefire.argline}</argLine>
@@ -462,6 +463,7 @@
                             </excludes>
                             <includes>
                                 <include>**/FakerRepeatabilityIntegrationTest.java</include>
+                                <include>**/FakerIntegrationTest.java</include>
                             </includes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This should help with https://github.com/datafaker-net/datafaker/issues/1173

The problem is that integration tests work with multiple locales and with multiple providers each of them should be initialized.
Sometimes it leads to the fact that initialization of one of them is not completed yet.
It's better to move it to integration test phase where almost everything should be initialized