### PR TITLE
fix generate sql will be truncate when quote char in word

### DIFF
--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -219,7 +219,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     private String handledObjectToString(int length, String strValue) {
-        StringBuilder builder = new StringBuilder(32);
+        StringBuilder builder = new StringBuilder(length);
 
         for (int k = 0; k < length; k++) {
             if (strValue.charAt(k) == quote) {

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -219,19 +219,16 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     private String handledObjectToString(int length, String strValue) {
-        StringJoiner joiner = null;
+        StringBuilder builder = new StringBuilder();
 
-        int j = 0;
         for (int k = 0; k < length; k++) {
             if (strValue.charAt(k) == quote) {
-                if (joiner == null) {
-                    joiner = new StringJoiner("" + quote);
-                }
-                joiner.add(strValue.substring(j, k + 1));
-                j = k + 1;
+                builder.append('\\').append(quote);
+            }else {
+                builder.append(strValue.charAt(k));
             }
         }
-        return joiner == null ? strValue : joiner.toString();
+        return builder.toString();
     }
 
     private String handlePrimitivesInArray(Class<?> componentType, Object value) {

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -219,7 +219,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     private String handledObjectToString(int length, String strValue) {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder(32);
 
         for (int k = 0; k < length; k++) {
             if (strValue.charAt(k) == quote) {

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -566,6 +567,30 @@ class SqlTest {
                 "       ('2', '8a4a0365-cd39-33c1-a52a-279b1076cf2d');" + LINE_SEPARATOR +
                 "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
                 "VALUES ('6', 'e807efdd-b6db-319d-8342-a044274d3417');";
+
+        assertThat(sql).isEqualTo(expected);
+    }
+
+    @Test
+    void testWordTruncated() {
+        BaseFaker faker = new BaseFaker(new Locale("test"),new Random(10L));
+        Schema<Integer, ?> schema = Schema.of(
+            field("Adress", () -> faker.address().country()),
+            field("Book", () -> faker.book().title())
+        );
+
+        SqlTransformer<Integer> transformer =
+            SqlTransformer
+                .<Integer>builder()
+                .batch(4)
+                .build();
+
+        String sql = transformer.generateStream(schema,3).collect(Collectors.joining(LINE_SEPARATOR));
+
+        String expected = "INSERT INTO \"MyTable\" (\"Adress\", \"Book\")" + LINE_SEPARATOR +
+            "VALUES ('Cote d\\'Ivoire', 'All the King\\'s Men')," + LINE_SEPARATOR +
+            "       ('Cote d\\'Ivoire', 'Blood\\'s a Rover')," + LINE_SEPARATOR +
+            "       ('Cote d\\'Ivoire', 'Blood\\'s a Rover');";
 
         assertThat(sql).isEqualTo(expected);
     }

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -1,5 +1,12 @@
 test:
   faker:
+    book:
+      title:
+        - "Blood's a Rover"
+        - "All the King's Men"
+    address:
+      country:
+        - "Cote d'Ivoire"
     code:
       isbn_gs1:
       - "333"

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -2,11 +2,11 @@ test:
   faker:
     book:
       title:
-        - "Blood's a Rover"
-        - "All the King's Men"
+      - "Blood's a Rover"
+      - "All the King's Men"
     address:
       country:
-        - "Cote d'Ivoire"
+      - "Cote d'Ivoire"
     code:
       isbn_gs1:
       - "333"


### PR DESCRIPTION
Some thesaurus`s word will be truncate when I use datafaker to generate SQL, like Address,Book... That reason is when SqlTransformer calling the handledObjectToString method will be one by one add char to new Object ,but if miss quote char will be stop.