### PR TITLE
Brazil passport number

### DIFF
--- a/src/main/resources/pt-BR.yml
+++ b/src/main/resources/pt-BR.yml
@@ -723,3 +723,6 @@ pt-BR:
                     "Taiwaneses", "Tanzanianos", "Tailandeses", "Tibetanos", "Trinitinos", "Tobagonianos", "Tunisianos", "Turcos", "Tuvaluenses",
                     "Ugandenses", "Ucranianos", "Uruguaios", "Uzbeques", "Vanuatuenses", "Venezuelanos", "Vietnamitas", "Galeses", "Iemenitas",
                     "Zambianos", "Zimbabuanos"]
+
+    passport:
+      valid: "[A-Z]{2}[0-9]{6}"

--- a/src/test/java/net/datafaker/providers/base/PassportTest.java
+++ b/src/test/java/net/datafaker/providers/base/PassportTest.java
@@ -78,4 +78,11 @@ class PassportTest extends BaseFakerTest<BaseFaker> {
             .hasSize(9);
     }
 
+    @RepeatedTest(10)
+    void testValidBrazil() {
+        assertThat(new BaseFaker(new Locale("pt", "BR")).passport().valid())
+            .hasSize(8)
+            .matches("[A-Z]{2}[0-9]{6}");
+    }
+
 }


### PR DESCRIPTION
Sources: [passports regex](https://community.zscaler.com/s/question/0D54u00009jZpJGCA0/international-passport-numbers-regex), [examples](https://regulaforensics.com/blog/brazilian-id-processing/)