### PR TITLE
fix: University tests

### DIFF
--- a/src/test/java/net/datafaker/providers/base/UniversityTest.java
+++ b/src/test/java/net/datafaker/providers/base/UniversityTest.java
@@ -9,11 +9,12 @@ import java.util.Collection;
 
 class UniversityTest extends BaseFakerTest<BaseFaker> {
 
+    private static final String UNIVERSITY_MATCHER = "[A-Za-z'() öèü-]+";
     private final University university = faker.university();
 
     @Test
     void testName() {
-        assertThat(university.name()).matches("[A-Za-z'() ]+");
+        assertThat(university.name()).matches(UNIVERSITY_MATCHER);
     }
 
     @Override
@@ -21,6 +22,6 @@ class UniversityTest extends BaseFakerTest<BaseFaker> {
         return List.of(TestSpec.of(university::prefix, "university.prefix"),
             TestSpec.of(university::suffix, "university.suffix"),
             TestSpec.of(university::degree, "university.degree"),
-            TestSpec.of(university::place, "university.place"));
+            TestSpec.of(university::place, "university.place", UNIVERSITY_MATCHER));
     }
 }


### PR DESCRIPTION
Extended the expected regex to include a few characters with accents.

Addresses https://github.com/datafaker-net/datafaker/pull/1404#issuecomment-2436479028

~~Add recently introduced test artifact `test.txt` to `.gitignore`~~

FYI if anyone needs to run single UnitTest classes or methods locally you can use:
` ./mvnw test -Dtest=UniversityTest`
` ./mvnw test -Dtest=UniversityTest#testName`
syntax.