### PR TITLE
Modify the enrichment provider classes map in BaseFaker 

### DIFF
--- a/src/main/java/net/datafaker/providers/base/BaseFaker.java
+++ b/src/main/java/net/datafaker/providers/base/BaseFaker.java
@@ -327,7 +327,7 @@ public class BaseFaker implements BaseProviders {
         if (result == null) {
             final AP newMapping = valueSupplier.apply(faker);
             final String simpleName = clazz.getSimpleName();
-            CLASSES.put(simpleName, new ConcurrentHashMap<>());
+            CLASSES.putIfAbsent(simpleName, new ConcurrentHashMap<>());
 
             Method[] methods = clazz.getMethods();
             Class newMappingClass = newMapping.getClass();

--- a/src/test/java/net/datafaker/providers/base/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/CustomFakerTest.java
@@ -100,4 +100,14 @@ class CustomFakerTest {
         BaseFaker faker = new BaseFaker();
         assertThat(BaseFaker.getProvider(Insect.class, Insect::new, faker).nextInsectName()).matches("[A-Za-z ]+");
     }
+
+    @Test
+    void testMultipleFakerContextsPerOneClassName() {
+        BaseFaker faker1 = new BaseFaker(Locale.ENGLISH);
+        BaseFaker faker2 = new BaseFaker(Locale.GERMAN);
+        faker1.getProvider(Insect.class, Insect::new);
+        faker2.getProvider(Insect.class, Insect::new);
+        assertThat(BaseFaker.getProvider("Insect",  faker1.getContext())).isNotNull();
+        assertThat(BaseFaker.getProvider("Insect",  faker2.getContext())).isNotNull();
+    }
 }


### PR DESCRIPTION
PR Modify the enrichment provider classes map in BaseFaker to store a complete list of generated FakerContext.
: #1190

This allows you to store multiple locals for one class in the net.datafaker.providers.base.BaseFaker#CLASSES map.
Before this, every call to the net.datafaker.providers.base.BaseFaker#getProvider(java.lang.Class<AP>, java.util.function.Function<PR,AP>, PR) method would overwrite the map for one class name, making the cache ineffective.