### PR TITLE
simplify few tests

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SwedenIdNumber.java
@@ -49,10 +49,13 @@ public class SwedenIdNumber implements IdNumberGenerator {
         return isYearOver100YearsAgo(date.toString().substring(0, 4), LocalDate.now()) ? "+" : "-";
     }
 
-    public static String generateEndPart(BaseProviders f) {
+    private String generateEndPart(BaseProviders f) {
         return "%03d".formatted(f.number().numberBetween(1, 1000));
     }
 
+    /**
+     * @deprecated Use method {@link #generateInvalid(BaseProviders)} instead
+     */
     @Deprecated
     public String getInvalidSsn(BaseProviders f) {
         return generateInvalid(f);
@@ -62,15 +65,11 @@ public class SwedenIdNumber implements IdNumberGenerator {
     public String generateInvalid(BaseProviders f) {
         String candidate = "121212-1212"; // Seed with a valid number
         while (isValidSwedishSsn(candidate)) {
-            String pattern = getPattern(f);
+            String pattern = f.options().option(VALID_PATTERNS);
             candidate = f.numerify(pattern);
         }
 
         return candidate;
-    }
-
-    private String getPattern(BaseProviders faker) {
-        return faker.options().option(VALID_PATTERNS);
     }
 
     public static boolean isValidSwedishSsn(String ssn) {

--- a/src/test/java/net/datafaker/helpers/IdNumberPatterns.java
+++ b/src/test/java/net/datafaker/helpers/IdNumberPatterns.java
@@ -9,5 +9,6 @@ public class IdNumberPatterns {
     public static final Pattern SOUTH_AFRICAN = Pattern.compile("[0-9]{10}([01])8[0-9]");
     public static final Pattern FRENCH = Pattern.compile("[12]\\d{2}(1[0-2]|0[1-9])\\d[0-9a-zA-Z]\\d{8}");
     public static final Pattern ITALIAN = Pattern.compile("[A-Z]{6}\\d{2}[ABCDEHLMPRST]\\d{2}[\\dA-Z]{5}");
+    public static final Pattern POLISH = Pattern.compile("\\d{11}");
 
 }


### PR DESCRIPTION
I see that `@ParametrizedTest` may be over-used. It causes "IFs" and logic in tests trying to handle all given values.

Sometimes it's better to just write plain old test without any IFs.