### PR TITLE
show actual values in error message

### DIFF
--- a/src/test/java/net/datafaker/Issue759Test.java
+++ b/src/test/java/net/datafaker/Issue759Test.java
@@ -82,7 +82,7 @@ class Issue759Test {
                 if (allElementsEqual(iters, iterationsPerThread)) {
                     break;
                 } else {
-                    throw new AssertionError("Not all of s%s are not equal to %s".formatted(Arrays.toString(iters), iterationsPerThread));
+                    throw new AssertionError("Not all of %s are equal to %s".formatted(Arrays.toString(iters), iterationsPerThread));
                 }
             }
             lastIters = iters;

--- a/src/test/java/net/datafaker/Issue759Test.java
+++ b/src/test/java/net/datafaker/Issue759Test.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.Arrays;
 
-class Issue759 {
+class Issue759Test {
     static class WorkerThread extends Thread {
         final Faker _faker;
         final int _workerNum;
@@ -56,13 +56,6 @@ class Issue759 {
         return true;
     }
 
-    static void printIterations(int[] arr) {
-        for (int n : arr) {
-            System.err.print(" " + n);
-        }
-        System.err.println();
-    }
-
     @RepeatedTest(10)
     void issue759Test() throws InterruptedException {
         final int numThreads = 5;
@@ -89,8 +82,7 @@ class Issue759 {
                 if (allElementsEqual(iters, iterationsPerThread)) {
                     break;
                 } else {
-                    printIterations(iters);
-                    throw new RuntimeException();
+                    throw new AssertionError("Not all of s%s are not equal to %s".formatted(Arrays.toString(iters), iterationsPerThread));
                 }
             }
             lastIters = iters;

--- a/src/test/java/net/datafaker/Issue759Test.java
+++ b/src/test/java/net/datafaker/Issue759Test.java
@@ -59,7 +59,7 @@ class Issue759Test {
     @RepeatedTest(10)
     void issue759Test() throws InterruptedException {
         final int numThreads = 5;
-        final int iterationsPerThread = 60000;
+        final int iterationsPerThread = 20000;
 
         final Faker faker = new Faker();
 


### PR DESCRIPTION
... instead of just throwing an empty runtime exception.

### Problem
Before this change, test might fail with an unclear message:

```java
java.lang.RuntimeException
	at net.datafaker.Issue759.issue759Test(Issue759.java:93)
```

or the output of multiple failing tests might be mixed:
```java
 0 0 0 0 0
 0 0 0 0 0
 0 0 0 0 0 0
 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 0 0 0 0 0
 0 0 0
 0 0 0
 0 0 0
 0

 0 0 0 0 0

java.lang.RuntimeException
	at net.datafaker.Issue759.issue759Test(Issue759.java:93)
```

### Solution
Now the error message is clear:
```java
java.lang.AssertionError: Not all of s[0, 0, 0, 0, 0] are not equal to 20000

	at net.datafaker.Issue759Test.issue759Test(Issue759Test.java:85)
```

### P.S.
To reproduce the issue, just put breakpoint, say, to any field of `WorkerThread`, run `Issue759` test in debug mode and resume the execution after stopping on the breakpoint.