### PR TITLE
[hotfix] Skip void or methods coming from Object or AbstractProvider

### DIFF
--- a/src/main/java/net/datafaker/providers/base/BaseFaker.java
+++ b/src/main/java/net/datafaker/providers/base/BaseFaker.java
@@ -339,7 +339,14 @@ public class BaseFaker implements BaseProviders {
             Class newMappingClass = newMapping.getClass();
             METHODS.putIfAbsent(newMappingClass, new ConcurrentHashMap<>(methods.length));
             for (Method method: methods) {
-                if (method.getParameterCount() > 0) continue;
+                if (method.getParameterCount() > 0
+                    || method.getDeclaringClass() == Object.class
+                    || method.getDeclaringClass() == AbstractProvider.class
+                    || method.getReturnType() == void.class
+                ) {
+                    continue;
+                }
+
                 final String methodName = method.getName();
 
                 Map<String, Method> methodMap = METHODS.get(newMappingClass);


### PR DESCRIPTION
No need to keep in cache void methods or methods coming from Object/AbstractProvider

one of the findings while looking at #1263  