### PR TITLE
generate ID Number together with birthday and gender

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/AlbanianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/AlbanianIdNumber.java
@@ -1,8 +1,15 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
+import net.datafaker.providers.base.PersonIdNumber.Gender;
 
 import java.time.LocalDate;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
 
 /**
  * The Albanian Identity Number is a unique personal identification number of 10 characters in the format YYMMDDSSSC
@@ -24,19 +31,20 @@ public class AlbanianIdNumber implements IdNumberGenerator {
     }
 
     @Override
-    public String generateValid(BaseProviders faker) {
-        LocalDate birthDate = faker.timeAndDate().birthday(0, 200);
-        boolean female = faker.bool().bool();
-        String basePart = yy(birthDate.getYear()) + mm(birthDate.getMonthValue(), female) + dd(birthDate.getDayOfMonth()) + sss(faker);
-        return basePart + checksum(basePart);
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        LocalDate birthDate = birthday(faker, request);
+        Gender gender = gender(faker, request);
+        String basePart = yy(birthDate.getYear()) + mm(birthDate.getMonthValue(), gender) + dd(birthDate.getDayOfMonth()) + sss(faker);
+        String idNumber = basePart + checksum(basePart);
+        return new PersonIdNumber(idNumber, birthDate, gender);
     }
 
     String yy(int year) {
         return FIRST_CHAR.charAt((year - 1800) / 10) + String.valueOf(year % 10);
     }
 
-    String mm(int month, boolean female) {
-        return String.format("%02d", (female ? 50 : 0) + month);
+    String mm(int month, Gender gender) {
+        return String.format("%02d", (gender == FEMALE ? 50 : 0) + month);
     }
 
     String dd(int dayOfMonth) {

--- a/src/main/java/net/datafaker/idnumbers/AmericanIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/AmericanIdNumber.java
@@ -1,9 +1,14 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber;
+import net.datafaker.providers.base.PersonIdNumber;
 
 import java.util.List;
 import java.util.regex.Pattern;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
 
 public class AmericanIdNumber implements IdNumberGenerator {
     @Override
@@ -34,6 +39,11 @@ public class AmericanIdNumber implements IdNumberGenerator {
         boolean isValid = INVALID_SSN_PATTERNS.stream()
             .noneMatch(invalidSSNPattern -> invalidSSNPattern.matcher(ssn).matches());
         return isValid ? ssn : generateValid(f);
+    }
+
+    @Override
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumber.IdNumberRequest request) {
+        return new PersonIdNumber(generateValid(faker), birthday(faker, request), gender(faker, request));
     }
 
     @Override

--- a/src/main/java/net/datafaker/idnumbers/BulgarianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/BulgarianIdNumber.java
@@ -1,8 +1,15 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
+import net.datafaker.providers.base.PersonIdNumber.Gender;
 
 import java.time.LocalDate;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
+import static net.datafaker.idnumbers.Utils.randomGender;
 
 /**
  * <a href="https://en.wikipedia.org/wiki/Unique_citizenship_number">Specification</a>
@@ -18,21 +25,22 @@ public class BulgarianIdNumber implements IdNumberGenerator {
     }
 
     @Override
-    public String generateValid(BaseProviders faker) {
-        String basePart = basePart(faker);
-        return basePart + checksum(basePart);
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        LocalDate birthday = birthday(faker, request);
+        Gender gender = gender(faker, request);
+        String basePart = basePart(faker, birthday, gender);
+        String idNumber = basePart + checksum(basePart);
+        return new PersonIdNumber(idNumber, birthday, gender);
     }
 
     @Override
     public String generateInvalid(BaseProviders faker) {
-        String basePart = basePart(faker);
+        String basePart = basePart(faker, faker.timeAndDate().birthday(), randomGender(faker));
         return basePart + (checksum(basePart) + 1) % 10;
     }
 
-    private String basePart(BaseProviders faker) {
-        LocalDate birthDate = faker.timeAndDate().birthday(0, 200);
-        boolean female = faker.bool().bool();
-        return yy(birthDate) + mm(birthDate) + dd(birthDate) + order(faker, female);
+    private String basePart(BaseProviders faker, LocalDate birthDate, Gender gender) {
+        return yy(birthDate) + mm(birthDate) + dd(birthDate) + order(faker, gender);
     }
 
     private String yy(LocalDate birthDate) {
@@ -49,8 +57,11 @@ public class BulgarianIdNumber implements IdNumberGenerator {
         return "%02d".formatted(birthDate.getDayOfMonth());
     }
 
-    private String order(BaseProviders faker, boolean female) {
-        int[] availableLastDigits = female ? ODD_DIGITS : EVEN_DIGITS;
+    private String order(BaseProviders faker, Gender gender) {
+        int[] availableLastDigits = switch (gender) {
+            case FEMALE -> ODD_DIGITS;
+            case MALE -> EVEN_DIGITS;
+        };
         int lastDigit = availableLastDigits[faker.number().numberBetween(0, 5)];
         return faker.number().digits(2) + lastDigit;
     }

--- a/src/main/java/net/datafaker/idnumbers/ChineseIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/ChineseIdNumber.java
@@ -1,7 +1,14 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
 import net.datafaker.service.RandomService;
+
+import java.time.LocalDate;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
 
 
 /**
@@ -32,7 +39,8 @@ public class ChineseIdNumber implements IdNumberGenerator {
      * @return a Chinese ID number string
      */
     @Override
