### PR TITLE
Add multi-row/batch insert for Spark SQL

### DIFF
--- a/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
@@ -46,11 +46,7 @@ public enum SqlDialect {
     PRESTO("\"", Casing.UNCHANGED),
     REDSHIFT("\"", Casing.TO_LOWER),
     SNOWFLAKE("\""),
-    SPARKSQL("`",
-        (columns, values, caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; },
-        (columns, values, caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; },
-        (caze) -> { throw SqlDialect.AuxiliaryConstants.BATCH_UNSUPPORTED; }
-    ) {
+    SPARKSQL("`") {
 
         @Override
         public String getCompositePrefix(SqlTransformer.Case caze) {
@@ -150,9 +146,6 @@ public enum SqlDialect {
     }
 
     static class AuxiliaryConstants {
-        static final UnsupportedOperationException BATCH_UNSUPPORTED =
-            new UnsupportedOperationException("This dialect not support batch insert.");
-
         static final TriFunction<Supplier<String>, Supplier<String>, SqlTransformer.Case, String> DEFAULT_FIRST_ROW = (supplier, supplier2, caze) -> {
             final String insertAll = INSERT_INTO.getValue(caze) + " ";
             final String values = LINE_SEPARATOR + VALUES.getValue(caze) + " ";

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -450,37 +450,31 @@ class SqlTest {
         );
     }
 
-
     @Test
     void batchTestForSqlTransformerSparkSql() {
+        int batchSize =  5;
+        int records = 20;
+        Faker faker = new Faker();
+
         SqlTransformer<String> transformer =
             SqlTransformer.<String>builder()
                 .dialect(SqlDialect.SPARKSQL)
-                .batch(10)
+                .batch(batchSize)
                 .build();
 
         String generation =
             transformer
                 .generate(
                     Schema.of(
-                        field("field1", () -> "value1"),
-                        field("field2", () -> "value2")
-                    ), 10
+                        field("name", () -> faker.cat().name()),
+                        field("breed", () -> faker.cat().breed())
+                    ), records
                 );
 
-        assertThat(generation).isEqualTo("INSERT INTO `MyTable` (`field1`, `field2`)\n" +
-            "VALUES ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2'),\n" +
-            "       ('value1', 'value2');");
+        assertThat(generation.split("INSERT INTO")).hasSize((records / batchSize) + 1);
+        assertThat(generation.split("VALUES")).hasSize((records / batchSize) + 1);
+        assertThat(generation.split(";")).hasSize((records / batchSize));
     }
-
 
     @ParameterizedTest
     @MethodSource("generateTestSchemaForSparkSql")

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -456,11 +456,29 @@ class SqlTest {
         SqlTransformer<String> transformer =
             SqlTransformer.<String>builder()
                 .dialect(SqlDialect.SPARKSQL)
-                .batch()
+                .batch(10)
                 .build();
 
-        assertThatThrownBy(() -> transformer.generate(Schema.of(field("ints", () -> new int[]{1, 2})), 1))
-            .isInstanceOf(UnsupportedOperationException.class);
+        String generation =
+            transformer
+                .generate(
+                    Schema.of(
+                        field("field1", () -> "value1"),
+                        field("field2", () -> "value2")
+                    ), 10
+                );
+
+        assertThat(generation).isEqualTo("INSERT INTO `MyTable` (`field1`, `field2`)\n" +
+            "VALUES ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2'),\n" +
+            "       ('value1', 'value2');");
     }
 
 


### PR DESCRIPTION
I was mistaken on the first PR https://github.com/datafaker-net/datafaker/pull/1261 

**Spark SQL supports multi-row inserts**
https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-dml-insert-into.html

Validated on Databricks that the following statement is accepted.
```sql
INSERT INTO `MY_TABLE` (`field1`, `field2`)
VALUES ('value1', 'value2'),
       ('value1', 'value2'),
       ('value1', 'value2'),
       ...
```
