### PR TITLE
fix: expressions resolution

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -817,7 +817,10 @@ public class FakeValuesService {
         // simple fetch of a value from the yaml file. the directive may have been mutated
         // such that if the current yml object is car: and directive is #{wheel} then
         // car.wheel will be looked up in the YAML file.
-        res.add(() -> safeFetch(simpleDirective, context, null));
+        // It's only "simple" if there aren't args
+        if (args.length == 0) {
+            res.add(() -> safeFetch(simpleDirective, context, null));
+        }
 
         // resolve method references on faker object like #{regexify '[a-z]'}
         if (dotIndex == -1 && root != null && (current == null || root.getClass() != current.getClass())) {

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -5,6 +5,8 @@ import net.datafaker.internal.helper.SingletonLocale;
 import net.datafaker.providers.base.AbstractProvider;
 import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.BaseProviders;
+
+import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -291,6 +293,13 @@ class FakeValuesServiceTest extends AbstractFakerTest {
         String expression = fakeValuesService.expression("#{date.past '4','TimeUnit.HOURS'}", faker, context);
         LocalDateTime date = LocalDateTime.parse(expression, DATE_TIME_FORMATTER);
         assertThat(date).isStrictlyBetween(nowMinus5Hours, now);
+    }
+
+    @Test
+    void expressionWithSingleEnumArg() {
+        // https://github.com/datafaker-net/datafaker/issues/1274
+        String masterCard = fakeValuesService.expression("#{finance.creditCard 'CreditCardType.MASTERCARD'}", faker, context);
+        assertThat(LuhnCheckDigit.LUHN_CHECK_DIGIT.isValid(masterCard.replace("-", ""))).isTrue();
     }
 
     @Test


### PR DESCRIPTION
If an expression has arguments it shouldn't be treated as "simple".

Tweak FaverValueService logic and add test to FakerValueServiceTest.

Fixes datafaker-net/datafaker#1274