### PR TITLE
swedish ssn symbol depends on birthday date of person

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
@@ -46,7 +46,7 @@ public class SwedenIdNumber implements IdNumberGenerator {
     }
 
     private String generateSymbol(LocalDate date){
-        return isYearOver100YearsAgo(date.toString().substring(0, 4)) ? "+" : "-";
+        return isYearOver100YearsAgo(date.toString().substring(0, 4), LocalDate.now()) ? "+" : "-";
     }
 
     public static String generateEndPart(BaseProviders f) {
@@ -112,18 +112,21 @@ public class SwedenIdNumber implements IdNumberGenerator {
 
         char symbol = ssn.charAt(6);
 
+        String lastCenturyPrefix = String.valueOf(LocalDate.now().minusYears(100).getYear()).substring(0, 2);
+        String thisCenturyPrefix = String.valueOf(LocalDate.now().getYear()).substring(0, 2);
+
         if (symbol == '+') {
-            dateString = "19" + dateString;
-            if (!isYearOver100YearsAgo(dateString)) {
+            dateString = lastCenturyPrefix + dateString;
+            if (!isYearOver100YearsAgo(dateString, LocalDate.now())) {
                 return true;
             }
         } else if (symbol == '-') {
             int year = Integer.parseInt(dateString.substring(0, 2));
             int currentYear = LocalDate.now().getYear() % 100;
             if (year > currentYear) {
-                dateString = "19" + dateString;
+                dateString = lastCenturyPrefix + dateString;
             } else {
-                dateString = "20" + dateString;
+                dateString = thisCenturyPrefix + dateString;
             }
         }
 
@@ -133,9 +136,9 @@ public class SwedenIdNumber implements IdNumberGenerator {
         return !reversed.equals(dateString);
     }
 
-    private static boolean isYearOver100YearsAgo(String date) {
+    static boolean isYearOver100YearsAgo(String date, LocalDate currentDate) {
         int year = Integer.parseInt(date);
-        LocalDate hundredYearsAgo = LocalDate.now().minusYears(100);
+        LocalDate hundredYearsAgo = currentDate.minusYears(100);
         return LocalDate.of(year, 1, 1).isBefore(hundredYearsAgo);
     }
 

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -1,10 +1,7 @@
 package net.datafaker.idnumbers;
 
-import net.datafaker.Faker;
-import net.datafaker.providers.base.IdNumber;
 import org.junit.jupiter.api.Test;
 
-import static net.datafaker.providers.base.IdNumber.GenderRequest.ANY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SwedishIdNumberTest {

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -17,6 +17,8 @@ class SwedishIdNumberTest {
         assertThat(SwedenIdNumber.isValidSwedishSsn("670919-9530")).isTrue();
         assertThat(SwedenIdNumber.isValidSwedishSsn("811228-9874")).isTrue();
         assertThat(SwedenIdNumber.isValidSwedishSsn("000229-9873")).isTrue();
+        assertThat(SwedenIdNumber.isValidSwedishSsn("991221+4146")).isTrue();
+        assertThat(SwedenIdNumber.isValidSwedishSsn("991227+0262")).isTrue();
     }
 
     @Test
@@ -45,6 +47,23 @@ class SwedishIdNumberTest {
             Arguments.of("1990", false),
             Arguments.of("2003", false),
             Arguments.of("2035", false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSsnForFindYearBeginning")
+    void testFindYearBeginningFromSsn(String ssn, String expectedYearBeginning) {
+        assertThat(SwedenIdNumber.findYearBeginningFromSsn(ssn)).isEqualTo(expectedYearBeginning);
+    }
+
+    private static Stream<Arguments> provideSsnForFindYearBeginning() {
+        return Stream.of(
+            Arguments.of("670919-9530", "19"),
+            Arguments.of("811228-9874", "19"),
+            Arguments.of("000225-9873", "20"),
+            Arguments.of("000225+9877", "19"),
+            Arguments.of("991221+4146", "18"),
+            Arguments.of("981227+0262", "18")
         );
     }
 }

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -1,6 +1,12 @@
 package net.datafaker.idnumbers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,5 +29,22 @@ class SwedishIdNumberTest {
         assertThat(SwedenIdNumber.isValidSwedishSsn("811200-9874")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("810028-9874")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("000229+9873")).isFalse();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getYears")
+    void testIsYearOver100YearsAgo(String year, boolean value) {
+        assertThat(SwedenIdNumber.isYearOver100YearsAgo(year, LocalDate.of(2024, 6, 1))).isEqualTo(value);
+    }
+
+    private static Stream<Arguments> getYears() {
+        return Stream.of(
+            Arguments.of("1900", true),
+            Arguments.of("1918", true),
+            Arguments.of("1924", true),
+            Arguments.of("1990", false),
+            Arguments.of("2003", false),
+            Arguments.of("2035", false)
+        );
     }
 }

--- a/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/SwedishIdNumberTest.java
@@ -1,7 +1,10 @@
 package net.datafaker.idnumbers;
 
+import net.datafaker.Faker;
+import net.datafaker.providers.base.IdNumber;
 import org.junit.jupiter.api.Test;
 
+import static net.datafaker.providers.base.IdNumber.GenderRequest.ANY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SwedishIdNumberTest {
@@ -10,6 +13,7 @@ class SwedishIdNumberTest {
     void validSwedishSsn() {
         assertThat(SwedenIdNumber.isValidSwedishSsn("670919-9530")).isTrue();
         assertThat(SwedenIdNumber.isValidSwedishSsn("811228-9874")).isTrue();
+        assertThat(SwedenIdNumber.isValidSwedishSsn("000229-9873")).isTrue();
     }
 
     @Test
@@ -21,5 +25,6 @@ class SwedishIdNumberTest {
         assertThat(SwedenIdNumber.isValidSwedishSsn("811228-9875")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("811200-9874")).isFalse();
         assertThat(SwedenIdNumber.isValidSwedishSsn("810028-9874")).isFalse();
+        assertThat(SwedenIdNumber.isValidSwedishSsn("000229+9873")).isFalse();
     }
 }


### PR DESCRIPTION
If a person is older than 100 years, their SSN should have a "+" as the separator.

I found that when I was using datafaker and it sometimes creates SSNs that look like "000229+XXXX," which is an invalid SSN because February 29 did not exist in the year 1900.

more info: https://swedish.identityinfo.net/personalidentitynumber