### PR TITLE
Add Spark SQL dialect

### DIFF
--- a/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
@@ -10,7 +10,9 @@ import static net.datafaker.transformations.sql.SqlDialect.AuxiliaryConstants.DE
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.INSERT_ALL;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.INSERT_INTO;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.INTO;
+import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.ROW;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.SELECT_1_FROM_DUAL;
+import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.NAMED_STRUCT;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.VALUES;
 
 public enum SqlDialect {
@@ -45,7 +47,34 @@ public enum SqlDialect {
     REDSHIFT("\"", Casing.TO_LOWER),
     SNOWFLAKE("\""),
     TERADATA("\""),
-    VERTICA("\"", Casing.UNCHANGED);
+    VERTICA("\"", Casing.UNCHANGED),
+    SPARKSQL("`",
+        (columns, values, caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; },
+        (columns, values, caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; },
+        (caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; }
+    ) {
+
+        @Override
+        public String getCompositePrefix(SqlTransformer.Case caze) {
+            return NAMED_STRUCT.getValue(caze);
+        }
+
+        @Override
+        public String getArrayStart() {
+            return "(";
+        }
+
+        @Override
+        public String getArrayEnd() {
+            return ")";
+        }
+
+        @Override
+        public String getFieldPrefix(String fieldName) {
+            return fieldName;
+        }
+    };
+
     private final String sqlQuoteIdentifier;
     private final Casing unquotedCasing;
     private final TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchFirstRow;
@@ -53,6 +82,7 @@ public enum SqlDialect {
     private final Function<SqlTransformer.Case, String> lastBatchRow;
 
     private static final String DEFAULT_BEFORE_EACH_BATCH_PREFIX = "       ";
+
 
     SqlDialect(String sqlQuoteIdentifier, Casing casing, TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchFirstRow,
                TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchOtherRows, Function<SqlTransformer.Case, String> lastBatchRow) {
@@ -101,7 +131,30 @@ public enum SqlDialect {
         return dialect == null ? "" : dialect.lastBatchRow.apply(caze);
     }
 
+    public String getCompositePrefix(SqlTransformer.Case caze) {
+        return ROW.getValue(caze);
+    }
+
+    /**
+     * Fields might have a prefix such as field name.
+     * Default "" works for most dialects.
+     */
+    public String getFieldPrefix(String fieldName) {
+        return "";
+    }
+
+    public String getArrayStart() {
+        return "[";
+    }
+
+    public String getArrayEnd() {
+        return "]";
+    }
+
     static class AuxiliaryConstants {
+        static final UnsupportedOperationException BATCH_UNSUPPORTED =
+            new UnsupportedOperationException("This dialect not support batch insert.");
+
         static final TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> DEFAULT_FIRST_ROW = (supplier, supplier2, caze) -> {
             final String insertAll = INSERT_INTO.getValue(caze) + " ";
             final String values = LINE_SEPARATOR + VALUES.getValue(caze) + " ";

--- a/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
@@ -46,8 +46,6 @@ public enum SqlDialect {
     PRESTO("\"", Casing.UNCHANGED),
     REDSHIFT("\"", Casing.TO_LOWER),
     SNOWFLAKE("\""),
-    TERADATA("\""),
-    VERTICA("\"", Casing.UNCHANGED),
     SPARKSQL("`",
         (columns, values, caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; },
         (columns, values, caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; },
@@ -73,7 +71,9 @@ public enum SqlDialect {
         public String getFieldPrefix(String fieldName) {
             return fieldName;
         }
-    };
+    },
+    TERADATA("\""),
+    VERTICA("\"", Casing.UNCHANGED);
 
     private final String sqlQuoteIdentifier;
     private final Casing unquotedCasing;
@@ -82,8 +82,7 @@ public enum SqlDialect {
     private final Function<SqlTransformer.Case, String> lastBatchRow;
 
     private static final String DEFAULT_BEFORE_EACH_BATCH_PREFIX = "       ";
-
-
+    
     SqlDialect(String sqlQuoteIdentifier, Casing casing, TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchFirstRow,
                TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchOtherRows, Function<SqlTransformer.Case, String> lastBatchRow) {
         this.sqlQuoteIdentifier = sqlQuoteIdentifier;

--- a/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
@@ -74,7 +74,6 @@ public enum SqlDialect {
     },
     TERADATA("\""),
     VERTICA("\"", Casing.UNCHANGED);
-
     private final String sqlQuoteIdentifier;
     private final Casing unquotedCasing;
     private final TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchFirstRow;
@@ -82,7 +81,7 @@ public enum SqlDialect {
     private final Function<SqlTransformer.Case, String> lastBatchRow;
 
     private static final String DEFAULT_BEFORE_EACH_BATCH_PREFIX = "       ";
-    
+
     SqlDialect(String sqlQuoteIdentifier, Casing casing, TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchFirstRow,
                TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> batchOtherRows, Function<SqlTransformer.Case, String> lastBatchRow) {
         this.sqlQuoteIdentifier = sqlQuoteIdentifier;

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -133,7 +133,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                             ? handlePrimitivesInArray(componentType, value)
                             : handleObjectInArray(value)) + dialect.getArrayEnd());
                 } else if (value instanceof Map) {
-                    result.add(MAP.getValue(keywordCase) + "(" + handeObjectInMap(value) + ")");
+                    result.add(MAP.getValue(keywordCase) + "(" + handleObjectInMap(value) + ")");
                 } else if (value instanceof Collection) {
                     result.add(MULTISET.getValue(keywordCase) + "[" +
                         handleObjectInCollection(value) + "]");
@@ -176,7 +176,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         return result.toString();
     }
 
-    private String handeObjectInMap(Object value) {
+    private String handleObjectInMap(Object value) {
         StringBuilder result = new StringBuilder();
         Map<Object, Object> map = (Map<Object, Object>) value;
         int i = 0;
@@ -204,7 +204,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                     : handleObjectInArray(value);
                 return ARRAY.getValue(keywordCase) + "[" + array + "]";
             } else if (value instanceof Map) {
-                return MAP.getValue(keywordCase) + "(" + handeObjectInMap(value) + ")";
+                return MAP.getValue(keywordCase) + "(" + handleObjectInMap(value) + ")";
             } else if (value instanceof Collection) {
                 return MULTISET.getValue(keywordCase)
                     + "[" + handleObjectInCollection(value) + "]";

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -11,14 +11,15 @@ import net.datafaker.transformations.Transformer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.ARRAY;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.INSERT_INTO;
+import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.MAP;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.MULTISET;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.NULL;
-import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.ROW;
 import static net.datafaker.transformations.sql.SqlTransformer.SQLKeyWords.VALUES;
 
 public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
@@ -89,23 +90,33 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         if (withBatchMode) {
             if (rowId == 0 || batchSize > 0 && rowId % batchSize == 0) {
                 return SqlDialect.getFirstRow(
-                    dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase);
+                    dialect, () -> appendTableInfo(fields), () -> addValues(input, fields, true), keywordCase);
             } else {
                 return String.join(LINE_SEPARATOR, ",",
                     SqlDialect.getOtherRow(
-                        dialect, () -> appendTableInfo(fields), () -> addValues(input, fields), keywordCase));
+                        dialect, () -> appendTableInfo(fields), () -> addValues(input, fields, true), keywordCase));
             }
         } else {
             return String.join(" ", INSERT_INTO.getValue(keywordCase),
                 appendTableInfo(fields),
                 VALUES.getValue(keywordCase),
-                addValues(input, fields));
+                addValues(input, fields, true));
         }
     }
 
-    private String addValues(IN input, Field<?, ? extends CharSequence>[] fields) {
+    private String addValues(IN input, Field<?, ? extends CharSequence>[] fields, Boolean isRoot) {
         StringJoiner result = new StringJoiner(", ");
         for (int i = 0; i < fields.length; i++) {
+
+            if(dialect != null) {
+                String fieldPrefix =
+                    dialect.getFieldPrefix(fields[i].getName());
+
+                if (!fieldPrefix.isEmpty() && !isRoot) {
+                    result.add(quote + dialect.getFieldPrefix(fields[i].getName()) + quote);
+                }
+            }
+
             if (fields[i] instanceof SimpleField) {
                 //noinspection unchecked
                 Object value = ((SimpleField<Object, ? extends CharSequence>) fields[i]).transform(input);
@@ -117,10 +128,12 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                     result.add(String.valueOf(value));
                 } else if (clazz.isArray()) {
                     final Class<?> componentType = clazz.getComponentType();
-                    result.add(ARRAY.getValue(keywordCase) + "[" +
+                    result.add(ARRAY.getValue(keywordCase) + dialect.getArrayStart() +
                         (componentType.isPrimitive()
                             ? handlePrimitivesInArray(componentType, value)
-                            : handleObjectInArray(value)) + "]");
+                            : handleObjectInArray(value)) + dialect.getArrayEnd());
+                } else if (value instanceof Map) {
+                    result.add(MAP.getValue(keywordCase) + "(" + handeObjectInMap(value) + ")");
                 } else if (value instanceof Collection) {
                     result.add(MULTISET.getValue(keywordCase) + "[" +
                         handleObjectInCollection(value) + "]");
@@ -128,7 +141,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                     result.add(handleObject(value));
                 }
             } else if (fields[i] instanceof CompositeField) {
-                result.add(ROW.getValue(keywordCase) + addValues(input, ((CompositeField) fields[i]).getFields()));
+                result.add(dialect.getCompositePrefix(keywordCase) + addValues(input, ((CompositeField) fields[i]).getFields(), false));
             } else {
                 throw new IllegalArgumentException(fields[i] + " not supported");
             }
@@ -163,6 +176,23 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         return result.toString();
     }
 
+    private String handeObjectInMap(Object value) {
+        StringBuilder result = new StringBuilder();
+        Map<Object, Object> map = (Map<Object, Object>) value;
+        int i = 0;
+        for (Map.Entry<Object, Object> entry : map.entrySet()) {
+            result.append(handleObject(entry.getKey()));
+            result.append(", ");
+            result.append(handleObject(entry.getValue()));
+
+            if (i < map.size() - 1) {
+                result.append(", ");
+            }
+            i++;
+        }
+        return result.toString();
+    }
+
     private String handleObject(Object value) {
         if (value == null) {
             return NULL.getValue(keywordCase);
@@ -173,6 +203,8 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                     ? handlePrimitivesInArray(componentType, value)
                     : handleObjectInArray(value);
                 return ARRAY.getValue(keywordCase) + "[" + array + "]";
+            } else if (value instanceof Map) {
+                return MAP.getValue(keywordCase) + "(" + handeObjectInMap(value) + ")";
             } else if (value instanceof Collection) {
                 return MULTISET.getValue(keywordCase)
                     + "[" + handleObjectInCollection(value) + "]";
@@ -459,6 +491,8 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
 
     enum SQLKeyWords {
         ARRAY("ARRAY", "array", "Array"),
+        MAP("MAP", "map", "Map"),
+        NAMED_STRUCT("NAMED_STRUCT", "named_struct", "Named_Struct"),
         INSERT_ALL("INSERT ALL", "insert all", "Insert All"),
         INSERT_INTO("INSERT INTO", "insert into", "Insert Into"),
         INTO("INTO", "into", "Into"),


### PR DESCRIPTION
###
Add Spark SQL support.
See "INSERT INTO" spec https://spark.apache.org/docs/3.2.1/sql-ref-syntax-dml-insert-into.html

There are some issues with existing design in order to support all Spark types. 
Spark SQL [has 3 complex data types](https://spark.apache.org/docs/latest/sql-ref-datatypes.html):
- Array
- Map
- Struct

Insertions look like this
```sql
-- Inserting an array
INSERT INTO MyTable (array_column) VALUES (ARRAY(1, 2, 3));

-- Inserting a map
INSERT INTO MyTable (map_column) VALUES (MAP('key1', 'value1', 'key2', 'value2'));

-- Inserting a struct
INSERT INTO MyTable (struct_column) VALUES (NAMED_STRUCT('field1', 'value1', 'field2', 'value2'));
```

So notable design changes are
- array start and end markers are now configurable with default "[", "]". Spark requires "(" and ")".
- row prefix is configurable as keyword "ROW" doesn't exist but we have "NAMED_TUPLE" for complex fields in Spark.
- a named tuples requires a prefix for each value, the field name (but root columns don't require field name prefix)
- there's also Map support required. I think it makes sense to correlate `java.util.Map` with Spark SQL Map
- batch insert is not support so I think it's best to throw exception on attempt to generate "batch" statements

I tested on latest Databricks runtime this generated SQL and work well 👍 
```sql
INSERT INTO `MyTable` (`bytes`) VALUES (ARRAY(1, 0));
INSERT INTO `MyTable` (`booleans`) VALUES (ARRAY(true, false));
INSERT INTO `MyTable` (`ints`) VALUES (ARRAY(1, 2, 3));

INSERT INTO `MyTable` (`struct_array`) VALUES (NAMED_STRUCT('name1', '1', 'struct', NAMED_STRUCT('name', ARRAY(1, 2, 3))));
INSERT INTO `MyTable` (`struct_struct`) VALUES (NAMED_STRUCT('name1', '1', 'struct', NAMED_STRUCT('name', '2')));
INSERT INTO `MyTable` (`longs`) VALUES (ARRAY(23, 45));
INSERT INTO `MyTable` (`empty_map`) VALUES (MAP());
INSERT INTO `MyTable` (`maps`) VALUES (MAP('k1', MAP('k1', 'v1'), 'k2', MAP('k1', 'v1')));
```