-    public String generateValid(BaseProviders faker) {
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        LocalDate birthday = birthday(faker, request);
         RandomService rand = faker.random();
         String loc = faker.options().option(LOCATIONS);
         final int dayLength = 8;
@@ -42,7 +50,7 @@ public class ChineseIdNumber implements IdNumberGenerator {
             res[i] = loc.charAt(i);
         }
 
-        generateDay(rand, 1930, 1, 1, 2030, 1, 12, res, locLength);
+        fillBirthday(res, locLength, birthday);
         res[locLength + dayLength] = (char)('0' + rand.nextInt(10));
         res[locLength + dayLength + 1] = (char)('0' + rand.nextInt(10));
         res[locLength + dayLength + 2] = (char)('0' + rand.nextInt(10));
@@ -65,27 +73,14 @@ public class ChineseIdNumber implements IdNumberGenerator {
         count += (res[15] - '0') * 4;
         count += (res[16] - '0') * 2;
         count %= 11;
-        if (count == 10) {
-            return String.valueOf(res) + "X";
-        } else {
-            return String.valueOf(res) + count;
-        }
+        String idNumber = count == 10 ? String.valueOf(res) + "X" : String.valueOf(res) + count;
+        return new PersonIdNumber(idNumber, birthday, gender(faker, request));
     }
 
-    private void generateDay(RandomService rand, int yearStart, int monthStart, int dayStart, int yearEnd, int monthEnd, int dayEnd, char[] res, int offset) {
-        final int year = rand.nextInt(yearStart, yearEnd);
-        final int month = rand.nextInt(monthStart, monthEnd);
-        final int lastDay;
-        if (month == 2) {
-            lastDay =
-                (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ?
-                    29 : 28;
-        } else if (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) {
-            lastDay = 31;
-        } else {
-            lastDay = 30;
-        }
-        int day = rand.nextInt(dayStart, Math.min(lastDay, dayEnd));
+    private void fillBirthday(char[] res, int offset, LocalDate birthday) {
+        int year = birthday.getYear();
+        int month = birthday.getMonthValue();
+        int day = birthday.getDayOfMonth();
         res[offset] = (char)('0' + year / 1000);
         res[offset + 1] = (char)('0' + (year % 1000) / 100);
         res[offset + 2] = (char)('0' + (year % 100) / 10);

--- a/src/main/java/net/datafaker/idnumbers/GeorgianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/GeorgianIdNumber.java
@@ -1,6 +1,11 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber;
+import net.datafaker.providers.base.PersonIdNumber;
+
+import static net.datafaker.idnumbers.Utils.birthday;
+import static net.datafaker.idnumbers.Utils.gender;
 
 /**
  * Generates ID numbers for Georgian citizens and Residents
@@ -14,6 +19,15 @@ public class GeorgianIdNumber implements IdNumberGenerator {
     @Override
     public String generateValid(BaseProviders faker) {
         return faker.numerify("###########");
+    }
+
+    @Override
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumber.IdNumberRequest request) {
+        return new PersonIdNumber(
+            generateValid(faker),
+            birthday(faker, request),
+            gender(faker, request)
+        );
     }
 
     @Override

--- a/src/main/java/net/datafaker/idnumbers/IdNumberGenerator.java
+++ b/src/main/java/net/datafaker/idnumbers/IdNumberGenerator.java
@@ -1,12 +1,12 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
 
-import java.time.format.DateTimeFormatter;
+import static net.datafaker.providers.base.IdNumber.GenderRequest.ANY;
 
 public interface IdNumberGenerator {
-    DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyMMdd");
-
     /**
      * ISO-2 code of the country this generator provides ID numbers for
      *
@@ -17,10 +17,20 @@ public interface IdNumberGenerator {
     /**
      * Generates a valid ID number for given country (a.k.a. "SSN", "Personal code" etc.)
      */
-    String generateValid(BaseProviders faker);
+    default String generateValid(BaseProviders faker) {
+        return generateValid(faker, new IdNumberRequest(18, 65, ANY)).idNumber();
+    }
 
     /**
      * Generates an invalid ID number for given country (a.k.a. "SSN", "Personal code" etc.)
      */
     String generateInvalid(BaseProviders faker);
+
+    /**
+     * Generates a valid ID number for given country corresponding to given criterias (age range, gender etc.)
+     *
+     * @return PersonIdNumber containing a valid combination of ID, Birthday and Gender.
+     * In countries where ID number doesn't contain gender and/or birthday, the latter values are just random.
+     */
+    PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request);
 }

--- a/src/main/java/net/datafaker/idnumbers/MacedonianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/MacedonianIdNumber.java
@@ -1,9 +1,17 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
+import net.datafaker.providers.base.PersonIdNumber.Gender;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
+import static net.datafaker.idnumbers.Utils.randomGender;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
 
 /**
  * The Macedonian Identity Number is a unique personal identification number of 13 digits in a form "DD MM YYY RR BBB K"
@@ -20,21 +28,23 @@ public class MacedonianIdNumber implements IdNumberGenerator {
     }
 
     @Override
-    public String generateValid(BaseProviders faker) {
-        String basePart = basePart(faker);
-        return basePart + checksum(basePart);
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        LocalDate birthday = birthday(faker, request);
+        Gender gender = gender(faker, request);
+        String basePart = basePart(faker, birthday, gender);
+        return new PersonIdNumber(basePart + checksum(basePart), birthday, gender);
     }
 
     @Override
     public String generateInvalid(BaseProviders faker) {
-        String basePart = basePart(faker);
+        LocalDate birthday = faker.timeAndDate().birthday();
+        Gender gender = randomGender(faker);
+        String basePart = basePart(faker, birthday, gender);
         return basePart + (checksum(basePart) + 1) % 10;
     }
 
-    private String basePart(BaseProviders faker) {
-        LocalDate bd = faker.timeAndDate().birthday(0, 120);
-        boolean female = faker.bool().bool();
-        return dd(bd) + mm(bd) + yyy(bd) + rr(faker) + sss(faker, female);
+    private String basePart(BaseProviders faker, LocalDate bd, Gender gender) {
+        return dd(bd) + mm(bd) + yyy(bd) + rr(faker) + sss(faker, gender);
     }
 
     private String dd(LocalDate bd) {
@@ -64,8 +74,8 @@ public class MacedonianIdNumber implements IdNumberGenerator {
      * - from 000 to 499 for the male, and
      * - from 500 to 999 for the female citizens.
      */
-    private String sss(BaseProviders faker, boolean female) {
-        int ordinal = female ? faker.number().numberBetween(500, 1000) : faker.number().numberBetween(0, 500);
+    private String sss(BaseProviders faker, Gender gender) {
+        int ordinal = gender == FEMALE ? faker.number().numberBetween(500, 1000) : faker.number().numberBetween(0, 500);
         return "%03d".formatted(ordinal);
     }
 

--- a/src/main/java/net/datafaker/idnumbers/MacedonianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/MacedonianIdNumber.java
@@ -11,7 +11,6 @@ import java.util.List;
 import static net.datafaker.idnumbers.Utils.gender;
 import static net.datafaker.idnumbers.Utils.birthday;
 import static net.datafaker.idnumbers.Utils.randomGender;
-import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
 
 /**
  * The Macedonian Identity Number is a unique personal identification number of 13 digits in a form "DD MM YYY RR BBB K"
@@ -75,7 +74,10 @@ public class MacedonianIdNumber implements IdNumberGenerator {
      * - from 500 to 999 for the female citizens.
      */
     private String sss(BaseProviders faker, Gender gender) {
-        int ordinal = gender == FEMALE ? faker.number().numberBetween(500, 1000) : faker.number().numberBetween(0, 500);
+        int ordinal = switch (gender) {
+            case FEMALE -> faker.number().numberBetween(500, 1000);
+            case MALE -> faker.number().numberBetween(0, 500);
+        };
         return "%03d".formatted(ordinal);
     }
 

--- a/src/main/java/net/datafaker/idnumbers/MoldovanIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/MoldovanIdNumber.java
@@ -1,8 +1,13 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
 
 import java.time.LocalDate;
+
+import static net.datafaker.idnumbers.Utils.birthday;
+import static net.datafaker.idnumbers.Utils.randomGender;
 
 /**
  * The Moldovan Individual Tax ID Number is 13 digits.
@@ -14,7 +19,7 @@ import java.time.LocalDate;
  */
 public class MoldovanIdNumber implements IdNumberGenerator {
 
-    private static final int[] CHECKSUM_MASK = new int[]{7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1};
+    private static final int[] CHECKSUM_MASK = {7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1};
 
     @Override
     public String countryCode() {
@@ -22,19 +27,20 @@ public class MoldovanIdNumber implements IdNumberGenerator {
     }
 
     @Override
-    public String generateValid(BaseProviders faker) {
-        String basePart = basePart(faker);
-        return basePart + checksum(basePart);
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        LocalDate birthday = birthday(faker, request);
+        String basePart = basePart(faker, birthday);
+        String idNumber = basePart + checksum(basePart);
+        return new PersonIdNumber(idNumber, birthday, randomGender(faker));
     }
 
     @Override
     public String generateInvalid(BaseProviders faker) {
-        String basePart = basePart(faker);
+        String basePart = basePart(faker, faker.timeAndDate().birthday());
         return basePart + (checksum(basePart) + 1) % 10;
     }
 
-    private String basePart(BaseProviders faker) {
-        var birthday = faker.timeAndDate().birthday(0, 120);
+    private String basePart(BaseProviders faker, LocalDate birthday) {
         // IDNP: 2ГГГXXXYYYYYK
         return firstDigit() + ГГГ(birthday) + XXX(faker) + YYYYY(faker);
     }

--- a/src/main/java/net/datafaker/idnumbers/PortugueseIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/PortugueseIdNumber.java
@@ -1,6 +1,11 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
 
 /**
  * Portuguese VAT identification number (NIF)
@@ -42,6 +47,11 @@ public class PortugueseIdNumber implements IdNumberGenerator {
         }
         int digitSum = calculateDigitSum(digits);
         return digits + digitSum;
+    }
+
+    @Override
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        return new PersonIdNumber(generateValid(faker), birthday(faker, request), gender(faker, request));
     }
 
     private int calculateDigitSum(String numbers) {

--- a/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
@@ -1,10 +1,16 @@
 package net.datafaker.idnumbers;
 
 import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber;
+import net.datafaker.providers.base.PersonIdNumber;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+
+import static net.datafaker.idnumbers.Utils.gender;
+import static net.datafaker.idnumbers.Utils.birthday;
 
 /**
  * Implementation based on the definition at
@@ -13,6 +19,8 @@ import java.time.temporal.ChronoField;
  * <a href="https://en.wikipedia.org/wiki/Personal_identity_number_">https://en.wikipedia.org/wiki/Personal_identity_number_</a>(Sweden)
  */
 public class SwedenIdNumber implements IdNumberGenerator {
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyMMdd");
+
     @Override
     public String countryCode() {
         return "SE";
@@ -27,12 +35,14 @@ public class SwedenIdNumber implements IdNumberGenerator {
     }
 
     @Override
-    public String generateValid(BaseProviders f) {
+    public PersonIdNumber generateValid(BaseProviders f, IdNumber.IdNumberRequest request) {
+        LocalDate birthday = birthday(f, request);
         String end = f.numerify("###");
-        String candidate = DATE_TIME_FORMATTER.format(f.timeAndDate().birthday(0, 100))
+        String basePart = DATE_TIME_FORMATTER.format(birthday)
             + f.options().option(PLUS_MINUS)
             + end;
-        return candidate + calculateChecksum(candidate);
+        String idNumber = basePart + calculateChecksum(basePart);
+        return new PersonIdNumber(idNumber, birthday, gender(f, request));
     }
 
     @Deprecated

--- a/src/main/java/net/datafaker/idnumbers/Utils.java
+++ b/src/main/java/net/datafaker/idnumbers/Utils.java
@@ -1,0 +1,32 @@
+package net.datafaker.idnumbers;
+
+import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber.Gender;
+
+import java.time.LocalDate;
+
+import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.MALE;
+
+public class Utils {
+
+    static LocalDate birthday(BaseProviders faker, IdNumberRequest request) {
+        return faker.timeAndDate().birthday(request.minAge(), request.maxAge());
+    }
+
+    static Gender gender(BaseProviders faker, IdNumberRequest request) {
+        IdNumber.GenderRequest gender = request.gender();
+        return switch (gender) {
+            case FEMALE -> FEMALE;
+            case MALE -> MALE;
+            case ANY -> randomGender(faker);
+        };
+    }
+
+    static Gender randomGender(BaseProviders faker) {
+        return faker.bool().bool() ? FEMALE : MALE;
+    }
+
+}

--- a/src/main/java/net/datafaker/providers/base/AbstractProvider.java
+++ b/src/main/java/net/datafaker/providers/base/AbstractProvider.java
@@ -37,7 +37,7 @@ public class AbstractProvider<T extends ProviderRegistration> {
         return getClass().hashCode();
     }
 
-    protected <G> List<G> loadGenerators(Class<G> generatorClass) {
+    protected final <G> List<G> loadGenerators(Class<G> generatorClass) {
         return ServiceLoader.load(generatorClass).stream()
             .map(ServiceLoader.Provider::get)
             .toList();

--- a/src/main/java/net/datafaker/providers/base/IdNumber.java
+++ b/src/main/java/net/datafaker/providers/base/IdNumber.java
@@ -48,9 +48,28 @@ public class IdNumber extends AbstractProvider<BaseProviders> {
             .orElseGet(() -> faker.numerify(faker.resolve("id_number.invalid")));
     }
 
+    public PersonIdNumber valid(IdNumberRequest request) {
+        return countryProvider()
+            .map(p -> p.generateValid(faker, request))
+            .orElseThrow(() -> new IllegalArgumentException("ID Number generation not supported for country '%s'".formatted(country())));
+    }
+
+    public record IdNumberRequest(
+        int minAge,
+        int maxAge,
+        GenderRequest gender
+    ) {}
+
+    public enum GenderRequest {
+        FEMALE, MALE, ANY
+    }
+
     private Optional<IdNumberGenerator> countryProvider() {
-        String country = faker.getContext().getLocale().getCountry();
-        return Optional.ofNullable(countryProviders.get(country));
+        return Optional.ofNullable(countryProviders.get(country()));
+    }
+
+    private String country() {
+        return faker.getContext().getLocale().getCountry();
     }
 
     public String ssnValid() {

--- a/src/main/java/net/datafaker/providers/base/PersonIdNumber.java
+++ b/src/main/java/net/datafaker/providers/base/PersonIdNumber.java
@@ -1,0 +1,13 @@
+package net.datafaker.providers.base;
+
+import java.time.LocalDate;
+
+public record PersonIdNumber(
+    String idNumber,
+    LocalDate birthDate,
+    Gender gender
+) {
+    public enum Gender {
+        FEMALE, MALE
+    }
+}

--- a/src/main/java/net/datafaker/service/RandomService.java
+++ b/src/main/java/net/datafaker/service/RandomService.java
@@ -33,7 +33,7 @@ public class RandomService {
     }
 
     public Integer nextInt(int min, int max) {
-        return random.nextInt((max - min) + 1) + min;
+        return random.nextInt(min, max + 1);
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/net/datafaker/idnumbers/AlbanianIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/AlbanianIdNumberTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import static java.lang.Integer.parseInt;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.MALE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AlbanianIdNumberTest {
@@ -44,14 +46,14 @@ class AlbanianIdNumberTest {
 
     @Test
     void mm() {
-        assertThat(generator.mm(1, false)).isEqualTo("01");
-        assertThat(generator.mm(2, false)).isEqualTo("02");
-        assertThat(generator.mm(9, false)).isEqualTo("09");
-        assertThat(generator.mm(12, false)).isEqualTo("12");
-        assertThat(generator.mm(1, true)).isEqualTo("51");
-        assertThat(generator.mm(2, true)).isEqualTo("52");
-        assertThat(generator.mm(8, true)).isEqualTo("58");
-        assertThat(generator.mm(12, true)).isEqualTo("62");
+        assertThat(generator.mm(1, MALE)).isEqualTo("01");
+        assertThat(generator.mm(2, MALE)).isEqualTo("02");
+        assertThat(generator.mm(9, MALE)).isEqualTo("09");
+        assertThat(generator.mm(12, MALE)).isEqualTo("12");
+        assertThat(generator.mm(1, FEMALE)).isEqualTo("51");
+        assertThat(generator.mm(2, FEMALE)).isEqualTo("52");
+        assertThat(generator.mm(8, FEMALE)).isEqualTo("58");
+        assertThat(generator.mm(12, FEMALE)).isEqualTo("62");
     }
 
     @Test

--- a/src/test/java/net/datafaker/idnumbers/EstonianIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/EstonianIdNumberTest.java
@@ -1,7 +1,12 @@
 package net.datafaker.idnumbers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static net.datafaker.idnumbers.EstonianIdNumber.firstDigit;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.MALE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EstonianIdNumberTest {
@@ -15,5 +20,33 @@ class EstonianIdNumberTest {
         assertThat(EstonianIdNumber.checksum("4940313652")).isEqualTo(6);
         assertThat(EstonianIdNumber.checksum("5110712176")).isEqualTo(0);
         assertThat(EstonianIdNumber.checksum("6110712176")).isEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1800, 1801, 1802, 1888, 1898, 1899})
+    void firstDigit_18xx(int year) {
+        assertThat(firstDigit(year, MALE)).isEqualTo(1);
+        assertThat(firstDigit(year, FEMALE)).isEqualTo(2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1900, 1901, 1902, 1988, 1998, 1999})
+    void firstDigit_19xx(int year) {
+        assertThat(firstDigit(year, MALE)).isEqualTo(3);
+        assertThat(firstDigit(year, FEMALE)).isEqualTo(4);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2000, 2001, 2002, 2088, 2098, 2099})
+    void firstDigit_20xx(int year) {
+        assertThat(firstDigit(year, MALE)).isEqualTo(5);
+        assertThat(firstDigit(year, FEMALE)).isEqualTo(6);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2100, 2101, 2102, 2188, 2198, 2199})
+    void firstDigit_21xx(int year) {
+        assertThat(firstDigit(year, MALE)).isEqualTo(7);
+        assertThat(firstDigit(year, FEMALE)).isEqualTo(8);
     }
 }

--- a/src/test/java/net/datafaker/idnumbers/SingaporeIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SingaporeIdNumberTest.java
@@ -1,0 +1,53 @@
+package net.datafaker.idnumbers;
+
+import net.datafaker.Faker;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static net.datafaker.idnumbers.SingaporeIdNumber.Type.FOREIGNER_TWENTIETH_CENTURY;
+import static net.datafaker.idnumbers.SingaporeIdNumber.Type.FOREIGNER_TWENTY_FIRST_CENTURY;
+import static net.datafaker.idnumbers.SingaporeIdNumber.Type.SINGAPOREAN_TWENTIETH_CENTURY;
+import static net.datafaker.idnumbers.SingaporeIdNumber.Type.SINGAPOREAN_TWENTY_FIRST_CENTURY;
+import static net.datafaker.idnumbers.SingaporeIdNumber.centuryPrefixCitizen;
+import static net.datafaker.idnumbers.SingaporeIdNumber.centuryPrefixForeigner;
+import static net.datafaker.idnumbers.SingaporeIdNumber.randomBirthDate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SingaporeIdNumberTest {
+    @Test
+    void centuryPrefix_forCitizens() {
+        assertThat(centuryPrefixCitizen(LocalDate.parse("1999-12-31"))).as("19xx = S").isEqualTo('S');
+        assertThat(centuryPrefixCitizen(LocalDate.parse("2000-12-31"))).as("20xx = T").isEqualTo('T');
+        assertThat(centuryPrefixCitizen(LocalDate.parse("2001-01-01"))).as("20xx = T").isEqualTo('T');
+        assertThat(centuryPrefixCitizen(LocalDate.parse("2101-01-01"))).as("21xx = U").isEqualTo('U');
+        assertThat(centuryPrefixCitizen(LocalDate.parse("2201-01-01"))).as("22xx = V").isEqualTo('V');
+    }
+
+    @Test
+    void centuryPrefix_forForeigner() {
+        assertThat(centuryPrefixForeigner(LocalDate.parse("1999-12-31"))).as("19xx = F").isEqualTo('F');
+        assertThat(centuryPrefixForeigner(LocalDate.parse("2000-12-31"))).as("20xx = G").isEqualTo('G');
+        assertThat(centuryPrefixForeigner(LocalDate.parse("2001-01-01"))).as("20xx = G").isEqualTo('G');
+        assertThat(centuryPrefixForeigner(LocalDate.parse("2101-01-01"))).as("21xx = H").isEqualTo('H');
+        assertThat(centuryPrefixForeigner(LocalDate.parse("2201-01-01"))).as("22xx = I").isEqualTo('I');
+    }
+
+    @Test
+    void randomBirthDate_20th_century() {
+        Faker faker = new Faker();
+        for (int i = 0; i < 100; i++) {
+            assertThat(randomBirthDate(faker, SINGAPOREAN_TWENTIETH_CENTURY).getYear() / 100).isEqualTo(19);
+            assertThat(randomBirthDate(faker, FOREIGNER_TWENTIETH_CENTURY).getYear() / 100).isEqualTo(19);
+        }
+    }
+
+    @Test
+    void randomBirthDate_21th_century() {
+        Faker faker = new Faker();
+        for (int i = 0; i < 100; i++) {
+            assertThat(randomBirthDate(faker, SINGAPOREAN_TWENTY_FIRST_CENTURY).getYear() / 100).isEqualTo(20);
+            assertThat(randomBirthDate(faker, FOREIGNER_TWENTY_FIRST_CENTURY).getYear() / 100).isEqualTo(20);
+        }
+    }
+}

--- a/src/test/java/net/datafaker/idnumbers/SouthAfricanIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SouthAfricanIdNumberTest.java
@@ -7,7 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
+import static java.lang.Integer.parseInt;
 import static net.datafaker.idnumbers.SouthAfricanIdNumber.isValidEnZASsn;
+import static net.datafaker.idnumbers.SouthAfricanIdNumber.sequentialNumber;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.FEMALE;
+import static net.datafaker.providers.base.PersonIdNumber.Gender.MALE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
@@ -38,5 +42,23 @@ class SouthAfricanIdNumberTest {
         final BaseFaker f = new BaseFaker(new Locale("en", "ZA"));
         assertThat(f.idNumber().valid()).matches("\\d{10}[01]8\\d");
         assertThat(f.idNumber().invalid()).matches("\\d{10}[01]8\\d");
+    }
+
+    @RepeatedTest(10000)
+    void sequentialNumber_forMales() {
+        BaseFaker f = new BaseFaker(new Locale("en", "ZA"));
+        String sequentialNumber = sequentialNumber(f, MALE);
+
+        assertThat(sequentialNumber).matches("\\d{4}");
+        assertThat(parseInt(sequentialNumber)).isGreaterThanOrEqualTo(5000);
+    }
+
+    @RepeatedTest(10000)
+    void sequentialNumber_forFemales() {
+        BaseFaker f = new BaseFaker(new Locale("en", "ZA"));
+        String sequentialNumber = sequentialNumber(f, FEMALE);
+
+        assertThat(sequentialNumber).matches("\\d{4}");
+        assertThat(parseInt(sequentialNumber)).isLessThan(5000);
     }
 }

--- a/src/test/java/net/datafaker/service/RandomServiceTest.java
+++ b/src/test/java/net/datafaker/service/RandomServiceTest.java
@@ -54,6 +54,16 @@ class RandomServiceTest extends AbstractFakerTest {
     }
 
     @Test
+    void nextInt_returnsValueWithinGivenRange() {
+        RandomService randomService = new RandomService();
+        for (int i = 0; i < 10_000; i++) {
+            assertThat(randomService.nextInt(2, 6))
+                .isGreaterThanOrEqualTo(2)
+                .isLessThanOrEqualTo(6);
+        }
+    }
+
+    @Test
     void predictableRandomRange() {
         RandomService randomService = new RandomService(new Random(10));
 


### PR DESCRIPTION
this commit adds method `IdNumber.valid(IdNumberRequest)` which returns a valid combination of ID number, birthday and gender.

### Usage:
```java
        PersonIdNumber person = faker.idNumber().valid(new IdNumberRequest(18, 96, ANY));
        PersonIdNumber person = faker.idNumber().valid(new IdNumberRequest(25, 45, FEMALE));
```

### Problem to solve:
In many countries, ID Number contains or depends on birthday and/or gender.
We need to generate a valid person containing a valid combination of ID number, birthday and gender matching each other. 

Until now, it was possible to generate them separately, but they didn't always match each other:

```java
        String idNumber = faker.idNumber().valid();  // contains birthday of 80 old man
        LocalDate birthday = faker.timeAndDate().birthday();  // birthday of 16 old woman
```