### PR TITLE
fix: Aviation Test

### DIFF
--- a/src/test/java/net/datafaker/providers/base/AviationTest.java
+++ b/src/test/java/net/datafaker/providers/base/AviationTest.java
@@ -47,7 +47,7 @@ class AviationTest extends BaseFakerTest<BaseFaker> {
 
     @Override
     protected Collection<TestSpec> providerListTest() {
-        return List.of(TestSpec.of(aviation::airport, "aviation.airport", "\\w{4}"),
+        return List.of(TestSpec.of(aviation::airport, "aviation.airport", "\\w{3,4}"),
             TestSpec.of(aviation::airportName, "aviation.airport_name"),
             TestSpec.of(aviation::airplane, "aviation.aircraft.airplane"),
             TestSpec.of(aviation::warplane, "aviation.aircraft.warplane"),


### PR DESCRIPTION
Following the failure here: https://github.com/datafaker-net/datafaker/actions/runs/9324424830/job/25669623466#step:4:1

Which apparently only had a 1 in 4037 chance of happening on any given test run, lucky us :grinning:

I threw together this temporary test (I'm sure there are more elegant ways to do this, it was just a quick thing):
```java
@Test
void checkLengths() {
	List<String> entries = getBaseList("aviation.airport");
	System.out.println(entries.size());
	Map<Integer, Integer> lenMap = new HashMap<>();
	lenMap.put(1, 0);
	lenMap.put(2, 0);
	lenMap.put(3, 0);
	lenMap.put(4, 0);
	lenMap.put(5, 0);
	lenMap.put(6, 0);
	for (String entry : entries) {
		Integer count = lenMap.get(entry.length());
		count++;
		lenMap.put(entry.length(), count);
		if (entry.length() != 4) {
			System.out.println(entry);
		}
	}
	System.out.println(lenMap);
}
```

Which produced:
```console
4037
N55
{1=0, 2=0, 3=1, 4=4036, 5=0, 6=0}
```

Indeed N55 is a valid airport: https://www.google.com/search?q=N55+airport - Jaluit Airport

So I've adjusted the regex in the test to allow length 3 or 4.