### PR TITLE
fix flaky test: remove leasing "0" from generated phone number

### DIFF
--- a/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
@@ -71,7 +71,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
         final PhoneNumber phoneNumberProvider = faker.phoneNumber();
         for (int i = 0; i < COUNT; i++) {
             String phoneNumber = phoneNumberProvider.phoneNumber();
-            Phonenumber.PhoneNumber proto = util.parse(phoneNumber, locale.getCountry());
+            Phonenumber.PhoneNumber proto = parse(phoneNumber, locale.getCountry());
             assertThat(util.isValidNumberForRegion(proto, locale.getCountry()))
                 .as(() -> "Invalid phone %s for locale %s".formatted(phoneNumber, locale))
                 .isTrue();
@@ -85,7 +85,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
         final PhoneNumber phoneNumberProvider = faker.phoneNumber();
         for (int i = 0; i < COUNT; i++) {
             String phoneNumber = phoneNumberProvider.phoneNumberInternational();
-            Phonenumber.PhoneNumber proto = util.parse(phoneNumber, locale.getCountry());
+            Phonenumber.PhoneNumber proto = parse(phoneNumber, locale.getCountry());
             assertThat(util.isValidNumberForRegion(proto, locale.getCountry()))
                 .as(() -> "Invalid phone %s for locale %s".formatted(phoneNumber, locale))
                 .isTrue();
@@ -99,7 +99,7 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
         final PhoneNumber phoneNumberProvider = faker.phoneNumber();
         for (int i = 0; i < COUNT; i++) {
             String phoneNumber = phoneNumberProvider.cellPhone();
-            Phonenumber.PhoneNumber proto = util.parse(phoneNumber, locale.getCountry());
+            Phonenumber.PhoneNumber proto = parse(phoneNumber, locale.getCountry());
             assertThat(util.isValidNumberForRegion(proto, locale.getCountry()))
                 .as(() -> "Invalid phone %s for locale %s".formatted(phoneNumber, locale))
                 .isTrue();
@@ -113,11 +113,16 @@ class PhoneNumberTest extends BaseFakerTest<BaseFaker> {
         final PhoneNumber phoneNumberProvider = faker.phoneNumber();
         for (int i = 0; i < COUNT; i++) {
             String phoneNumber = phoneNumberProvider.cellPhoneInternational();
-            Phonenumber.PhoneNumber proto = util.parse(phoneNumber, locale.getCountry());
+            Phonenumber.PhoneNumber proto = parse(phoneNumber, locale.getCountry());
             assertThat(util.isValidNumberForRegion(proto, locale.getCountry()))
                 .as(() -> "Invalid phone %s for locale %s".formatted(phoneNumber, locale))
                 .isTrue();
         }
+    }
+
+    private Phonenumber.PhoneNumber parse(String generatedNumber, String countryCode) throws NumberParseException {
+        String normalizedNumber = "IT".equals(countryCode) || "HU".equals(countryCode) ? generatedNumber : generatedNumber.replaceFirst("^0(.+)", "$1");
+        return util.parse(normalizedNumber, countryCode);
     }
 
     // `new Locale("en", "IND")` in `new Locale("en", "IND"), "IN")` is a Java's Locale

--- a/src/test/java/net/datafaker/providers/base/PhoneNumberValidityFinderTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhoneNumberValidityFinderTest.java
@@ -49,12 +49,17 @@ class PhoneNumberValidityFinderTest extends BaseFakerTest<BaseFaker> {
         PhoneNumber phoneNumberGenerator = f.phoneNumber();
         for (int i = 0; i < COUNT; i++) {
             String generatedNumber = phoneNumberGenerator.phoneNumber();
-            Phonenumber.PhoneNumber parsedNumber = util.parse(generatedNumber, phoneNumberGenerator.countryCodeIso2());
+            Phonenumber.PhoneNumber parsedNumber = parse(generatedNumber, phoneNumberGenerator.countryCodeIso2());
 
             assertThat(util.isValidNumber(parsedNumber))
                 .as(() -> "Generated phone number %s for locale %s (country: %s)".formatted(generatedNumber, supportedLocale, phoneNumberGenerator.countryCodeIso2()))
                 .isTrue();
         }
+    }
+
+    private Phonenumber.PhoneNumber parse(String generatedNumber, String countryCode) throws NumberParseException {
+        String normalizedNumber = "IT".equals(countryCode) || "HU".equals(countryCode) ? generatedNumber : generatedNumber.replaceFirst("^0(.+)", "$1");
+        return util.parse(normalizedNumber, countryCode);
     }
 
     public Stream<Arguments> allSupportedLocales() {


### PR DESCRIPTION
the leading "0" makes the generated phone number an invalid in very rare cases in Argentina. For example, "011 1579-5896" was generated from AR pattern, but occurred to be invalid.

And it seems that "0" is still needed in Italy.