### PR TITLE
Use cache for fetchObject

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -242,6 +242,11 @@ public class FakeValuesService {
             }
         }
         if (local2Add != null) {
+            Object curResult = key2fetchedObject.getOrDefault(local2Add, Collections.emptyMap())
+                .get(key);
+            if (curResult != null) {
+                return result;
+            }
             key2fetchedObject.updateNestedValue(local2Add, MAP_STRING_OBJECT_SUPPLIER, key, result);
         }
         if (result instanceof List list) {


### PR DESCRIPTION
This fixes #1285 

no need to recalculate same values for different locales

before 
```
Benchmark                                        Mode  Cnt     Score    Error   Units
LocalePerformanceBenchmark.en_fullname          thrpt   10  3160.491 ± 71.525  ops/ms
LocalePerformanceBenchmark.en_gb_fullname       thrpt   10    62.385 ±  6.717  ops/ms
LocalePerformanceBenchmark.en_gb_streetAddress  thrpt   10    46.018 ± 25.115  ops/ms
LocalePerformanceBenchmark.en_streetAddress     thrpt   10  2268.299 ± 37.201  ops/ms
```
after
```

Benchmark                                        Mode  Cnt     Score    Error   Units
LocalePerformanceBenchmark.en_fullname          thrpt   10  3168.236 ± 65.091  ops/ms
LocalePerformanceBenchmark.en_gb_fullname       thrpt   10  1829.919 ± 34.379  ops/ms
LocalePerformanceBenchmark.en_gb_streetAddress  thrpt   10  1154.528 ± 43.499  ops/ms
LocalePerformanceBenchmark.en_streetAddress     thrpt   10  2251.981 ± 30.529  ops/ms
```