### PR TITLE
Mark Internet#pass deprecated

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -176,26 +176,62 @@ public class Internet extends AbstractProvider<BaseProviders> {
         return resolve("internet.http_method");
     }
 
+    /**
+     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
+     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
+     * as an example.
+     */
+    @Deprecated(since = "2.3.0")
     public String password() {
         return password(8, 16);
     }
 
+    /**
+     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
+     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
+     * as an example.
+     */
+    @Deprecated(since = "2.3.0")
     public String password(boolean includeDigit) {
         return password(8, 16, false, false, includeDigit);
     }
 
+    /**
+     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
+     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
+     * as an example.
+     */
+    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength) {
         return password(minimumLength, maximumLength, false);
     }
 
+    /**
+     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
+     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
+     * as an example.
+     */
+    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase) {
         return password(minimumLength, maximumLength, includeUppercase, false);
     }
 
+    /**
+     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
+     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
+     * as an example.
+     */
+    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial) {
         return password(minimumLength, maximumLength, includeUppercase, includeSpecial, true);
     }
 
+    /**
+     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
+     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
+     * as an example.
+     */
+    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
         return faker.text().text(minimumLength, maximumLength, includeUppercase, includeSpecial, includeDigit);
     }

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -177,9 +177,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
-     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
-     * as an example.
+     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
      */
     @Deprecated(since = "2.3.0")
     public String password() {
@@ -187,9 +185,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
-     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
-     * as an example.
+     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
      */
     @Deprecated(since = "2.3.0")
     public String password(boolean includeDigit) {
@@ -197,9 +193,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
-     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
-     * as an example.
+     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
      */
     @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength) {
@@ -207,9 +201,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
-     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
-     * as an example.
+     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
      */
     @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase) {
@@ -217,9 +209,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
-     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
-     * as an example.
+     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
      */
     @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial) {
@@ -227,9 +217,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Consider usage of {@link net.datafaker.providers.base.Text#text} instead,
-     * look at net.datafaker.providers.base.TextTest#textShouldContain3RULowerCaseAnd5CustomSpecialSymbols()
-     * as an example.
+     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
      */
     @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {

--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -73,7 +73,7 @@ public class Text extends AbstractProvider<BaseProviders> {
         if (config == null) {
             TextSymbolsBuilder builder =
                 TextSymbolsBuilder.builder()
-                                  .with(Text.EN_LOWERCASE);
+                    .with(Text.EN_LOWERCASE);
             if (includeUppercase) builder = builder.with(Text.EN_UPPERCASE, 1);
             if (includeSpecial) builder = builder.with(Text.DEFAULT_SPECIAL, 1);
             if (includeDigit) builder = builder.with(Text.DIGITS, 1);
@@ -168,6 +168,33 @@ public class Text extends AbstractProvider<BaseProviders> {
         }
     }
 
+    /**
+     * Allows to configure custom expected rules. Example
+     * <pre>
+     *     faker.text().text(Text.TextSymbolsBuilder.builder()
+     *                 .len(5)
+     *                 .with(EN_LOWERCASE, 1)
+     *                 .with(EN_UPPERCASE, 1)
+     *                 .with(DIGITS, 1);
+     * </pre>
+     * This will generate a text with length 5, minimum 1 lower case and 1 upper case symbol
+     * from en locale and minimum 1 digit.
+     * Custom symbol sets are also possible
+     * <pre>
+     *     final String ruLowerCase = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя";
+     *     final String customSpecialSymbols = "!@#$%^&*;'][{}";
+     *     final int ruCnt = 3;
+     *     final int specSmbCnt = 5;
+     *     final Text.TextRuleConfig config = Text.TextSymbolsBuilder.builder()
+     *         .len(faker.number().numberBetween(ruCnt + specSmbCnt, Math.max(ruCnt + specSmbCnt, 10)))
+     *         .with(ruLowerCase, ruCnt)
+     *         .with(customSpecialSymbols, specSmbCnt).build();
+     *     final String text = faker.text().text(config);
+     * </pre>
+     * This will generate a string with length between 8 and 10. The string will contain min 3 lower case symbols
+     * from RU locale and minimum 5 symbols from the defined string var
+     * {@code final String customSpecialSymbols = "!@#$%^&*;'][{}";}.
+     */
     public String text(TextRuleConfig textRuleConfig) {
         final int fixedNumberOfCharacters = textRuleConfig.getFixedNumberOfCharacters();
         final int numberOfRequiredSymbols = textRuleConfig.getNumberOfRequiredSymbols();

--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -185,7 +185,7 @@ public class Text extends AbstractProvider<BaseProviders> {
      * <pre>
      * {@code
      *     final String ruLowerCase = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя";
-     *     final String customSpecialSymbols = "!@#$%^&*;'][{}";
+     *     final String customSpecialSymbols = "!@#$%^*;'][{}";
      *     final int ruCnt = 3;
      *     final int specSmbCnt = 5;
      *     final Text.TextRuleConfig config = Text.TextSymbolsBuilder.builder()
@@ -198,7 +198,7 @@ public class Text extends AbstractProvider<BaseProviders> {
      * This will generate a string with length between 8 and 10.
      * The string will contain min 3 lower case symbols
      * from ru locale and minimum 5 symbols from the defined string var
-     * {@code final String customSpecialSymbols = "!@#$%^&*;'][{}";}.
+     * {@code final String customSpecialSymbols = "!@#$%^*;'][{}";}.
      */
     public String text(TextRuleConfig textRuleConfig) {
         final int fixedNumberOfCharacters = textRuleConfig.getFixedNumberOfCharacters();

--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -171,16 +171,19 @@ public class Text extends AbstractProvider<BaseProviders> {
     /**
      * Allows to configure custom expected rules. Example
      * <pre>
+     * {@code
      *     faker.text().text(Text.TextSymbolsBuilder.builder()
      *                 .len(5)
      *                 .with(EN_LOWERCASE, 1)
      *                 .with(EN_UPPERCASE, 1)
      *                 .with(DIGITS, 1);
+     * }
      * </pre>
-     * This will generate a text with length 5, minimum 1 lower case and 1 upper case symbol
+     * This will generate a text with length 5 containing minimum 1 lower case and 1 upper case symbol
      * from en locale and minimum 1 digit.
      * Custom symbol sets are also possible
      * <pre>
+     * {@code
      *     final String ruLowerCase = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя";
      *     final String customSpecialSymbols = "!@#$%^&*;'][{}";
      *     final int ruCnt = 3;
@@ -190,9 +193,11 @@ public class Text extends AbstractProvider<BaseProviders> {
      *         .with(ruLowerCase, ruCnt)
      *         .with(customSpecialSymbols, specSmbCnt).build();
      *     final String text = faker.text().text(config);
+     * }
      * </pre>
-     * This will generate a string with length between 8 and 10. The string will contain min 3 lower case symbols
-     * from RU locale and minimum 5 symbols from the defined string var
+     * This will generate a string with length between 8 and 10.
+     * The string will contain min 3 lower case symbols
+     * from ru locale and minimum 5 symbols from the defined string var
      * {@code final String customSpecialSymbols = "!@#$%^&*;'][{}";}.
      */
     public String text(TextRuleConfig textRuleConfig) {


### PR DESCRIPTION
`Internet#password` is very limited with its functionality and we should encourage users to use `Text` instead which covers much more cases