### PR TITLE
Descrease amount of calls to nextInt for numerify

### DIFF
--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -373,22 +373,27 @@ public class FakeValuesService {
 
     private String bothify(String input, FakerContext context, boolean isUpper, boolean numerify, boolean letterify) {
         final int baseChar = isUpper ? 'A' : 'a';
+        boolean changed = false;
         final char[] res = input.toCharArray();
+        RandomService randomService = context.getRandomService();
         for (int i = 0; i < res.length; i++) {
             switch (res[i]) {
                 case '#' -> {
                     if (numerify) {
-                        res[i] = DIGITS[context.getRandomService().nextInt(10)];
+                        changed = true;
+                        i += GenerationUtils.generateAndSetNumber(i, res, res[i], randomService) - 1;
                     }
                 }
                 case 'Ø' -> {
                     if (numerify) {
-                        res[i] = DIGITS[context.getRandomService().nextInt(1, 9)];
+                        changed = true;
+                        res[i] = DIGITS[randomService.nextInt(1, 9)];
                     }
                 }
                 case '?' -> {
                     if (letterify) {
-                        res[i] = (char) (baseChar + context.getRandomService().nextInt(26)); // a-z
+                        changed = true;
+                        res[i] = (char) (baseChar + randomService.nextInt(26)); // a-z
                     }
                 }
                 default -> {
@@ -396,7 +401,7 @@ public class FakeValuesService {
             }
         }
 
-        return String.valueOf(res);
+        return changed ? String.valueOf(res) : input;
     }
 
     /**

--- a/src/main/java/net/datafaker/service/GenerationUtils.java
+++ b/src/main/java/net/datafaker/service/GenerationUtils.java
@@ -1,0 +1,55 @@
+package net.datafaker.service;
+
+public class GenerationUtils {
+    private static final char[] DIGITS = "0123456789".toCharArray();
+
+    // Based on Integer.MAX_VALUE the max value is 1_000_000_000
+    // assuming that every digit should have equal chance.
+    private static final int INT_LIMIT_DIGITS = 9;
+    private static final int[] TENS = initTens();
+
+    private static int generateNumber(RandomService randomService, int amountOfDigits) {
+        if (amountOfDigits > INT_LIMIT_DIGITS || amountOfDigits < 1) {
+            // should never happen
+            // in case it happened most probably there is a bug in a method invoking this
+            throw new IllegalArgumentException("Invalid amount of digits: " + amountOfDigits);
+        }
+        return randomService.nextInt(TENS[amountOfDigits + 1]);
+    }
+
+    static int generateAndSetNumber(int position, char[] target, char symbol, RandomService randomService) {
+        int symbolCounter = 0;
+        int generated = 0;
+        do {
+            symbolCounter++;
+
+            if (symbolCounter - generated == INT_LIMIT_DIGITS) {
+                final int r = generateNumber(randomService, INT_LIMIT_DIGITS);
+                insertNumber(r, INT_LIMIT_DIGITS, target, position + generated);
+                generated += INT_LIMIT_DIGITS;
+            }
+        } while (position + symbolCounter < target.length && target[position + symbolCounter] == symbol);
+
+        final int diff = symbolCounter - generated;
+        if (diff > 0) {
+            final int r = generateNumber(randomService, diff);
+            insertNumber(r, diff, target, position + generated);
+        }
+        return symbolCounter;
+    }
+
+    private static int[] initTens() {
+        int[] tens  = new int[INT_LIMIT_DIGITS + 2];
+        tens[0] = 1;
+        for (int i = 1; i < tens.length; i++) {
+            tens[i] = tens[i-1] * 10;
+        }
+        return tens;
+    }
+
+    private static void insertNumber(int number, int amountOfDigits, char[] target, int offset) {
+        for (int k = 0; k < amountOfDigits; k++) {
+            target[offset + k] = DIGITS[(number / TENS[k] % 10)];
+        }
+    }
+}

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reflections.Reflections;
 
@@ -76,24 +77,19 @@ class FakerTest extends AbstractFakerTest {
         assertThat(faker.bothify("ABC????DEF")).matches("ABC\\w{4}DEF");
     }
 
-    @Test
-    void numerifyShouldGenerateNumbers() {
-        assertThat(faker.numerify("####")).matches("\\d{4}");
-    }
-
-    @RepeatedTest(25)
-    void numerifyShouldGenerateNumbersNotStartingWithZero() {
-        assertThat(faker.numerify("Ø###")).matches("[1-9]\\d{3}");
-    }
-
-    @RepeatedTest(25)
-    void numerifyShouldGenerateNonZeroNumbers() {
-        assertThat(faker.numerify("ØØ")).matches("[1-9]{2}");
-    }
-
-    @Test
-    void numerifyShouldLeaveNonSpecialCharactersAlone() {
-        assertThat(faker.numerify("####123")).matches("\\d{4}123");
+    @ParameterizedTest
+    @CsvSource(delimiter = ';',
+        value = {
+        "Ø###;[1-9]\\d{3}",
+        "ØØ;[1-9]{2}",
+        "####123;\\d{4}123",
+        "####;\\d{4}",
+        "#############;\\d{13}",
+        "################;\\d{16}",
+        "####################;\\d{20}"
+        } )
+    void numerifyTest(String input, String expected) {
+        assertThat(faker.numerify(input)).matches(expected);
     }
 
     @Test

--- a/src/test/java/net/datafaker/annotations/FakeAnnotationTest.java
+++ b/src/test/java/net/datafaker/annotations/FakeAnnotationTest.java
@@ -74,8 +74,8 @@ public class FakeAnnotationTest {
 
         assertThat(person).isNotNull();
         assertThat(person.name()).isEqualTo("Aztar Ivy");
-        assertThat(person.address()).isEqualTo("Am Buttermarkt 46b, Dannerheim, BE 32422");
-        assertThat(person.color()).isEqualTo("rot");
+        assertThat(person.address()).isEqualTo("Am Buttermarkt 43b, Furkanheim, BE 36219");
+        assertThat(person.color()).isEqualTo("blau");
     }
 
     @Test


### PR DESCRIPTION
Since `nextInt` is one of the top consumers while executing `numerify` the idea is to reduce amount of calls to `nextInt`. 
For instance if we need to execute `numerify` for `####` then 4 digit number should be generated.
Current approach is generation a digit for every `#`. At the same time if `#` are together we can first count them and generate one number and then pick digits for every `#`. Then only one call to `nextInt` will be required. 
For sure if amount of sharps is large then several calls will be required (because of limited amount of numbers for int)
I also tried `nextLong` however it works significantly slower than `nextInt`.

some measurements for 6 `#` like
```java
@Benchmark
@BenchmarkMode(Mode.Throughput)
public void numerify(Blackhole blackhole) {
    blackhole.consume(DATA_FAKER.numerify("######"));
}
```
before PR
```
Benchmark                           Mode  Cnt      Score     Error   Units
DatafakerTemplateStrings.numerify  thrpt   10  39593.364 ± 237.243  ops/ms
```
after PR
```
Benchmark                           Mode  Cnt      Score     Error   Units
DatafakerTemplateStrings.numerify  thrpt   10  48787.181 ± 255.048  ops/ms
```

For cases with less than 5 `#` it is almost same behavior (no significant diff)

As a result it should also speed up a number of providers for id and address generation where such `numerify` calls are used, probably something else. Perhaps in similar way `letterify` might be improved... however not in this PR