### PR TITLE
remove old commented out test in FakeValuesTest

### DIFF
--- a/src/test/java/net/datafaker/internal/helper/LazyEvaluatedTest.java
+++ b/src/test/java/net/datafaker/internal/helper/LazyEvaluatedTest.java
@@ -1,0 +1,57 @@
+package net.datafaker.internal.helper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LazyEvaluatedTest {
+    private final AtomicInteger executions = new AtomicInteger(0);
+    private final Supplier<Integer> slowLoader = () -> {
+        sleep();
+        return executions.incrementAndGet();
+    };
+
+    private final LazyEvaluated<Integer> lazyEvaluated = new LazyEvaluated<>(slowLoader);
+
+    @Test
+    void notInitializedUntilCalled() {
+        assertThat(executions.get()).isEqualTo(0);
+    }
+
+    @Test
+    void initializedOnlyOnce() throws InterruptedException {
+        int threadsCount = 5;
+        ExecutorService threadPool = newFixedThreadPool(threadsCount);
+
+        for (int i = 0; i < threadsCount; i++) {
+            threadPool.submit(() -> {
+                try {
+                    assertThat(lazyEvaluated.get()).isEqualTo(1);
+                } catch (Throwable e) {
+                    System.out.printf("Loading failed...%s%n", e);
+                }
+            });
+        }
+
+        threadPool.shutdown();
+        assertThat(threadPool.awaitTermination(10, SECONDS)).isTrue();
+
+        assertThat(executions.get())
+            .as("The slowLoader should be executed only once, even if the value was asked in multiple parallel threads.")
+            .isEqualTo(1);
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/net/datafaker/service/FakeValuesTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesTest.java
@@ -19,43 +19,6 @@ class FakeValuesTest {
     private static final String PATH = "address";
     private final FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, "address.yml", PATH));
 
-/*
-    Test case for for https://github.com/datafaker-net/datafaker/issues/574
-    To test it need to change net.datafaker.service.FakeValues.loadValues to something from private
-    Powermock can not test it because it requires JUnit4
-    @Test
-    void testLoadValues() {
-        FakeValues fv = Mockito.spy(new FakeValues(Locale.ENGLISH));
-        ExecutorService service = new ForkJoinPool(2);
-        CountDownLatch latch = new CountDownLatch(2);
-        service.submit(() -> {
-            latch.countDown();
-            try {
-                latch.await(10, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            fv.get("key");
-        });
-        service.submit(() -> {
-            latch.countDown();
-            try {
-                latch.await(10, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            fv.get("key");
-        });
-        service.shutdown();
-        try {
-            service.awaitTermination(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        verify(fv, times(1)).loadValues();
-    }
-*/
-
     @Test
     void getAValueReturnsAValue() {
         assertThat(fakeValues.get(PATH)).isNotNull();


### PR DESCRIPTION
The loading synchronization was later implemented in `LazyEvaluated`, and this commit adds a similar test `LazyEvaluatedTest`.