### PR TITLE
#1412 fix concurrency issue in `CopyOnWriteMap`

### DIFF
--- a/src/main/java/net/datafaker/internal/helper/CopyOnWriteMap.java
+++ b/src/main/java/net/datafaker/internal/helper/CopyOnWriteMap.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 /**
  * This is a Copy On Write map. The main idea behind this is that
  * there is lots of static info per provider to make the providers operate.
@@ -59,6 +62,7 @@ public class CopyOnWriteMap<K, V> implements Map<K, V> {
 
     @Override
     public V put(K key, V value) {
+        requireNonNull(value, () -> "value is null for key " + key);
         Map<K, V> newMap = mapSupplier.get();
         newMap.putAll(map);
         final V result = newMap.put(key, value);
@@ -101,5 +105,16 @@ public class CopyOnWriteMap<K, V> implements Map<K, V> {
     @Override
     public Set<Entry<K, V>> entrySet() {
         return map.entrySet();
+    }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        V v = get(key);
+        return requireNonNullElse(v, defaultValue);
     }
 }

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -153,7 +153,8 @@ class FakerTest extends AbstractFakerTest {
     @Test
     void expression() {
         assertThat(faker.expression("#{options.option 'a','b','c','d'}")).matches("([abcd])");
-        assertThat(faker.expression("#{options.option ''''}")).matches("(')");
+        assertThat(faker.expression("#{options.option 'single'}")).isEqualTo("single");
+        assertThat(faker.expression("#{options.option ''''}")).isEqualTo("'");
         assertThat(faker.expression("#{options.option '12','345','89','54321'}")).matches("(12|345|89|54321)");
         assertThat(faker.expression("#{regexify '(a|b){2,3}'}")).matches("([ab]){2,3}");
         assertThat(faker.expression("#{regexify '\\.\\*\\?\\+'}")).matches("\\.\\*\\?\\+");


### PR DESCRIPTION
The default method `Map.getOrDefault` is not thread-safe: the condition `if (v == null && containsKey(key))` leaves `v = null` if the `key` was added by another thread exactly at the same moment. Then both conditions are true: `v==null` and `containsKey(key)`.

Now `CopyOnWriteMap.getOrDefault` does NOT check `containsKey(key)`. 
P.S. As a side-effect, `CopyOnWriteMap` doesn't allow putting `null` values to the map. But we don't need it anyway.