### PR TITLE
Update docs for date faking

### DIFF
--- a/docs/documentation/date-format.md
+++ b/docs/documentation/date-format.md
@@ -7,10 +7,9 @@ Since 1.2.0 Datafaker supports specifying of date formats for dates and timestam
 
     ``` java 
     Faker faker = new Faker();
-    System.out.println(faker.date().future(1, TimeUnit.HOURS, "YYYY MM.dd mm:hh:ss");
-    System.out.println(faker.date().past(1, TimeUnit.HOURS, "YYYY-MM-dd mm:hh:ss");
-    System.out.println(faker.date().birthday(1, 99, "YYYY/MM/dd");
-
+    System.out.println(faker.timeAndDate().future(1, TimeUnit.HOURS, "YYYY MM.dd mm:hh:ss"));
+    System.out.println(faker.timeAndDate().past(1, TimeUnit.HOURS, "YYYY-MM-dd mm:hh:ss"));
+    System.out.println(faker.timeAndDate().birthday(1, 99, "YYYY/MM/dd"));
     ```
 
 And also this feature could be used in expressions like
@@ -18,7 +17,7 @@ And also this feature could be used in expressions like
 === "Java"
 
     ``` java 
-    faker.expression("#{date.past '15','SECONDS','dd/MM/yyyy hh:mm:ss'}")
+    faker.expression("#{date.past '15','SECONDS','dd/MM/yyyy hh:mm:ss'}");
     ```
 
 List of available time units:

--- a/src/main/java/net/datafaker/providers/base/DateAndTime.java
+++ b/src/main/java/net/datafaker/providers/base/DateAndTime.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author pmiklos
  * @since 0.8.0
+ * @deprecated Use {@link TimeAndDate} instead.
  */
 @Deprecated(since = "2.3.0", forRemoval = true)
 public class DateAndTime extends AbstractProvider<BaseProviders> {


### PR DESCRIPTION
The `net.datafaker.providers.base.DateAndTime` has been marked for deprecation, an additional hint what should be used instead makes it easier to adapt the changes. Also updated the docs to `net.datafaker.providers.base.TimeAndDate`.