### PR TITLE
Initial support for streams in transformers

### DIFF
--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -108,6 +108,18 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
+    @Override
+    public String getStartStream(Schema<IN, ?> schema) {
+        StringBuilder sb = new StringBuilder();
+        generateHeader(null, sb);
+        return sb.toString();
+    }
+
+    @Override
+    public String getEndStream() {
+        return null;
+    }
+
     public static class CsvTransformerBuilder<IN> {
         private String separator = DEFAULT_SEPARATOR;
         private char quote = DEFAULT_QUOTE;

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -120,6 +120,16 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
         throw new UnsupportedOperationException("Object as input is required");
     }
 
+    @Override
+    public String getStartStream(Schema<Object, ?> schema) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getEndStream() {
+        throw new UnsupportedOperationException();
+    }
+
     private Object getObject(Schema<Object, ?> schema, Object result, Constructor<?> recordConstructor) {
         final Field<Object, ?>[] fields = schema.getFields();
         final Object[] values = new Object[fields.length];

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -10,7 +10,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.StringJoiner;
 
-public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
+public class JsonTransformer<IN> implements Transformer<IN, String> {
 
     private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
     private static final char[] WRAPPERS = "[]".toCharArray();

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -10,7 +10,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.StringJoiner;
 
-public class JsonTransformer<IN> implements Transformer<IN, Object> {
+public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
 
     private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
     private static final char[] WRAPPERS = "[]".toCharArray();
@@ -71,6 +71,20 @@ public class JsonTransformer<IN> implements Transformer<IN, Object> {
         }
 
         return limit > 1 ? WRAPPERS[0] + LINE_SEPARATOR + sb + LINE_SEPARATOR + WRAPPERS[1] : sb.toString();
+    }
+
+    @Override
+    public String getStartStream(Schema<IN, ?> schema) {
+        return "[";
+    }
+
+    @Override
+    public String getEndStream() {
+        return "]";
+    }
+
+    public String getElementSeparator() {
+        return ",";
     }
 
     private void applyValue(IN input, StringBuilder sb, Object value) {

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -10,7 +10,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.StringJoiner;
 
-public class JsonTransformer<IN> implements Transformer<IN, String> {
+public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
 
     private static final Map<Character, String> ESCAPING_MAP = createEscapeMap();
     private static final char[] WRAPPERS = "[]".toCharArray();

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -1,11 +1,13 @@
 package net.datafaker.transformations;
 
+import java.util.stream.Stream;
+
 public interface Transformer<IN, OUT> {
     String LINE_SEPARATOR = System.lineSeparator();
 
     OUT apply(IN input, Schema<IN, ?> schema);
 
-    default OUT apply(IN input, Schema<IN, ?> schema, int rowId) {
+    default OUT apply(IN input, Schema<IN, ?> schema, long rowId) {
         // ignore rowId by default
         return apply(input, schema);
     }
@@ -13,4 +15,48 @@ public interface Transformer<IN, OUT> {
     OUT generate(Iterable<IN> input, final Schema<IN, ?> schema);
 
     OUT generate(final Schema<IN, ?> schema, int limit);
+
+
+    String getStartStream(final Schema<IN, ?> schema);
+
+    String getEndStream();
+
+    default String getLineSeparator() {
+        return LINE_SEPARATOR;
+    }
+
+    default String getElementSeparator() {
+        return "";
+    }
+
+
+    default Stream<OUT> generateStream(final Schema<IN, ?> schema, long limit) {
+        Item item = new Item(0);
+        return Stream.generate(() -> {
+            StringBuilder res = new StringBuilder();
+            if (item.current == 0) {
+                res.append(getStartStream(schema)).append(getLineSeparator());
+            }
+            res.append(apply(null, schema, item.current));
+
+            if (item.current == limit - 1) {
+                res.append(getLineSeparator()).append(getEndStream());
+            } else {
+                if (!getElementSeparator().isEmpty()) {
+                    res.append(getElementSeparator());
+                }
+            }
+            item.current++;
+            return (OUT) res.toString();
+        }).limit(limit);
+    }
+
+    class Item {
+        private long current;
+
+        public Item(long current) {
+            this.current = current;
+        }
+    }
+
 }

--- a/src/main/java/net/datafaker/transformations/XmlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/XmlTransformer.java
@@ -53,6 +53,16 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
+    @Override
+    public String getStartStream(Schema<IN, ?> schema) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getEndStream() {
+        throw new UnsupportedOperationException();
+    }
+
     public static class XmlTransformerBuilder<IN> {
 
         private boolean pretty = false;

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -49,6 +49,16 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
+    @Override
+    public String getStartStream(Schema<IN, ?> schema) {
+        return "";
+    }
+
+    @Override
+    public String getEndStream() {
+        return "";
+    }
+
     private String apply(final StringBuilder sb, final IN input, final Field<IN, ?>[] fields, final String offset) {
         Set<String> keys = new HashSet<>();
         for (Field<IN, ?> field : fields) {

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -65,10 +65,10 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         if (forceSqlQuoteIdentifierUsage) return true;
         for (int i = 0; i < name.length(); i++) {
             if (casing == Casing.TO_UPPER && Character.isLowerCase(name.charAt(i))
-                    || casing == Casing.TO_LOWER && Character.isUpperCase(name.charAt(i))
-                    || name.charAt(i) == openSqlIdentifier
-                    || name.charAt(i) == closeSqlIdentifier
-                    || name.charAt(i) == DEFAULT_CATALOG_SEPARATOR) {
+                || casing == Casing.TO_LOWER && Character.isUpperCase(name.charAt(i))
+                || name.charAt(i) == openSqlIdentifier
+                || name.charAt(i) == closeSqlIdentifier
+                || name.charAt(i) == DEFAULT_CATALOG_SEPARATOR) {
                 return true;
             }
         }
@@ -81,7 +81,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     @Override
-    public CharSequence apply(IN input, Schema<IN, ?> schema, int rowId) {
+    public CharSequence apply(IN input, Schema<IN, ?> schema, long rowId) {
         //noinspection unchecked
         Field<?, ? extends CharSequence>[] fields = (Field<?, ? extends CharSequence>[]) schema.getFields();
         if (fields.length == 0) {
@@ -90,17 +90,17 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         if (withBatchMode) {
             if (rowId == 0 || batchSize > 0 && rowId % batchSize == 0) {
                 return SqlDialect.getFirstRow(
-                        dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase);
+                    dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase);
             } else {
                 return String.join(LINE_SEPARATOR, ",",
-                        SqlDialect.getOtherRow(
+                    SqlDialect.getOtherRow(
                         dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase));
             }
         } else {
             return String.join(" ", INSERT_INTO.getValue(keywordCase),
-                    appendTableInfo(fields),
-                    VALUES.getValue(keywordCase),
-                    addValues(input, fields));
+                appendTableInfo(fields),
+                VALUES.getValue(keywordCase),
+                addValues(input, fields));
         }
     }
 
@@ -112,19 +112,19 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                 Object value = ((SimpleField<Object, ? extends CharSequence>) fields[i]).transform(input);
                 Class<?> clazz = value == null ? null : value.getClass();
                 if (value == null
-                        || value instanceof Number
-                        || value instanceof Boolean
-                        || clazz.isPrimitive()) {
+                    || value instanceof Number
+                    || value instanceof Boolean
+                    || clazz.isPrimitive()) {
                     result.add(String.valueOf(value));
                 } else if (clazz.isArray()) {
                     final Class<?> componentType = clazz.getComponentType();
                     result.add(ARRAY.getValue(keywordCase) + "[" +
-                            (componentType.isPrimitive()
-                                    ? handlePrimitivesInArray(componentType, value)
-                                    : handleObjectInArray(value)) + "]");
+                        (componentType.isPrimitive()
+                            ? handlePrimitivesInArray(componentType, value)
+                            : handleObjectInArray(value)) + "]");
                 } else if (value instanceof Collection) {
                     result.add(MULTISET.getValue(keywordCase) + "[" +
-                            handleObjectInCollection(value) + "]");
+                        handleObjectInCollection(value) + "]");
                 } else {
                     result.add(handleObject(value));
                 }
@@ -171,12 +171,12 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
             if (value.getClass().isArray()) {
                 final Class<?> componentType = value.getClass().getComponentType();
                 String array = componentType.isPrimitive()
-                        ? handlePrimitivesInArray(componentType, value)
-                        : handleObjectInArray(value);
+                    ? handlePrimitivesInArray(componentType, value)
+                    : handleObjectInArray(value);
                 return ARRAY.getValue(keywordCase) + "[" + array + "]";
             } else if (value instanceof Collection) {
                 return MULTISET.getValue(keywordCase)
-                        + "[" + handleObjectInCollection(value) + "]";
+                    + "[" + handleObjectInCollection(value) + "]";
             } else {
                 String strValue = value.toString();
                 final int length = strValue.length();
@@ -336,6 +336,16 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
+    @Override
+    public String getStartStream(Schema<IN, ?> schema) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getEndStream() {
+        throw new UnsupportedOperationException();
+    }
+
     private String generateBatchModeStatements(Schema<IN, ?> schema, List<IN> inputs, int limit) {
         StringBuilder sb = new StringBuilder();
         limit = inputs != null ? Math.min(limit, inputs.size()) : limit;
@@ -433,11 +443,11 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         public SqlTransformer<IN> build() {
             if (dialect == null) {
                 return new SqlTransformer<>(
-                        schemaName, tableName, quote, null, sqlQuoteIdentifier, casing, withBatchMode, batchSize, keywordCase, forceSqlQuoteIdentifierUsage);
+                    schemaName, tableName, quote, null, sqlQuoteIdentifier, casing, withBatchMode, batchSize, keywordCase, forceSqlQuoteIdentifierUsage);
             } else {
                 return new SqlTransformer<>(
-                        schemaName, tableName, quote, dialect, dialect.getSqlQuoteIdentifier(), dialect.getUnquotedCasing(),
-                        withBatchMode, batchSize, keywordCase, forceSqlQuoteIdentifierUsage);
+                    schemaName, tableName, quote, dialect, dialect.getSqlQuoteIdentifier(), dialect.getUnquotedCasing(),
+                    withBatchMode, batchSize, keywordCase, forceSqlQuoteIdentifierUsage);
             }
         }
     }

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -40,17 +40,17 @@ class JsonTest {
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         Stream<CharSequence> json = transformer.generateStream(schema, 10);
         String output = json.collect(Collectors.joining(LINE_SEPARATOR));
-        assertThat(output).isEqualTo("[\n" +
-            "{\"Text\": \"Willis\", \"Bool\": false},\n" +
-            "{\"Text\": \"Carlena\", \"Bool\": true},\n" +
-            "{\"Text\": \"Stephnie\", \"Bool\": true},\n" +
-            "{\"Text\": \"Rutha\", \"Bool\": true},\n" +
-            "{\"Text\": \"Armand\", \"Bool\": true},\n" +
-            "{\"Text\": \"Margot\", \"Bool\": false},\n" +
-            "{\"Text\": \"Patrick\", \"Bool\": false},\n" +
-            "{\"Text\": \"Alphonse\", \"Bool\": false},\n" +
-            "{\"Text\": \"Louisa\", \"Bool\": true},\n" +
-            "{\"Text\": \"Caryn\", \"Bool\": false}\n" +
+        assertThat(output).isEqualTo("[" + LINE_SEPARATOR +
+            "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
+            "{\"Text\": \"Carlena\", \"Bool\": true}," + LINE_SEPARATOR +
+            "{\"Text\": \"Stephnie\", \"Bool\": true}," + LINE_SEPARATOR +
+            "{\"Text\": \"Rutha\", \"Bool\": true}," + LINE_SEPARATOR +
+            "{\"Text\": \"Armand\", \"Bool\": true}," + LINE_SEPARATOR +
+            "{\"Text\": \"Margot\", \"Bool\": false}," + LINE_SEPARATOR +
+            "{\"Text\": \"Patrick\", \"Bool\": false}," + LINE_SEPARATOR +
+            "{\"Text\": \"Alphonse\", \"Bool\": false}," + LINE_SEPARATOR +
+            "{\"Text\": \"Louisa\", \"Bool\": true}," + LINE_SEPARATOR +
+            "{\"Text\": \"Caryn\", \"Bool\": false}" + LINE_SEPARATOR +
             "]");
     }
 

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -38,7 +38,7 @@ class JsonTest {
         );
 
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
-        Stream<CharSequence> json = transformer.generateStream(schema, 10);
+        Stream<String> json = transformer.generateStream(schema, 10);
         String output = json.collect(Collectors.joining(LINE_SEPARATOR));
         assertThat(output).isEqualTo("[\n" +
             "{\"Text\": \"Willis\", \"Bool\": false},\n" +

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
@@ -28,6 +29,31 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 class JsonTest {
+    @Test
+    void testJsonStream() {
+        BaseFaker faker = new BaseFaker(new Random(10L));
+        Schema<Object, ?> schema = Schema.of(
+            field("Text", () -> faker.name().firstName()),
+            field("Bool", () -> faker.bool().bool())
+        );
+
+        JsonTransformer<Object> transformer = JsonTransformer.builder().build();
+        Stream<CharSequence> json = transformer.generateStream(schema, 10);
+        String output = json.collect(Collectors.joining(LINE_SEPARATOR));
+        assertThat(output).isEqualTo("[\n" +
+            "{\"Text\": \"Willis\", \"Bool\": false},\n" +
+            "{\"Text\": \"Carlena\", \"Bool\": true},\n" +
+            "{\"Text\": \"Stephnie\", \"Bool\": true},\n" +
+            "{\"Text\": \"Rutha\", \"Bool\": true},\n" +
+            "{\"Text\": \"Armand\", \"Bool\": true},\n" +
+            "{\"Text\": \"Margot\", \"Bool\": false},\n" +
+            "{\"Text\": \"Patrick\", \"Bool\": false},\n" +
+            "{\"Text\": \"Alphonse\", \"Bool\": false},\n" +
+            "{\"Text\": \"Louisa\", \"Bool\": true},\n" +
+            "{\"Text\": \"Caryn\", \"Bool\": false}\n" +
+            "]");
+    }
+
     @Test
     void testGenerateFromSchemaWithLimit() {
         BaseFaker faker = new BaseFaker(new Random(10L));

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -38,7 +38,7 @@ class JsonTest {
         );
 
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
-        Stream<String> json = transformer.generateStream(schema, 10);
+        Stream<CharSequence> json = transformer.generateStream(schema, 10);
         String output = json.collect(Collectors.joining(LINE_SEPARATOR));
         assertThat(output).isEqualTo("[\n" +
             "{\"Text\": \"Willis\", \"Bool\": false},\n" +


### PR DESCRIPTION
This adds a feature of streams generation in transformers
with it will be possible to make transformations with huge numbers like 
```java
        BaseFaker faker = new BaseFaker(new Random(10L));
        Schema<Object, ?> schema = Schema.of(
            field("Text", () -> faker.name().firstName()),
            field("Bool", () -> faker.bool().bool())
        );

        JsonTransformer<Object> transformer = JsonTransformer.builder().build();
        Stream<CharSequence> json = transformer.generateStream(schema, 1000_000_000);
        json.forEach(System.out::println);
```