### PR TITLE
Finish Release Workflow

### DIFF
--- a/.github/workflows/pom_update.yml
+++ b/.github/workflows/pom_update.yml
@@ -1,5 +1,9 @@
 on:
-  workflow_call:
+  workflow_run:
+    workflows:
+      - Release from GitHub Release
+    types:
+      - completed
 
 permissions:
   contents: write
@@ -24,6 +28,10 @@ jobs:
         git checkout -b $BRANCH
         ./mvnw build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT
         git add pom.xml
+        VERS=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout|tr -d SNAPSHOT|tr -d "-")
+        # Replace version in README.md look for >, :, ` (greater than, colon, backtick) followed by 2 period number period number and replace it with the leading char and new version
+        sed -i -E 's/([\>`\:]{1})2\.[0-9]\.[0-9]/\1'"$VERS"'/g' README.md
+        git add README.md
         git commit -m "Update pom SNAPSHOT version" -m "A release just completed, this PR increments the SNAPSHOT version in pom.xml" --signoff
         git push --set-upstream origin $BRANCH --force
         gh pr create --fill

--- a/.github/workflows/release-from-tag.yml
+++ b/.github/workflows/release-from-tag.yml
@@ -46,7 +46,3 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-
-  call_pom_update:
-    needs: publish
-    uses: ./.github/workflows/pom_update.yml


### PR DESCRIPTION
- Have the pom update workflow trigger when the release has completed. (Instead of being called, since a called workflow can't have greater permissions than the caller.)
- Also update the versions in README.md.

Fixes datafaker-net/datafaker#1488

Tested in this junk repo: https://github.com/kingthorin/dftest (which will be removed after this PR is merged).