### PR TITLE
swedish ssn cannot have format like XXXXXX-000X

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
@@ -45,13 +45,8 @@ public class SwedenIdNumber implements IdNumberGenerator {
         return new PersonIdNumber(idNumber, birthday, gender(f, request));
     }
 
-    private String generateEndPart(BaseProviders f) {
-        String end;
-        do {
-            end = f.numerify("###");
-        } while (end.equals("000"));
-
-        return end;
+    public static String generateEndPart(BaseProviders f) {
+        return "%03d".formatted(f.number().numberBetween(1, 1000));
     }
 
     @Deprecated

--- a/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
@@ -37,12 +37,21 @@ public class SwedenIdNumber implements IdNumberGenerator {
     @Override
     public PersonIdNumber generateValid(BaseProviders f, IdNumber.IdNumberRequest request) {
         LocalDate birthday = birthday(f, request);
-        String end = f.numerify("###");
+        String end = generateEndPart(f);
         String basePart = DATE_TIME_FORMATTER.format(birthday)
             + f.options().option(PLUS_MINUS)
             + end;
         String idNumber = basePart + calculateChecksum(basePart);
         return new PersonIdNumber(idNumber, birthday, gender(f, request));
+    }
+
+    private String generateEndPart(BaseProviders f) {
+        String end;
+        do {
+            end = f.numerify("###");
+        } while (!end.equals("000"));
+
+        return end;
     }
 
     @Deprecated

--- a/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
@@ -49,7 +49,7 @@ public class SwedenIdNumber implements IdNumberGenerator {
         String end;
         do {
             end = f.numerify("###");
-        } while (!end.equals("000"));
+        } while (end.equals("000"));
 
         return end;
     }
@@ -84,6 +84,10 @@ public class SwedenIdNumber implements IdNumberGenerator {
                 return false;
             }
         } catch (DateTimeParseException | NumberFormatException ignore) {
+            return false;
+        }
+
+        if(ssn.startsWith("000", 7)){
             return false;
         }
 

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -14,6 +14,7 @@ class SwedishIdNumberTest {
 
     @Test
     void invalidSwedishSsn() {
+        assertThat(SwedenIdNumber.isValidSwedishSsn("020914-0001")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("8112289873")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("foo228-9873")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("811228-9873")).isFalse();

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -14,7 +14,7 @@ class SwedishIdNumberTest {
 
     @Test
     void invalidSwedishSsn() {
-        assertThat(SwedenIdNumber.isValidSwedishSsn("020914-0001")).isFalse();
+        assertThat(SwedenIdNumber.isValidSwedishSsn("020914-0003")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("8112289873")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("foo228-9873")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("811228-9873")).isFalse();


### PR DESCRIPTION
swedish ssn cannot have format like XXXXXX-000X, the end number part has to be between 001 and 999

explanation: https://www4.skatteverket.se/rattsligvagledning/edition/2024.5/330242.html#update_20240802105842

Information obtained with help of @Jakub-Pazio and @Johannestegner