### PR TITLE
TomlTransformer implementation

### DIFF
--- a/src/main/java/net/datafaker/transformations/TomlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/TomlTransformer.java
@@ -1,0 +1,131 @@
+package net.datafaker.transformations;
+
+import net.datafaker.sequence.FakeSequence;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TomlTransformer<IN> implements Transformer<IN, String> {
+    @Override
+    public String apply(IN input, Schema<IN, ?> schema) {
+        if (schema == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        writeSchema(sb, input, schema, "");
+        int len = sb.length();
+        int sepLen = LINE_SEPARATOR.length();
+        if (len >= sepLen && sb.lastIndexOf(LINE_SEPARATOR, len - sepLen) >= 0) {
+            sb.setLength(len - sepLen);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String generate(Iterable<IN> input, Schema<IN, ?> schema) {
+        if (input instanceof FakeSequence<IN> fs && fs.isInfinite()) {
+            throw new IllegalArgumentException("The sequence should be finite of size: " + fs);
+        }
+        StringJoiner joiner = new StringJoiner(LINE_SEPARATOR);
+        for (IN in : input) {
+            joiner.add(apply(in, schema));
+        }
+        return joiner.toString();
+    }
+
+    @Override
+    public String generate(Schema<IN, ?> schema, int limit) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < limit; i++) {
+            sb.append(apply(null, schema));
+            if (i < limit - 1) {
+                sb.append(LINE_SEPARATOR);
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getStartStream(Schema<IN, ?> schema) {
+        return "";
+    }
+
+    @Override
+    public String getEndStream() {
+        return "";
+    }
+
+    private void writeSchema(StringBuilder sb, IN input, Schema<IN, ?> schema, String pathPrefix) {
+        Field<IN, ?>[] fields = schema.getFields();
+        Set<String> seen = new HashSet<>();
+        for (Field<IN, ?> f : fields) {
+            String key = f.getName();
+            if (!seen.add(key)) {
+                continue;
+            }
+            Object val = f.transform(input);
+            writeValue(sb, key, pathPrefix, val);
+        }
+    }
+
+    private void writeValue(StringBuilder sb, String key, String pathPrefix, Object val) {
+        String fullPath = pathPrefix.isEmpty() ? key : pathPrefix + "." + key;
+
+        if (val instanceof Schema<?, ?> nested) {
+            sb.append("[").append(fullPath).append("]").append(LINE_SEPARATOR);
+            writeSchema(sb, null, (Schema<IN, ?>) nested, fullPath);
+            return;
+        }
+
+        if (val instanceof Collection<?> col) {
+            if (col.isEmpty()) {
+                sb.append(key).append(" = []").append(LINE_SEPARATOR);
+                return;
+            }
+            Object first = col.iterator().next();
+            if (first instanceof Schema<?, ?>) {
+                for (Object item : col) {
+                    sb.append("[[").append(fullPath).append("]]").append(LINE_SEPARATOR);
+                    writeSchema(sb, null, (Schema<IN, ?>) item, fullPath);
+                }
+            } else {
+                String array = col.stream().map(this::value2String).collect(Collectors.joining(", "));
+                sb.append(key).append(" = [ ").append(array).append(" ]").append(LINE_SEPARATOR);
+            }
+            return;
+        }
+
+        if (val != null && val.getClass().isArray()) {
+            handleArray(sb, key, val);
+            return;
+        }
+
+        // Scalar value
+        sb.append(key).append(" = ").append(value2String(val)).append(LINE_SEPARATOR);
+    }
+
+    private void handleArray(StringBuilder sb, String key, Object array) {
+        int length = java.lang.reflect.Array.getLength(array);
+        if (length == 0) {
+            sb.append(key).append(" = []").append(LINE_SEPARATOR);
+            return;
+        }
+        List<Object> list = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            list.add(java.lang.reflect.Array.get(array, i));
+        }
+        String joined = list.stream().map(this::value2String).collect(Collectors.joining(", "));
+        sb.append(key).append(" = [ ").append(joined).append(" ]").append(LINE_SEPARATOR);
+    }
+
+    private String value2String(Object val) {
+        if (val == null) {
+            return "null";
+        }
+        if (val instanceof Number || val instanceof Boolean) {
+            return val.toString();
+        }
+        String s = String.valueOf(val).replace("\\", "\\\\").replace("\"", "\\\"");
+        return "\"" + s + "\"";
+    }
+}

--- a/src/test/java/net/datafaker/formats/TomlTest.java
+++ b/src/test/java/net/datafaker/formats/TomlTest.java
@@ -1,0 +1,126 @@
+package net.datafaker.formats;
+
+import net.datafaker.providers.base.BaseFaker;
+import net.datafaker.providers.base.Name;
+import net.datafaker.transformations.Schema;
+import net.datafaker.transformations.TomlTransformer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static net.datafaker.transformations.Field.field;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+class TomlTest {
+
+    @ParameterizedTest
+    @MethodSource("generateTestSchema")
+    void simpleTomlTest(Schema<String, String> schema, String expected) {
+        TomlTransformer<String> tomlTransformer = new TomlTransformer<>();
+        assertThat(tomlTransformer.generate(schema, 1)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> generateTestSchema() {
+        String sep = System.lineSeparator();
+        return Stream.of(
+            of(Schema.of(), ""),
+            of(Schema.of(field("key", () -> "value")), "key = \"value\""),
+            of(Schema.of(field("number", () -> 123)), "number = 123"),
+            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.0))), "number = 123.0"),
+            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), "number = 123.123"),
+            of(Schema.of(field("boolean", () -> true)), "boolean = true"),
+            of(Schema.of(field("nullValue", () -> null)), "nullValue = null"),
+            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+                "array = [ null, \"test\", \"123\" ]"),
+            of(Schema.of(field("array", () -> new Integer[]{123, 456, 789})),
+                "array = [ 123, 456, 789 ]"),
+            of(Schema.of(field("array", () -> new Object[]{"test", 456, true})),
+                "array = [ \"test\", 456, true ]"),
+            of(Schema.of(field("emptyarray", () -> new Long[]{})), "emptyarray = []"),
+            of(Schema.of(field("emptyarray", Collections::emptyList)), "emptyarray = []"),
+            of(Schema.of(
+                field("key", () -> "value"),
+                field("nested", () -> Schema.of(field("nestedkey", () -> "nestedvalue")))
+            ), "key = \"value\"" + sep +
+                "[nested]" + sep +
+                "nestedkey = \"nestedvalue\""),
+            of(Schema.of(
+                field("key", () -> "value"),
+                field("nested", () -> Schema.of(
+                    field("nestedkey", () -> "nestedvalue"),
+                    field("nested2", () -> Schema.of(
+                        field("nestedkey2", () -> "nestedvalue2")
+                    ))
+                ))
+            ), "key = \"value\"" + sep +
+                "[nested]" + sep +
+                "nestedkey = \"nestedvalue\"" + sep +
+                "[nested.nested2]" + sep +
+                "nestedkey2 = \"nestedvalue2\""),
+            of(Schema.of(
+                field("parent", () -> Schema.of(
+                    field("numbers", () -> new Integer[]{1, 2})
+                ))
+            ), "[parent]" + sep +
+                "numbers = [ 1, 2 ]"),
+            of(Schema.of(
+                field("items", () -> List.of(
+                    Schema.of(field("id", () -> 1)),
+                    Schema.of(field("id", () -> 2))
+                ))
+            ), "[[items]]" + sep +
+                "id = 1" + sep +
+                "[[items]]" + sep +
+                "id = 2")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 4, 8})
+    void generateFromFakeSequence(int limit) {
+        final BaseFaker faker = new BaseFaker();
+        Schema<Name, String> schema = Schema.of(field("firstName", Name::firstName));
+
+        TomlTransformer<Name> transformer = new TomlTransformer<>();
+
+        String toml = transformer.generate(
+            faker.<Name>collection().suppliers(faker::name).maxLen(limit).build(),
+            schema);
+
+        int numberOfLines = 0;
+        for (int i = 0; i < toml.length(); i++) {
+            if (toml.regionMatches(i, System.lineSeparator(), 0, System.lineSeparator().length())) {
+                numberOfLines++;
+            }
+        }
+
+        assertThat(numberOfLines).isEqualTo((limit * (schema.getFields().length)) - 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 4, 8})
+    void generateFromFakeSequenceWithCollection(int limit) {
+        final BaseFaker faker = new BaseFaker();
+        Schema<Name, List<String>> schema = Schema.of(field("firstNames", name -> IntStream.rangeClosed(1, limit)
+            .mapToObj(it -> name.firstName())
+            .collect(Collectors.toList())));
+
+        TomlTransformer<Name> transformer = new TomlTransformer<>();
+
+        String toml = transformer.generate(
+            faker.<Name>collection().suppliers(faker::name).maxLen(1).build(),
+            schema);
+
+        assertThat(toml).matches("firstNames = \\[ \"(.+\",?){" + limit + "} ]");
+    }
+
+}


### PR DESCRIPTION
Adding to the collection of Transformers (JsonTransformer, YamlTransformer etc.)
**TOML support**,  to generate data in TOML format ([specs](https://toml.io/en/v1.0.0#objectives)).

The format is often used in Python and Rust.

The implementation is based on YamlTransformer and its tests structure