### PR TITLE
#1343 simplify code for returning all available locales

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Locality.java
+++ b/src/main/java/net/datafaker/providers/base/Locality.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * @since 1.7.0
  */
 public class Locality extends AbstractProvider<BaseProviders> {
-    private static final List<String> locales = List.of(
+    private static final List<String> LOCALES = List.of(
         "_al", "_bg", "_by", "_ca", "_ch", "_cn", "_cz", "_ee", "_ge", "_md", "_mk", "_ru", "_us",
         "ar", "be", "bg", "by", "ca", "ca-cat", "cs", "cs-cz",
         "da-dk", "de", "de-at", "de-ch",
@@ -55,7 +55,7 @@ public class Locality extends AbstractProvider<BaseProviders> {
      */
     @Deterministic
     public final List<String> allSupportedLocales() {
-        return locales;
+        return LOCALES;
     }
 
     /**
@@ -64,8 +64,8 @@ public class Locality extends AbstractProvider<BaseProviders> {
      * @return locale in the form: "English (United States) or English"
      */
     public String displayName() {
-        int randomIndex = faker.random().nextInt(locales.size());
-        Locale locale = Locale.forLanguageTag(locales.get(randomIndex));
+        int randomIndex = faker.random().nextInt(LOCALES.size());
+        Locale locale = Locale.forLanguageTag(LOCALES.get(randomIndex));
 
         String displayLanguage = locale.getDisplayLanguage(Locale.ROOT);
         String displayCountry = locale.getDisplayCountry(Locale.ROOT);
@@ -93,8 +93,8 @@ public class Locality extends AbstractProvider<BaseProviders> {
     public String localeStringWithRandom(Random random) {
 
         // Randomly select a locale from list of all locales supported
-        int randomIndex = random.nextInt(locales.size());
-        return locales.get(randomIndex);
+        int randomIndex = random.nextInt(LOCALES.size());
+        return LOCALES.get(randomIndex);
     }
 
     /**
@@ -115,7 +115,7 @@ public class Locality extends AbstractProvider<BaseProviders> {
         if (shuffledLocales.isEmpty() || shuffledLocaleIndex >= shuffledLocales.size() - 1) {
             // copy list of locales supported into shuffledLocales
             shuffledLocales.clear();
-            shuffledLocales.addAll(locales);
+            shuffledLocales.addAll(LOCALES);
             shuffledLocaleIndex = 0;
             Collections.shuffle(shuffledLocales, random);
         }

--- a/src/main/java/net/datafaker/providers/base/Locality.java
+++ b/src/main/java/net/datafaker/providers/base/Locality.java
@@ -2,28 +2,12 @@ package net.datafaker.providers.base;
 
 import net.datafaker.annotations.Deterministic;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
-
-import static java.util.Collections.emptySet;
 
 /**
  * Generates random locales in different forms.
@@ -31,10 +15,19 @@ import static java.util.Collections.emptySet;
  * @since 1.7.0
  */
 public class Locality extends AbstractProvider<BaseProviders> {
-    private static final Logger log = Logger.getLogger(Locality.class.getName());
-    private static final Predicate<String> SCAN_ALL_JARS = name -> true;
+    private static final List<String> locales = List.of(
+        "_al", "_bg", "_by", "_ca", "_ch", "_cn", "_cz", "_ee", "_ge", "_md", "_mk", "_ru", "_us",
+        "ar", "be", "bg", "by", "ca", "ca-cat", "cs", "cs-cz",
+        "da-dk", "de", "de-at", "de-ch",
+        "el-gr", "en", "en-au", "en-au-ocker", "en-bork", "en-ca", "en-gb", "en-ind", "en-md", "en-ms", "en-nep",
+        "en-ng", "en-nz", "en-pak", "en-ph", "en-pk", "en-sg", "en-ug", "en-us", "en-za",
+        "es", "es-ar", "es-mx", "es-py", "et", "fa", "fi-fi", "fr", "fr-ca", "fr-ch",
+        "he", "hr", "hu", "hy", "id", "id-id", "it", "ja", "ka", "ko", "lv", "mk",
+        "nb-no", "nl", "nl-be", "no-no", "pl", "pt", "pt-br",
+        "ro-md", "ru", "ru-md", "sk", "sq", "sv", "sv-se",
+        "th", "tr", "uk", "vi", "zh-cn", "zh-tw"
+    );
 
-    private final List<String> locales;
     private final List<String> shuffledLocales = new ArrayList<>();
     private int shuffledLocaleIndex = 0;
 
@@ -43,7 +36,16 @@ public class Locality extends AbstractProvider<BaseProviders> {
      */
     public Locality(BaseProviders baseProviders) {
         super(baseProviders);
-        this.locales = allSupportedLocales();
+    }
+
+    /**
+     * @param fileMasks is not used anymore
+     * @deprecated Use {{@link #allSupportedLocales()}} instead
+     */
+    @Deprecated
+    @SuppressWarnings("unused")
+    public List<String> allSupportedLocales(Set<String> fileMasks) {
+        return allSupportedLocales();
     }
 
     /**
@@ -53,66 +55,7 @@ public class Locality extends AbstractProvider<BaseProviders> {
      */
     @Deterministic
     public final List<String> allSupportedLocales() {
-        return allSupportedLocales(SCAN_ALL_JARS);
-    }
-
-    private boolean addLocaleIfPresent(Path file, Set<String> langs, Set<String> locales) {
-        final String filename = file.getFileName().toString().toLowerCase(Locale.ROOT);
-        if ((filename.endsWith(".yml") || filename.endsWith(".yaml")) && Files.isRegularFile(file) && Files.isReadable(file)) {
-            final Path parent = file.getParent();
-            final String parentFileName = parent == null || parent.getFileName() == null ? null : parent.getFileName().toString();
-            if (parentFileName != null && langs.contains(parentFileName)) {
-                locales.add(parentFileName);
-            } else {
-                // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
-                locales.add(filename.substring(0, filename.indexOf(".")));
-            }
-            return true;
-        }
-        return false;
-    }
-
-    public List<String> allSupportedLocales(Set<String> fileMasks) {
-        return allSupportedLocales((name) -> fileMasks.stream().anyMatch(name::contains));
-    }
-
-    private List<String> allSupportedLocales(Predicate<String> jarFileFilter) {
-        Set<String> langs = Set.of(Locale.getISOLanguages());
-        String[] paths = ManagementFactory.getRuntimeMXBean().getClassPath().split(File.pathSeparator);
-        Set<String> locales = new HashSet<>();
-
-        final SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                final String filename = file.getFileName().toString().toLowerCase(Locale.ROOT);
-                if (addLocaleIfPresent(file, langs, locales)) {
-                    // do nothing, everything is done at addLocaleIfPresent
-                } else if (filename.endsWith(".jar") && jarFileFilter.test(filename)) {
-
-                    if (Files.isRegularFile(file) && Files.isReadable(file)) {
-                        try (FileSystem jarfs = FileSystems.newFileSystem(file, (ClassLoader) null)) {
-                            for (Path rootPath : jarfs.getRootDirectories()) {
-                                log.fine(() -> "  Scanning %s for locales...".formatted(rootPath));
-                                Files.walkFileTree(rootPath, emptySet(), 3, this);
-                            }
-                        }
-                    } else {
-                        log.warning(() -> "Failed to scan file %s".formatted(file));
-                    }
-                }
-                return super.visitFile(file, attrs);
-            }
-        };
-        for (String s: paths) {
-            try {
-                log.fine(() -> "  Scanning %s for locales...".formatted(s));
-                Files.walkFileTree(Paths.get(s).toAbsolutePath(), visitor);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to read path \"%s\"".formatted(s), e);
-            }
-        }
-
-        return new ArrayList<>(locales);
+        return locales;
     }
 
     /**
@@ -172,7 +115,7 @@ public class Locality extends AbstractProvider<BaseProviders> {
         if (shuffledLocales.isEmpty() || shuffledLocaleIndex >= shuffledLocales.size() - 1) {
             // copy list of locales supported into shuffledLocales
             shuffledLocales.clear();
-            shuffledLocales.addAll(this.locales);
+            shuffledLocales.addAll(locales);
             shuffledLocaleIndex = 0;
             Collections.shuffle(shuffledLocales, random);
         }

--- a/src/test/java/net/datafaker/providers/base/LocalityTest.java
+++ b/src/test/java/net/datafaker/providers/base/LocalityTest.java
@@ -1,7 +1,6 @@
 package net.datafaker.providers.base;
 
 import net.datafaker.Faker;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -11,36 +10,27 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static java.util.Locale.ROOT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LocalityTest extends BaseFakerTest<BaseFaker> {
-
-    private BaseFaker f;
-    private Locality locality;
-    private List<String> allLocales;
-
-    /**
-     * Initialize tests by instantiating a Locality object and list of all supported locales
-     */
-    @BeforeEach
-    void init() {
-        f = new Faker();
-        locality = f.locality();
-        allLocales = locality.allSupportedLocales();
-    }
+    private final BaseFaker f = new Faker();
+    private final Locality locality = f.locality();
 
     /**
      * Test to check that list of all locales support is loaded
      */
     @Test
-    void testAllSupportedLocales() {
+    void allSupportedLocales() {
         // Check that directory of locale resources exists
         File resourceDirectory = new File("./src/main/resources");
         assertThat(resourceDirectory).exists();
 
-        // Check that list of locales is not empty
-        assertThat(allLocales).isNotEmpty();
+        List<String> allLocales = locality.allSupportedLocales();
+        assertThat(allLocales).hasSize(87);
+        assertThat(allLocales).containsExactlyInAnyOrderElementsOf(findAllSupportedLocales(resourceDirectory));
     }
 
     @Test
@@ -54,7 +44,7 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
      * should have deterministic results.
      */
     @Test
-    void testLocaleStringRandom() {
+    void localeStringRandom() {
         // Check that we get the same locale when using pseudorandom number generator with a fixed seed
         final long fixedSeed = 5;
 
@@ -72,33 +62,42 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
      * locale is within the set of all supported locales
      */
     @RepeatedTest(100)
-    void testLocaleStringWithRandom() {
+    void localeStringWithRandom() {
         Random random = new Random();
         String randomLocale = locality.localeStringWithRandom(random);
-        assertThat(allLocales).contains(randomLocale);
+        assertThat(locality.allSupportedLocales()).contains(randomLocale);
     }
 
     @Test
-    void testLocaleStringWithoutReplacement() {
+    void localeStringWithoutReplacement() {
         Random random = new Random();
         // loop through all supported locales
         for (int i = 0; i < 2; i++) {
-            Set<String> returnedLocales = IntStream.range(0, allLocales.size())
+            Set<String> returnedLocales = IntStream.range(0, locality.allSupportedLocales().size())
                 .mapToObj(j -> locality.localeStringWithoutReplacement(random))
                 .collect(Collectors.toSet());
 
-            assertThat(allLocales).containsAll(returnedLocales);
+            assertThat(locality.allSupportedLocales()).containsAll(returnedLocales);
         }
     }
 
     @Test
-    void testLocaleString() {
-        assertThat(allLocales).contains(locality.localeString());
+    void localeString() {
+        assertThat(locality.allSupportedLocales()).contains(locality.localeString());
     }
 
     @Test
-    void testLocaleWithoutReplacement() {
+    void localeWithoutReplacement() {
         assertThat(locality.localeStringWithoutReplacement()).isNotNull();
     }
 
+    private List<String> findAllSupportedLocales(File resourceDirectory) {
+        File[] localeFiles = resourceDirectory.listFiles((dir, name) -> name.endsWith(".yml"));
+        assert localeFiles != null;
+        return Stream.of(localeFiles)
+            .peek(f -> assertThat(f).isFile())
+            .peek(f -> assertThat(f).isReadable())
+            .map(f -> f.getName().toLowerCase(ROOT).replace(".yml", ""))
+            .toList();
+    }
 }

--- a/src/test/java/net/datafaker/providers/base/LocalityTest.java
+++ b/src/test/java/net/datafaker/providers/base/LocalityTest.java
@@ -30,7 +30,9 @@ class LocalityTest extends BaseFakerTest<BaseFaker> {
 
         List<String> allLocales = locality.allSupportedLocales();
         assertThat(allLocales).hasSize(87);
-        assertThat(allLocales).containsExactlyInAnyOrderElementsOf(findAllSupportedLocales(resourceDirectory));
+        assertThat(allLocales)
+            .as("Somebody forgot to add the new locale to Locality.LOCALES")
+            .containsExactlyInAnyOrderElementsOf(findAllSupportedLocales(resourceDirectory));
     }
 
     @Test


### PR DESCRIPTION
Now we don't scan classpath at all, but just return a hardcoded list of locales. Instead, we now have a unit-test that verifies that this list is up-to-date.

Related to:
- datafaker-net/datafaker#1343 
- datafaker-net/datafaker#1349