### PR TITLE
Undeprecated password generation methods.

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -176,50 +176,26 @@ public class Internet extends AbstractProvider<BaseProviders> {
         return resolve("internet.http_method");
     }
 
-    /**
-     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
-     */
-    @Deprecated(since = "2.3.0")
     public String password() {
         return password(8, 16);
     }
 
-    /**
-     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
-     */
-    @Deprecated(since = "2.3.0")
     public String password(boolean includeDigit) {
         return password(8, 16, false, false, includeDigit);
     }
 
-    /**
-     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
-     */
-    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength) {
         return password(minimumLength, maximumLength, false);
     }
 
-    /**
-     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
-     */
-    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase) {
         return password(minimumLength, maximumLength, includeUppercase, false);
     }
 
-    /**
-     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
-     */
-    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial) {
         return password(minimumLength, maximumLength, includeUppercase, includeSpecial, true);
     }
 
-    /**
-     * Consider usage of {@link Text#text(Text.TextRuleConfig)} instead.
-     */
-    @Deprecated(since = "2.3.0")
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
         return faker.text().text(minimumLength, maximumLength, includeUppercase, includeSpecial, includeDigit);
     }


### PR DESCRIPTION
I've removed the deprecation annotations here, it's really not clear to me why these methods were deprecated, and what their replacement was. 

Eg, someone used to be able to do `faker.internet().password()`. How would someone do this now?

Like this?

```
          faker.text().text(Text.TextSymbolsBuilder.builder()
                      .len(5)
                      .with(EN_LOWERCASE, 1)
                      .with(EN_UPPERCASE, 1)
                      .with(DIGITS, 1);
```

That seems overly complex for a password. If I'm missing something, please let me know, because I'm not sure what happened here.