### PR TITLE
Added support for generating Latvian id number

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/EstonianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/EstonianIdNumber.java
@@ -58,7 +58,7 @@ public class EstonianIdNumber implements IdNumberGenerator {
             case 19 -> 3;
             case 20 -> 5;
             case 21 -> 7;
-            default -> throw new IllegalStateException("Too far in future: " + birthYear);
+            default -> throw new IllegalStateException("Birth year %s is out of allowed range [1800, 2199]".formatted(birthYear));
         };
         return switch (gender) {
             case FEMALE -> digit + 1;

--- a/src/main/java/net/datafaker/idnumbers/LatvianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/LatvianIdNumber.java
@@ -58,7 +58,7 @@ public class LatvianIdNumber implements IdNumberGenerator {
             case 18 -> 0;
             case 19 -> 1;
             case 20 -> 2;
-            default -> throw new IllegalStateException("Too far in future: " + birthYear);
+            default -> throw new IllegalStateException("Birth year %s is out of allowed range [1800, 2017]".formatted(birthYear));
         };
     }
 

--- a/src/main/java/net/datafaker/idnumbers/LatvianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/LatvianIdNumber.java
@@ -1,0 +1,77 @@
+package net.datafaker.idnumbers;
+
+import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
+import net.datafaker.providers.base.PersonIdNumber.Gender;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static net.datafaker.idnumbers.Utils.*;
+
+/**
+ * Latvian personal identification number
+ * See <a href="https://en.wikipedia.org/wiki/National_identification_number#Latvia">Latvian identification number</a>
+ */
+public class LatvianIdNumber implements IdNumberGenerator {
+    private static final DateTimeFormatter BIRTHDAY_FORMAT = DateTimeFormatter.ofPattern("ddMMyy");
+    private static final int[] CHECKSUM_COEFFICIENTS = {1, 6, 3, 7, 9, 10, 5, 8, 4, 2};
+    private static final LocalDate CHANGE_TO_NEW_FORMAT_DATE = LocalDate.of(2017, 7, 1);
+
+    @Override
+    public String countryCode() {
+        return "LV";
+    }
+
+    @Override
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        LocalDate birthday = birthday(faker, request);
+        Gender gender = gender(faker, request);
+
+        if (birthday.isBefore(CHANGE_TO_NEW_FORMAT_DATE)) {
+            String digits = basePart(faker, birthday);
+            String idNumber = digits + checksum(digits);
+            return new PersonIdNumber(idNumber, birthday, gender);
+        } else {
+            String idNumber = "3" + faker.number().numberBetween(2000000000L, 9999999999L);
+            return new PersonIdNumber(idNumber, birthday, gender);
+        }
+    }
+
+    @Override
+    public String generateInvalid(final BaseProviders faker) {
+        LocalDate birthday = faker.timeAndDate().birthday();
+        String digits = basePart(faker, birthday);
+        return digits + (checksum(digits) + 1) % 10;
+    }
+
+    private String basePart(BaseProviders faker, LocalDate birthday) {
+        return BIRTHDAY_FORMAT.format(birthday) +
+            "-" +
+            centuryDigit(birthday.getYear()) +
+            faker.number().digits(3);
+    }
+
+    static int centuryDigit(int birthYear) {
+        return switch (birthYear / 100) {
+            case 18 -> 0;
+            case 19 -> 1;
+            case 20 -> 2;
+            default -> throw new IllegalStateException("Too far in future: " + birthYear);
+        };
+    }
+
+    static int checksum(String numbers) {
+        int checkSum = 0;
+        numbers = numbers.replace("-", "");
+
+        for (int i = 0; i < numbers.length(); i++) {
+            int digit = Character.getNumericValue(numbers.charAt(i));
+            checkSum += CHECKSUM_COEFFICIENTS[i] * digit;
+        }
+
+        return ((1101 - checkSum) % 11) % 10;
+    }
+
+}

--- a/src/main/resources/META-INF/services/net.datafaker.idnumbers.IdNumberGenerator
+++ b/src/main/resources/META-INF/services/net.datafaker.idnumbers.IdNumberGenerator
@@ -6,6 +6,7 @@ net.datafaker.idnumbers.EstonianIdNumber
 net.datafaker.idnumbers.FrenchIdNumber
 net.datafaker.idnumbers.GeorgianIdNumber
 net.datafaker.idnumbers.ItalianIdNumber
+net.datafaker.idnumbers.LatvianIdNumber
 net.datafaker.idnumbers.MacedonianIdNumber
 net.datafaker.idnumbers.MexicanIdNumber
 net.datafaker.idnumbers.MoldovanIdNumber

