### PR TITLE
Improve performance when generating with a specific locale

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -5,6 +5,7 @@ import org.yaml.snakeyaml.Yaml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -113,7 +114,7 @@ public class FakeValues implements FakeValuesInterface {
                 return result;
             }
         }
-        return null;
+        return Collections.emptyMap();
     }
 
     private void enrichMapWithJavaNames(Map<String, Object> result) {


### PR DESCRIPTION
## Overview

This is a partial fix for the issue https://github.com/datafaker-net/datafaker/issues/1285.

Result before changes:
```
Time to process 1000000 values: 40.341209708s
```

Result after changes:
```
Time to process 1000000 values: 19.826039958s
```

Result with no locale:
```
Time to process 1000000 values: 2.310795584s
```

Results are based on the code here: https://github.com/vitaly-ivanov/datafaker-memory-leak/blob/main/app/src/main/kotlin/org/example/Performance.kt

## Details

Nulls were interpreted as no attempt to load

If values were missing for the specified locale, the `loadValues` method returned null instead of an empty map, resulting in subsequent attempts to load values into the cache.