### PR TITLE
#1593 fix Singapore ID number generation

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/SingaporeIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/SingaporeIdNumber.java
@@ -4,7 +4,6 @@ import net.datafaker.providers.base.BaseProviders;
 import net.datafaker.providers.base.IdNumber.IdNumberRequest;
 import net.datafaker.providers.base.PersonIdNumber;
 import net.datafaker.providers.base.PersonIdNumber.Gender;
-import net.datafaker.service.RandomService;
 
 import java.time.LocalDate;
 
@@ -42,7 +41,7 @@ public class SingaporeIdNumber implements IdNumberGenerator {
         return id.toString();
     }
 
-    private static final int[] CODE = {0, 2, 7, 6, 5, 4, 3, 2};
+    private static final int[] CODE = {2, 7, 6, 5, 4, 3, 2};
     private static final String FIN_LETTERS = "XWUTRQPNMLK";
     private static final String UIN_LETTERS = "JZIHGFEDCBA";
 
@@ -60,7 +59,7 @@ public class SingaporeIdNumber implements IdNumberGenerator {
     }
 
     private static PersonIdNumber generateValidIdNumber(BaseProviders faker, LocalDate birthDate, boolean citizen, Gender gender) {
-        int[] number = randomDigits(faker);
+        int[] number = faker.number().randomDigits(7);
         String idNumber = format(birthDate, citizen, number);
         return new PersonIdNumber(idNumber, birthDate, gender);
     }
@@ -87,15 +86,6 @@ public class SingaporeIdNumber implements IdNumberGenerator {
             case SINGAPOREAN_TWENTY_FIRST_CENTURY,
                  FOREIGNER_TWENTY_FIRST_CENTURY -> faker.timeAndDate().birthday(Math.max(0, now - 2099), now - 2000);
         };
-    }
-
-    private static int[] randomDigits(BaseProviders f) {
-        final RandomService random = f.random();
-        final int[] number = new int[7];
-        for (int i = 0; i < number.length; i++) {
-            number[i] = random.nextInt(0, 9);
-        }
-        return number;
     }
 
     static char centuryPrefixCitizen(LocalDate issueDate) {

--- a/src/main/java/net/datafaker/providers/base/Number.java
+++ b/src/main/java/net/datafaker/providers/base/Number.java
@@ -24,6 +24,17 @@ public class Number extends AbstractProvider<BaseProviders> {
     }
 
     /**
+     * Returns an array of random numbers from 0 to 9 (both inclusive) of given length
+     */
+    public int[] randomDigits(int length) {
+        int[] result = new int[length];
+        for (int i = 0; i < length; i++) {
+            result[i] = randomDigit();
+        }
+        return result;
+    }
+
+    /**
      * Returns a random number from 1-9 (both inclusive)
      */
     public int randomDigitNotZero() {

--- a/src/test/java/net/datafaker/providers/base/NumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/NumberTest.java
@@ -3,6 +3,8 @@ package net.datafaker.providers.base;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -38,6 +40,17 @@ class NumberTest extends BaseFakerTest<BaseFaker> {
             nums.add(value);
         }
         assertThat(nums).contains(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 8, 16, 25, 36})
+    void randomDigits(int length) {
+        final Number number = faker.number();
+        int[] value = number.randomDigits(length);
+        assertThat(value).hasSize(length);
+        for (int i = 0; i < length; i++) {
+            assertThat(value[i]).isLessThanOrEqualTo(9).isGreaterThanOrEqualTo(0);
+        }
     }
 
     @Test


### PR DESCRIPTION
`SingaporeIdNumber.CODE` array has length 8 but is used to compute pair-wise weighted sum with random digits of length 7. This commit removes the first element (0).

I've tested results with online NRIC validator https://nric.biz/