--- a/src/test/java/net/datafaker/idnumbers/LatvianIdNumberTest.java
+++ b/src/test/java/net/datafaker/idnumbers/LatvianIdNumberTest.java
@@ -1,0 +1,35 @@
+package net.datafaker.idnumbers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static net.datafaker.idnumbers.LatvianIdNumber.centuryDigit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LatvianIdNumberTest {
+    @Test
+    void checksum() {
+        assertThat(LatvianIdNumber.checksum("080594-1684")).isEqualTo(1);
+        assertThat(LatvianIdNumber.checksum("121282-1121")).isEqualTo(0);
+        assertThat(LatvianIdNumber.checksum("121282-8888")).isEqualTo(2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1800, 1801, 1802, 1888, 1898, 1899})
+    void centuryDigit_18xx(int year) {
+        assertThat(centuryDigit(year)).isEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1900, 1901, 1902, 1988, 1998, 1999})
+    void centuryDigit_19xx(int year) {
+        assertThat(centuryDigit(year)).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2000, 2001, 2002, 2088, 2098, 2099})
+    void centuryDigit_20xx(int year) {
+        assertThat(centuryDigit(year)).isEqualTo(2);
+    }
+}

--- a/src/test/java/net/datafaker/providers/base/IdNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/IdNumberTest.java
@@ -1,20 +1,24 @@
 package net.datafaker.providers.base;
 
-import static java.lang.Integer.parseInt;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Locale;
-
+import net.datafaker.Faker;
+import net.datafaker.helpers.IdNumberPatterns;
+import net.datafaker.idnumbers.SouthAfricanIdNumber;
+import net.datafaker.idnumbers.SwedenIdNumber;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import net.datafaker.Faker;
-import net.datafaker.helpers.IdNumberPatterns;
-import net.datafaker.idnumbers.SouthAfricanIdNumber;
-import net.datafaker.idnumbers.SwedenIdNumber;
+import java.time.LocalDate;
+import java.util.Locale;
+
+import static java.lang.Integer.parseInt;
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static net.datafaker.providers.base.IdNumber.GenderRequest.ANY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class IdNumberTest extends BaseFakerTest<BaseFaker> {
 
@@ -22,6 +26,7 @@ class IdNumberTest extends BaseFakerTest<BaseFaker> {
     private static final Faker SOUTH_AFRICA = new Faker(new Locale("en", "ZA"));
     private static final Faker US = new Faker(new Locale("en", "US"));
     private static final Faker ESTONIAN = new Faker(new Locale("et", "EE"));
+    private static final Faker LATVIAN = new Faker(new Locale("lv", "LV"));
     private static final Faker ALBANIAN = new Faker(new Locale("sq", "AL"));
     private static final Faker BULGARIAN = new Faker(new Locale("bg", "BG"));
     private static final Faker MACEDONIAN = new Faker(new Locale("mk", "MK"));
@@ -113,6 +118,26 @@ class IdNumberTest extends BaseFakerTest<BaseFaker> {
     @RepeatedTest(100)
     void estonianPersonalCode_invalid() {
         assertThatPin(ESTONIAN.idNumber().invalid()).matches("[1-6][0-9]{10}");
+    }
+
+    @RepeatedTest(100)
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    void latvianPersonalCode_valid_oldFormat_before_2017_07_01() {
+        int minAgeApplicableForOldFormat = LocalDate.now().getYear() - 2017 + 1;
+        String idNumber = LATVIAN.idNumber().valid(new IdNumberRequest(minAgeApplicableForOldFormat, minAgeApplicableForOldFormat + 50, ANY)).idNumber();
+        assertThatPin(idNumber).matches("[0-3]\\d[0-1]\\d{3}-[0-2]\\d{4}");
+        assertThatCode(() -> LocalDate.parse(idNumber.substring(0, 6), ofPattern("ddMMyy"))).doesNotThrowAnyException();
+    }
+
+    @RepeatedTest(100)
+    void latvianPersonalCode_valid_newFormat_since_2017_07_01() {
+        int maxAgeApplicableForNewFormat = LocalDate.now().getYear() - 2017 - 1;
+        assertThatPin(LATVIAN.idNumber().valid(new IdNumberRequest(0, maxAgeApplicableForNewFormat, ANY)).idNumber()).matches("3[2-9]\\d{9}");
+    }
+
+    @RepeatedTest(100)
+    void latvianPersonalCode_invalid() {
+        assertThatPin(LATVIAN.idNumber().invalid()).matches("[0-3]\\d[0-1]\\d{3}-[0-2]\\d{4}");
     }
 
     @RepeatedTest(100)


### PR DESCRIPTION
* We support two formats: old (before 01.07.2017) and new (since 01.07.2017)
* For generating invalid ID numbers, we use only the old format (for simplicity)