### PR TITLE
Refactor BaseFakerTest (provider list test)

### DIFF
--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -381,12 +381,12 @@ class FakerTest {
                 }
                 if (m.isAnnotationPresent(Deterministic.class)) {
                     assertThat(set)
-                        .as("Class: " + ap.getClass().getName()
+                        .as(() -> "Class: " + ap.getClass().getName()
                             + ", method: " + m.getName() + " should have the same return value")
                         .hasSize(1);
                 } else {
                     assertThat(set)
-                        .as("Class: " + ap.getClass().getName()
+                        .as(() -> "Class: " + ap.getClass().getName()
                             + ", method: " + m.getName() + " should generate different return values")
                         .hasSizeGreaterThan(1);
                 }

--- a/src/test/java/net/datafaker/providers/base/AncientTest.java
+++ b/src/test/java/net/datafaker/providers/base/AncientTest.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-class AncientTest extends BaseFakerTest<BaseFaker> {
+class AncientTest extends BaseFakerTest {
 
     private static Collection<TestSpec> getProviderListTests(Ancient ancient) {
         return List.of(
@@ -24,11 +24,13 @@ class AncientTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Nested
-    class AncientInGreekTest extends BaseFakerTest<BaseFaker> {
+    final class AncientInGreekTest extends ProviderListTest<BaseFaker> {
+
+        private final BaseFaker faker = new BaseFaker(new Locale("el", "GR"));
 
         @Override
         protected BaseFaker getFaker() {
-            return new BaseFaker(new Locale("el", "GR"));
+            return faker;
         }
 
         @Override

--- a/src/test/java/net/datafaker/providers/base/AnimalTest.java
+++ b/src/test/java/net/datafaker/providers/base/AnimalTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class AnimalTest extends BaseFakerTest<BaseFaker> {
+class AnimalTest extends BaseFakerTest {
 
     private final Animal animal = faker.animal();
 

--- a/src/test/java/net/datafaker/providers/base/AppTest.java
+++ b/src/test/java/net/datafaker/providers/base/AppTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class AppTest extends BaseFakerTest<BaseFaker> {
+class AppTest extends BaseFakerTest {
 
     private final App app = faker.app();
 

--- a/src/test/java/net/datafaker/providers/base/ApplianceTest.java
+++ b/src/test/java/net/datafaker/providers/base/ApplianceTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class ApplianceTest extends BaseFakerTest<BaseFaker> {
+final class ApplianceTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/ArtistTest.java
+++ b/src/test/java/net/datafaker/providers/base/ArtistTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class ArtistTest extends BaseFakerTest<BaseFaker> {
+class ArtistTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/AustraliaTest.java
+++ b/src/test/java/net/datafaker/providers/base/AustraliaTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class AustraliaTest extends BaseFakerTest<BaseFaker> {
+class AustraliaTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/AviationTest.java
+++ b/src/test/java/net/datafaker/providers/base/AviationTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Collection;
 import java.util.regex.Pattern;
 
-class AviationTest extends BaseFakerTest<BaseFaker> {
+class AviationTest extends BaseFakerTest {
 
     private final Aviation aviation = faker.aviation();
 

--- a/src/test/java/net/datafaker/providers/base/AwsTest.java
+++ b/src/test/java/net/datafaker/providers/base/AwsTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AwsTest extends BaseFakerTest<BaseFaker> {
+class AwsTest extends BaseFakerTest {
 
     @Test
     void testAccountId() {

--- a/src/test/java/net/datafaker/providers/base/BaseFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/BaseFakerTest.java
@@ -1,93 +1,11 @@
 package net.datafaker.providers.base;
 
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+public abstract class BaseFakerTest extends ProviderListTest<BaseFaker> {
+    protected final BaseFaker faker = new BaseFaker();
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class BaseFakerTest<T extends BaseFaker> {
-
-    protected final T faker = getFaker();
-
-    @SuppressWarnings("unchecked")
-    protected T getFaker() {
-        return (T) new BaseFaker();
+    @Override
+    protected final BaseFaker getFaker() {
+        return faker;
     }
 
-    protected List<String> getBaseList(String key) {
-        return faker.fakeValuesService().fetchObject(key, faker.getContext());
-    }
-
-    @ParameterizedTest
-    @MethodSource("providerListTest")
-    protected void testProviderList(TestSpec testSpec) {
-        // Given
-        Set<String> actual = new HashSet<>(getBaseList(testSpec.key));
-        // When
-        String item = (String) testSpec.supplier.get();
-        // Then
-        assertThat(item).as("Check item isn't empty").isNotEmpty();
-        String collection = "\"" + testSpec.key + "\"";
-        assertThat(actual).as("Check actual list isn't empty and contains the item for the key " + collection).isNotEmpty()
-            .anyMatch(item::equals);
-        assertThat(actual).as("Actual should not have empty entries. " + collection).noneMatch(single -> single.isBlank());
-        if (!testSpec.regex.isEmpty()) {
-            assertThat(item).as("Check item matches regex").matches(Pattern.compile(testSpec.regex));
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("providerListTest")
-    void testNoDuplications(TestSpec testSpec) {
-        var terms = getBaseList(testSpec.key);
-
-        Set<String> uniques = new HashSet<>();
-        Set<String> duplicates = new HashSet<>();
-        for (String term : terms) {
-            if (!uniques.add(term)) {
-                duplicates.add(term);
-            }
-        }
-        assertThat(duplicates)
-            .as("Check no duplications in " + testSpec.key + " with terms " + terms)
-            .isEmpty();
-    }
-
-    protected abstract Collection<TestSpec> providerListTest();
-
-    protected static class TestSpec {
-        private final Supplier<?> supplier;
-        private final String key;
-        @SuppressWarnings("unused")
-        private final String regex;
-
-        private TestSpec(Supplier<?> supplier, String key, String regex) {
-            this.supplier = supplier;
-            this.key = key;
-            this.regex = regex;
-        }
-
-        public static TestSpec of(Supplier<?> supplier, String key) {
-            return new TestSpec(supplier, key, "");
-        }
-
-        public static TestSpec of(Supplier<?> supplier, String key, String regex) {
-            return new TestSpec(supplier, key, regex);
-        }
-
-        @Override
-        public String toString() {
-            // The result of this toString will be used by IDE in test report
-            return "Key: " + key;
-        }
-    }
 }

--- a/src/test/java/net/datafaker/providers/base/BloodTypeTest.java
+++ b/src/test/java/net/datafaker/providers/base/BloodTypeTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class BloodTypeTest extends BaseFakerTest<BaseFaker> {
+class BloodTypeTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/BookTest.java
+++ b/src/test/java/net/datafaker/providers/base/BookTest.java
@@ -2,12 +2,12 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Collection;
-
-class BookTest extends BaseFakerTest<BaseFaker> {
+class BookTest extends BaseFakerTest {
 
     private final Book book = faker.book();
 

--- a/src/test/java/net/datafaker/providers/base/BrandTest.java
+++ b/src/test/java/net/datafaker/providers/base/BrandTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class BrandTest extends BaseFakerTest<BaseFaker> {
+class BrandTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/BusinessTest.java
+++ b/src/test/java/net/datafaker/providers/base/BusinessTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class BusinessTest extends BaseFakerTest<BaseFaker> {
+class BusinessTest extends BaseFakerTest {
 
     private final Business business = faker.business();
 

--- a/src/test/java/net/datafaker/providers/base/CameraTest.java
+++ b/src/test/java/net/datafaker/providers/base/CameraTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class CameraTest extends BaseFakerTest<BaseFaker> {
+class CameraTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CannabisTest.java
+++ b/src/test/java/net/datafaker/providers/base/CannabisTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class CannabisTest extends BaseFakerTest<BaseFaker> {
+class CannabisTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CatTest.java
+++ b/src/test/java/net/datafaker/providers/base/CatTest.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
-class CatTest extends BaseFakerTest<BaseFaker> {
+class CatTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
+++ b/src/test/java/net/datafaker/providers/base/ChiquitoTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class ChiquitoTest extends BaseFakerTest<BaseFaker> {
+class ChiquitoTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CoinTest.java
+++ b/src/test/java/net/datafaker/providers/base/CoinTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class CoinTest extends BaseFakerTest<BaseFaker> {
+class CoinTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/ColorTest.java
+++ b/src/test/java/net/datafaker/providers/base/ColorTest.java
@@ -2,12 +2,12 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Collection;
-
-class ColorTest extends BaseFakerTest<BaseFaker> {
+class ColorTest extends BaseFakerTest {
 
     private final Color color = faker.color();
 

--- a/src/test/java/net/datafaker/providers/base/CommerceTest.java
+++ b/src/test/java/net/datafaker/providers/base/CommerceTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import static java.lang.Float.parseFloat;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CommerceTest extends BaseFakerTest<BaseFaker> {
+class CommerceTest extends BaseFakerTest {
 
     private static final String CAPITALIZED_WORD_REGEX = "[A-Z][a-z]+";
 

--- a/src/test/java/net/datafaker/providers/base/CommunityTest.java
+++ b/src/test/java/net/datafaker/providers/base/CommunityTest.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
-public class CommunityTest extends BaseFakerTest<BaseFaker> {
+public class CommunityTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CompanyTest.java
+++ b/src/test/java/net/datafaker/providers/base/CompanyTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Collection;
 import java.util.regex.Pattern;
 
-class CompanyTest extends BaseFakerTest<BaseFaker> {
+class CompanyTest extends BaseFakerTest {
 
     public static final Pattern URL_PATTERN = Pattern.compile("(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])");
     public static final Pattern PHRASE_PATTERN = Pattern.compile("(\\w+[ /-]?){1,9}");

--- a/src/test/java/net/datafaker/providers/base/ComputerTest.java
+++ b/src/test/java/net/datafaker/providers/base/ComputerTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class ComputerTest extends BaseFakerTest<BaseFaker> {
+class ComputerTest extends BaseFakerTest {
 
     private final Computer computer = faker.computer();
 

--- a/src/test/java/net/datafaker/providers/base/ConstructionTest.java
+++ b/src/test/java/net/datafaker/providers/base/ConstructionTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class ConstructionTest extends BaseFakerTest<BaseFaker> {
+class ConstructionTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CosmereTest.java
+++ b/src/test/java/net/datafaker/providers/base/CosmereTest.java
@@ -4,7 +4,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class CosmereTest extends BaseFakerTest<BaseFaker> {
+class CosmereTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CountryTest.java
+++ b/src/test/java/net/datafaker/providers/base/CountryTest.java
@@ -3,12 +3,12 @@ package net.datafaker.providers.base;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Collection;
-
-class CountryTest extends BaseFakerTest<BaseFaker> {
+class CountryTest extends BaseFakerTest {
 
     private final Country country = faker.country();
 

--- a/src/test/java/net/datafaker/providers/base/CryptoCoinTest.java
+++ b/src/test/java/net/datafaker/providers/base/CryptoCoinTest.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
-class CryptoCoinTest extends BaseFakerTest<BaseFaker> {
+class CryptoCoinTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CultureSeriesTest.java
+++ b/src/test/java/net/datafaker/providers/base/CultureSeriesTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class CultureSeriesTest extends BaseFakerTest<BaseFaker> {
+class CultureSeriesTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/CurrencyTest.java
+++ b/src/test/java/net/datafaker/providers/base/CurrencyTest.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
-class CurrencyTest extends BaseFakerTest<BaseFaker> {
+class CurrencyTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/DcComicsTest.java
+++ b/src/test/java/net/datafaker/providers/base/DcComicsTest.java
@@ -3,10 +3,10 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-public class DcComicsTest extends BaseFakerTest<BaseFaker> {
+public class DcComicsTest extends BaseFakerTest {
 
     @Override
-protected Collection<TestSpec> providerListTest() { 
+    protected Collection<TestSpec> providerListTest() {
         DcComics dcComics = faker.dcComics();
         return List.of(TestSpec.of(dcComics::hero, "dc_comics.hero"),
                 TestSpec.of(dcComics::heroine, "dc_comics.heroine"),

--- a/src/test/java/net/datafaker/providers/base/DemographicTest.java
+++ b/src/test/java/net/datafaker/providers/base/DemographicTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class DemographicTest extends BaseFakerTest<BaseFaker> {
+class DemographicTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/DeviceTest.java
+++ b/src/test/java/net/datafaker/providers/base/DeviceTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class DeviceTest extends BaseFakerTest<BaseFaker> {
+class DeviceTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/DogTest.java
+++ b/src/test/java/net/datafaker/providers/base/DogTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class DogTest extends BaseFakerTest<BaseFaker> {
+class DogTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/DroneTest.java
+++ b/src/test/java/net/datafaker/providers/base/DroneTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class DroneTest extends BaseFakerTest<BaseFaker> {
+class DroneTest extends BaseFakerTest {
 
     private final Drone drone = faker.drone();
 

--- a/src/test/java/net/datafaker/providers/base/DungeonsAndDragonsTest.java
+++ b/src/test/java/net/datafaker/providers/base/DungeonsAndDragonsTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class DungeonsAndDragonsTest extends BaseFakerTest<BaseFaker> {
+class DungeonsAndDragonsTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/ElectricalComponentsTest.java
+++ b/src/test/java/net/datafaker/providers/base/ElectricalComponentsTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class ElectricalComponentsTest extends BaseFakerTest<BaseFaker> {
+class ElectricalComponentsTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/EmojiTest.java
+++ b/src/test/java/net/datafaker/providers/base/EmojiTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class EmojiTest extends BaseFakerTest<BaseFaker> {
+class EmojiTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Collection;
 import java.util.Set;
 
-class FinanceTest extends BaseFakerTest<BaseFaker> {
+class FinanceTest extends BaseFakerTest {
 
     private final Finance finance = faker.finance();
 

--- a/src/test/java/net/datafaker/providers/base/FunnyNameTest.java
+++ b/src/test/java/net/datafaker/providers/base/FunnyNameTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class FunnyNameTest extends BaseFakerTest<BaseFaker> {
+class FunnyNameTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/GarmentSizeTest.java
+++ b/src/test/java/net/datafaker/providers/base/GarmentSizeTest.java
@@ -4,7 +4,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-public class GarmentSizeTest extends BaseFakerTest<BaseFaker> {
+public class GarmentSizeTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/GenderTest.java
+++ b/src/test/java/net/datafaker/providers/base/GenderTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class GenderTest extends BaseFakerTest<BaseFaker> {
+class GenderTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/GreekPhilosopherTest.java
+++ b/src/test/java/net/datafaker/providers/base/GreekPhilosopherTest.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class GreekPhilosopherTest extends BaseFakerTest<BaseFaker> {
+final class GreekPhilosopherTest extends BaseFakerTest {
 
     @RepeatedTest(10)
     void testName() {
@@ -35,11 +35,12 @@ class GreekPhilosopherTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Nested
-    class GreekPhilosopherInGreekTest extends BaseFakerTest<BaseFaker> {
+    final class GreekPhilosopherInGreekTest extends ProviderListTest<BaseFaker> {
+        private final BaseFaker faker = new BaseFaker(new Locale("el", "GR"));
 
         @Override
-        protected final BaseFaker getFaker() {
-            return new BaseFaker(new Locale("el", "GR"));
+        protected BaseFaker getFaker() {
+            return faker;
         }
 
         @Override

--- a/src/test/java/net/datafaker/providers/base/HackerTest.java
+++ b/src/test/java/net/datafaker/providers/base/HackerTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class HackerTest extends BaseFakerTest<BaseFaker> {
+class HackerTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/HipsterTest.java
+++ b/src/test/java/net/datafaker/providers/base/HipsterTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class HipsterTest extends BaseFakerTest<BaseFaker> {
+class HipsterTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/HobbyTest.java
+++ b/src/test/java/net/datafaker/providers/base/HobbyTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class HobbyTest extends BaseFakerTest<BaseFaker> {
+class HobbyTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/HololiveTest.java
+++ b/src/test/java/net/datafaker/providers/base/HololiveTest.java
@@ -8,7 +8,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class HololiveTest extends BaseFakerTest<BaseFaker> {
+class HololiveTest extends BaseFakerTest {
 
     private static final BaseFaker JA_FAKER = new BaseFaker(new Locale("ja"));
 

--- a/src/test/java/net/datafaker/providers/base/HorseTest.java
+++ b/src/test/java/net/datafaker/providers/base/HorseTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class HorseTest extends BaseFakerTest<BaseFaker> {
+class HorseTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/HouseTest.java
+++ b/src/test/java/net/datafaker/providers/base/HouseTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class HouseTest extends BaseFakerTest<BaseFaker> {
+class HouseTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/IndustrySegmentsTest.java
+++ b/src/test/java/net/datafaker/providers/base/IndustrySegmentsTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-public class IndustrySegmentsTest extends BaseFakerTest<BaseFaker> {
+public class IndustrySegmentsTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/JobTest.java
+++ b/src/test/java/net/datafaker/providers/base/JobTest.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-class JobTest extends BaseFakerTest<BaseFaker> {
+class JobTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {
@@ -18,11 +18,13 @@ class JobTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Nested
-    class JobInGreekTest extends BaseFakerTest<BaseFaker> {
+    final class JobInGreekTest extends ProviderListTest<BaseFaker> {
+
+        private final BaseFaker faker = new BaseFaker(new Locale("el", "GR"));
 
         @Override
-        protected final BaseFaker getFaker() {
-            return new BaseFaker(new Locale("el", "GR"));
+        protected BaseFaker getFaker() {
+            return faker;
         }
 
         @Override

--- a/src/test/java/net/datafaker/providers/base/KpopTest.java
+++ b/src/test/java/net/datafaker/providers/base/KpopTest.java
@@ -4,7 +4,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class KpopTest extends BaseFakerTest<BaseFaker> {
+class KpopTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/LargeLanguageModelTest.java
+++ b/src/test/java/net/datafaker/providers/base/LargeLanguageModelTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.Collection;
 import java.util.List;
 
-class LargeLanguageModelTest extends BaseFakerTest<BaseFaker> {
+class LargeLanguageModelTest extends BaseFakerTest {
 
     private final LargeLanguageModel llm = faker.largeLanguageModel();
 

--- a/src/test/java/net/datafaker/providers/base/LocationTest.java
+++ b/src/test/java/net/datafaker/providers/base/LocationTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.Collection;
 import java.util.List;
 
-class LocationTest extends BaseFakerTest<BaseFaker> {
+class LocationTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/LoremTest.java
+++ b/src/test/java/net/datafaker/providers/base/LoremTest.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class LoremTest extends BaseFakerTest<BaseFaker> {
+class LoremTest extends BaseFakerTest {
 
     private final Lorem lorem = faker.lorem();
 

--- a/src/test/java/net/datafaker/providers/base/MarketingTest.java
+++ b/src/test/java/net/datafaker/providers/base/MarketingTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class MarketingTest extends BaseFakerTest<BaseFaker> {
+class MarketingTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MatzTest.java
+++ b/src/test/java/net/datafaker/providers/base/MatzTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class MatzTest extends BaseFakerTest<BaseFaker> {
+class MatzTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MeasurementTest.java
+++ b/src/test/java/net/datafaker/providers/base/MeasurementTest.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-class MeasurementTest extends BaseFakerTest<BaseFaker> {
+class MeasurementTest extends BaseFakerTest {
 
     private static Collection<TestSpec> getProviderListTests(Measurement measurement) {
         return List.of(
@@ -28,11 +28,12 @@ class MeasurementTest extends BaseFakerTest<BaseFaker> {
     }
 
     @Nested
-    class MeasurementInGreekTest extends BaseFakerTest<BaseFaker> {
+    final class MeasurementInGreekTest extends ProviderListTest<BaseFaker> {
+        private final BaseFaker faker = new BaseFaker(new Locale("el", "GR"));
 
         @Override
-        protected final BaseFaker getFaker() {
-            return new BaseFaker(new Locale("el", "GR"));
+        protected BaseFaker getFaker() {
+            return faker;
         }
 
         @Override

--- a/src/test/java/net/datafaker/providers/base/MedicalTest.java
+++ b/src/test/java/net/datafaker/providers/base/MedicalTest.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class MedicalTest extends BaseFakerTest<BaseFaker> {
+class MedicalTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MilitaryTest.java
+++ b/src/test/java/net/datafaker/providers/base/MilitaryTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class MilitaryTest extends BaseFakerTest<BaseFaker> {
+class MilitaryTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MoodTest.java
+++ b/src/test/java/net/datafaker/providers/base/MoodTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class MoodTest extends BaseFakerTest<BaseFaker> {
+class MoodTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MountainTest.java
+++ b/src/test/java/net/datafaker/providers/base/MountainTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class MountainTest extends BaseFakerTest<BaseFaker> {
+class MountainTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MountaineeringTest.java
+++ b/src/test/java/net/datafaker/providers/base/MountaineeringTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class MountaineeringTest extends BaseFakerTest<BaseFaker> {
+class MountaineeringTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/MusicTest.java
+++ b/src/test/java/net/datafaker/providers/base/MusicTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class MusicTest extends BaseFakerTest<BaseFaker> {
+class MusicTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/NationTest.java
+++ b/src/test/java/net/datafaker/providers/base/NationTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class NationTest extends BaseFakerTest<BaseFaker> {
+class NationTest extends BaseFakerTest {
 
     private final Nation nation = faker.nation();
 

--- a/src/test/java/net/datafaker/providers/base/NatoPhoneticAlphabetTest.java
+++ b/src/test/java/net/datafaker/providers/base/NatoPhoneticAlphabetTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class NatoPhoneticAlphabetTest extends BaseFakerTest<BaseFaker> {
+class NatoPhoneticAlphabetTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/NigeriaTest.java
+++ b/src/test/java/net/datafaker/providers/base/NigeriaTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class NigeriaTest extends BaseFakerTest<BaseFaker> {
+class NigeriaTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/OlympicSportTest.java
+++ b/src/test/java/net/datafaker/providers/base/OlympicSportTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class OlympicSportTest extends BaseFakerTest<BaseFaker> {
+class OlympicSportTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/PhotographyTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhotographyTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class PhotographyTest extends BaseFakerTest<BaseFaker> {
+class PhotographyTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/PlanetTest.java
+++ b/src/test/java/net/datafaker/providers/base/PlanetTest.java
@@ -10,13 +10,13 @@ import static net.datafaker.providers.base.Planet.PlanetName.JUPITER;
 import static net.datafaker.providers.base.Planet.PlanetName.MARS;
 import static net.datafaker.providers.base.Planet.PlanetName.MERCURY;
 import static net.datafaker.providers.base.Planet.PlanetName.NEPTUNE;
+import static net.datafaker.providers.base.Planet.PlanetName.PLUTO;
 import static net.datafaker.providers.base.Planet.PlanetName.SATURN;
 import static net.datafaker.providers.base.Planet.PlanetName.URANUS;
 import static net.datafaker.providers.base.Planet.PlanetName.VENUS;
-import static net.datafaker.providers.base.Planet.PlanetName.PLUTO;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class PlanetTest extends BaseFakerTest<BaseFaker> {
+class PlanetTest extends BaseFakerTest {
 
     private final Planet planet = faker.planet();
 
@@ -31,7 +31,7 @@ class PlanetTest extends BaseFakerTest<BaseFaker> {
         // PlanetName enum has 9 entries
         assertThat(Planet.PlanetName.values()).hasSize(9);
         // planet.yml has 9 names
-        assertThat(getBaseList("planet.name")).hasSize(9);
+        assertThat(getBaseList(faker, "planet.name")).hasSize(9);
     }
 
     @Test

--- a/src/test/java/net/datafaker/providers/base/ProgrammingLanguageTest.java
+++ b/src/test/java/net/datafaker/providers/base/ProgrammingLanguageTest.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
-class ProgrammingLanguageTest extends BaseFakerTest<BaseFaker> {
+class ProgrammingLanguageTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/PronounsTest.java
+++ b/src/test/java/net/datafaker/providers/base/PronounsTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.Collection;
 import java.util.List;
 
-class PronounsTest extends BaseFakerTest<BaseFaker> {
+class PronounsTest extends BaseFakerTest {
 
     private final Pronouns pronouns = faker.pronouns();
 

--- a/src/test/java/net/datafaker/providers/base/ProviderListTest.java
+++ b/src/test/java/net/datafaker/providers/base/ProviderListTest.java
@@ -1,0 +1,89 @@
+package net.datafaker.providers.base;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class ProviderListTest<T extends BaseFaker> {
+    protected abstract T getFaker();
+
+    protected List<String> getBaseList(T faker, String key) {
+        return faker.fakeValuesService().fetchObject(key, faker.getContext());
+    }
+
+    @ParameterizedTest
+    @MethodSource("providerListTest")
+    protected void testProviderList(TestSpec testSpec) {
+        T faker = getFaker();
+        // Given
+        Set<String> actual = new HashSet<>(getBaseList(faker, testSpec.key));
+        // When
+        String item = (String) testSpec.supplier.get();
+        // Then
+        assertThat(item).as("Check item isn't empty").isNotEmpty();
+        String collection = "\"" + testSpec.key + "\"";
+        assertThat(actual).as("Check actual list isn't empty and contains the item for the key " + collection).isNotEmpty()
+            .anyMatch(item::equals);
+        assertThat(actual).as("Actual should not have empty entries. " + collection).noneMatch(single -> single.isBlank());
+        if (!testSpec.regex.isEmpty()) {
+            assertThat(item).as("Check item matches regex").matches(Pattern.compile(testSpec.regex));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("providerListTest")
+    void testNoDuplications(TestSpec testSpec) {
+        T faker = getFaker();
+        var terms = getBaseList(faker, testSpec.key);
+
+        Set<String> uniques = new HashSet<>();
+        Set<String> duplicates = new HashSet<>();
+        for (String term : terms) {
+            if (!uniques.add(term)) {
+                duplicates.add(term);
+            }
+        }
+        assertThat(duplicates)
+            .as("Check no duplications in " + testSpec.key + " with terms " + terms)
+            .isEmpty();
+    }
+
+    protected abstract Collection<TestSpec> providerListTest();
+
+    protected static class TestSpec {
+        private final Supplier<?> supplier;
+        private final String key;
+        @SuppressWarnings("unused")
+        private final String regex;
+
+        private TestSpec(Supplier<?> supplier, String key, String regex) {
+            this.supplier = supplier;
+            this.key = key;
+            this.regex = regex;
+        }
+
+        public static TestSpec of(Supplier<?> supplier, String key) {
+            return new TestSpec(supplier, key, "");
+        }
+
+        public static TestSpec of(Supplier<?> supplier, String key, String regex) {
+            return new TestSpec(supplier, key, regex);
+        }
+
+        @Override
+        public String toString() {
+            // The result of this toString will be used by IDE in test report
+            return "Key: " + key;
+        }
+    }
+}

--- a/src/test/java/net/datafaker/providers/base/ProviderListTest.java
+++ b/src/test/java/net/datafaker/providers/base/ProviderListTest.java
@@ -32,9 +32,13 @@ public abstract class ProviderListTest<T extends BaseFaker> {
         // Then
         assertThat(item).as("Check item isn't empty").isNotEmpty();
         String collection = "\"" + testSpec.key + "\"";
-        assertThat(actual).as("Check actual list isn't empty and contains the item for the key " + collection).isNotEmpty()
-            .anyMatch(item::equals);
-        assertThat(actual).as("Actual should not have empty entries. " + collection).noneMatch(single -> single.isBlank());
+        assertThat(actual)
+            .as(() -> "Check actual list isn't empty and contains the item for the key " + collection)
+            .isNotEmpty()
+            .contains(item);
+        assertThat(actual)
+            .as(() -> "Actual should not have empty entries. " + collection)
+            .noneMatch(single -> single.isBlank());
         if (!testSpec.regex.isEmpty()) {
             assertThat(item).as("Check item matches regex").matches(Pattern.compile(testSpec.regex));
         }
@@ -54,7 +58,7 @@ public abstract class ProviderListTest<T extends BaseFaker> {
             }
         }
         assertThat(duplicates)
-            .as("Check no duplications in " + testSpec.key + " with terms " + terms)
+            .as(() -> "Check no duplications in " + testSpec.key + " with terms " + terms)
             .isEmpty();
     }
 

--- a/src/test/java/net/datafaker/providers/base/RelationshipTest.java
+++ b/src/test/java/net/datafaker/providers/base/RelationshipTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-class RelationshipTest extends BaseFakerTest<BaseFaker> {
+class RelationshipTest extends BaseFakerTest {
 
     private final BaseFaker mockFaker = spy(new BaseFaker());
     private final FakeValuesService fakeValuesService = mock();

--- a/src/test/java/net/datafaker/providers/base/RestaurantTest.java
+++ b/src/test/java/net/datafaker/providers/base/RestaurantTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class RestaurantTest extends BaseFakerTest<BaseFaker> {
+class RestaurantTest extends BaseFakerTest {
 
     private final Restaurant restaurant = faker.restaurant();
 

--- a/src/test/java/net/datafaker/providers/base/RobinTest.java
+++ b/src/test/java/net/datafaker/providers/base/RobinTest.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
-class RobinTest extends BaseFakerTest<BaseFaker> {
+class RobinTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/RockBandTest.java
+++ b/src/test/java/net/datafaker/providers/base/RockBandTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class RockBandTest extends BaseFakerTest<BaseFaker> {
+class RockBandTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/ScienceTest.java
+++ b/src/test/java/net/datafaker/providers/base/ScienceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class ScienceTest extends BaseFakerTest<BaseFaker> {
+class ScienceTest extends BaseFakerTest {
 
     private final Science science = faker.science();
 

--- a/src/test/java/net/datafaker/providers/base/SizeTest.java
+++ b/src/test/java/net/datafaker/providers/base/SizeTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class SizeTest extends BaseFakerTest<BaseFaker> {
+class SizeTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/SpaceTest.java
+++ b/src/test/java/net/datafaker/providers/base/SpaceTest.java
@@ -2,15 +2,15 @@ package net.datafaker.providers.base;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Collection;
-
-class SpaceTest extends BaseFakerTest<BaseFaker> {
+class SpaceTest extends BaseFakerTest {
 
     private static final String SPACE_REGEX = "(?:\\w+ ?){2,3}";
-    
+
     @Override
     protected Collection<TestSpec> providerListTest() {
         Space space = faker.space();

--- a/src/test/java/net/datafaker/providers/base/StockTest.java
+++ b/src/test/java/net/datafaker/providers/base/StockTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class StockTest extends BaseFakerTest<BaseFaker> {
+class StockTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/SubscriptionTest.java
+++ b/src/test/java/net/datafaker/providers/base/SubscriptionTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class SubscriptionTest extends BaseFakerTest<BaseFaker> {
+class SubscriptionTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/SuperheroTest.java
+++ b/src/test/java/net/datafaker/providers/base/SuperheroTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class SuperheroTest extends BaseFakerTest<BaseFaker> {
+class SuperheroTest extends BaseFakerTest {
 
     @Test
     void testName() {

--- a/src/test/java/net/datafaker/providers/base/TeamTest.java
+++ b/src/test/java/net/datafaker/providers/base/TeamTest.java
@@ -8,7 +8,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TeamTest extends BaseFakerTest<BaseFaker> {
+class TeamTest extends BaseFakerTest {
 
     private final Team team = faker.team();
 

--- a/src/test/java/net/datafaker/providers/base/TireTest.java
+++ b/src/test/java/net/datafaker/providers/base/TireTest.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TireTest extends BaseFakerTest<BaseFaker> {
+class TireTest extends BaseFakerTest {
 
     private final static String CODE_PATTERN = "\\d{3}/\\d{2,3}R\\d{2}\\.?\\d?";
     private final Tire tire = faker.tire();

--- a/src/test/java/net/datafaker/providers/base/TransportTest.java
+++ b/src/test/java/net/datafaker/providers/base/TransportTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.Collection;
 import java.util.List;
 
-public class TransportTest extends BaseFakerTest<BaseFaker> {
+public class TransportTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/UniversityTest.java
+++ b/src/test/java/net/datafaker/providers/base/UniversityTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class UniversityTest extends BaseFakerTest<BaseFaker> {
+class UniversityTest extends BaseFakerTest {
 
     private static final String UNIVERSITY_MATCHER = "[A-Za-z'() öèü\\-.]+";
     private final University university = faker.university();

--- a/src/test/java/net/datafaker/providers/base/WeatherTest.java
+++ b/src/test/java/net/datafaker/providers/base/WeatherTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Collection;
 
-class WeatherTest extends BaseFakerTest<BaseFaker> {
+class WeatherTest extends BaseFakerTest {
 
     private final Weather weather = faker.weather();
 

--- a/src/test/java/net/datafaker/providers/base/WordTest.java
+++ b/src/test/java/net/datafaker/providers/base/WordTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.Collection;
 import java.util.List;
 
-class WordTest extends BaseFakerTest<BaseFaker> {
+class WordTest extends BaseFakerTest {
 
     private final Word word = faker.word();
 

--- a/src/test/java/net/datafaker/providers/base/YodaTest.java
+++ b/src/test/java/net/datafaker/providers/base/YodaTest.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 /**
  * @author Luka Obradovic (luka@vast.com)
  */
-class YodaTest extends BaseFakerTest<BaseFaker> {
+class YodaTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/base/ZodiacTest.java
+++ b/src/test/java/net/datafaker/providers/base/ZodiacTest.java
@@ -3,7 +3,7 @@ package net.datafaker.providers.base;
 import java.util.List;
 import java.util.Collection;
 
-class ZodiacTest extends BaseFakerTest<BaseFaker> {
+class ZodiacTest extends BaseFakerTest {
 
     @Override
     protected Collection<TestSpec> providerListTest() {

--- a/src/test/java/net/datafaker/providers/entertainment/EntertainmentFakerTest.java
+++ b/src/test/java/net/datafaker/providers/entertainment/EntertainmentFakerTest.java
@@ -1,10 +1,13 @@
 package net.datafaker.providers.entertainment;
 
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 
-public abstract class EntertainmentFakerTest extends BaseFakerTest<EntertainmentFaker> {
+public abstract class EntertainmentFakerTest extends ProviderListTest<EntertainmentFaker> {
+
+    protected final EntertainmentFaker faker = new EntertainmentFaker();
+
     @Override
     protected final EntertainmentFaker getFaker() {
-        return new EntertainmentFaker();
+        return faker;
     }
 }

--- a/src/test/java/net/datafaker/providers/foods/FoodFakerTest.java
+++ b/src/test/java/net/datafaker/providers/foods/FoodFakerTest.java
@@ -1,11 +1,14 @@
 package net.datafaker.providers.foods;
 
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 import net.datafaker.providers.food.FoodFaker;
 
-public abstract class FoodFakerTest extends BaseFakerTest<FoodFaker> {
+public abstract class FoodFakerTest extends ProviderListTest<FoodFaker> {
+
+    protected final FoodFaker faker = new FoodFaker();
+
     @Override
     protected final FoodFaker getFaker() {
-        return new FoodFaker();
+        return faker;
     }
 }

--- a/src/test/java/net/datafaker/providers/foods/TeaTest.java
+++ b/src/test/java/net/datafaker/providers/foods/TeaTest.java
@@ -3,18 +3,18 @@ package net.datafaker.providers.foods;
 import net.datafaker.providers.food.Tea;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TeaTest extends FoodFakerTest {
 
-    private final Tea tea = getFaker().tea();
+    private final Tea tea = faker.tea();
 
     @Test
     void testVariety() {
-        assertThat(faker.tea().variety()).matches("^(?:[A-Z]['.\\-a-z]+[\\s-])*[A-Z]['.\\-a-z]+$");
+        assertThat(tea.variety()).matches("^(?:[A-Z]['.\\-a-z]+[\\s-])*[A-Z]['.\\-a-z]+$");
     }
 
     @Override

--- a/src/test/java/net/datafaker/providers/healthcare/DiseaseTest.java
+++ b/src/test/java/net/datafaker/providers/healthcare/DiseaseTest.java
@@ -22,7 +22,7 @@ class DiseaseTest extends HealthcareFakerTest {
     private final Disease disease = faker.disease();
 
     private final Set<String> allDiseases = Arrays.stream(Disease.DiseaseType.values())
-        .map((Disease.DiseaseType diseaseType) -> getBaseList(diseaseType.yamlKey))
+        .map((Disease.DiseaseType diseaseType) -> getBaseList(faker, diseaseType.yamlKey))
         .flatMap(Collection::stream)
         .collect(Collectors.toSet());
 

--- a/src/test/java/net/datafaker/providers/healthcare/HealthcareFakerTest.java
+++ b/src/test/java/net/datafaker/providers/healthcare/HealthcareFakerTest.java
@@ -1,10 +1,13 @@
 package net.datafaker.providers.healthcare;
 
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 
-abstract class HealthcareFakerTest extends BaseFakerTest<HealthcareFaker> {
+abstract class HealthcareFakerTest extends ProviderListTest<HealthcareFaker> {
+
+    protected final HealthcareFaker faker = new HealthcareFaker();
+
     @Override
     protected final HealthcareFaker getFaker() {
-        return new HealthcareFaker();
+        return faker;
     }
 }

--- a/src/test/java/net/datafaker/providers/sport/FootballTest.java
+++ b/src/test/java/net/datafaker/providers/sport/FootballTest.java
@@ -1,15 +1,15 @@
 package net.datafaker.providers.sport;
 
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 import org.junit.jupiter.api.Nested;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-class FootballTest extends SportFakerTest {
+final class FootballTest extends SportFakerTest {
 
-    private final Football football = getFaker().football();
+    private final Football football = faker.football();
 
     private static Collection<TestSpec> getProviderListTests(Football football) {
         return List.of(
@@ -27,11 +27,13 @@ class FootballTest extends SportFakerTest {
     }
 
     @Nested
-    class FootballInGreekTest extends BaseFakerTest<SportFaker> {
+    final class FootballInGreekTest extends ProviderListTest<SportFaker> {
+
+        private final SportFaker faker = new SportFaker(new Locale("el", "GR"));
 
         @Override
-        protected final SportFaker getFaker() {
-            return new SportFaker(new Locale("el", "GR"));
+        protected SportFaker getFaker() {
+            return faker;
         }
 
         @Override

--- a/src/test/java/net/datafaker/providers/sport/SportFakerTest.java
+++ b/src/test/java/net/datafaker/providers/sport/SportFakerTest.java
@@ -1,10 +1,13 @@
 package net.datafaker.providers.sport;
 
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 
-abstract class SportFakerTest extends BaseFakerTest<SportFaker> {
+abstract class SportFakerTest extends ProviderListTest<SportFaker> {
+
+    protected final SportFaker faker = new SportFaker();
+
     @Override
     protected final SportFaker getFaker() {
-        return new SportFaker();
+        return faker;
     }
 }

--- a/src/test/java/net/datafaker/providers/videogame/VideoGameFakerTest.java
+++ b/src/test/java/net/datafaker/providers/videogame/VideoGameFakerTest.java
@@ -1,10 +1,13 @@
 package net.datafaker.providers.videogame;
 
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 
-public abstract class VideoGameFakerTest extends BaseFakerTest<VideoGameFaker> {
+public abstract class VideoGameFakerTest extends ProviderListTest<VideoGameFaker> {
+
+    protected final VideoGameFaker faker = new VideoGameFaker();
+
     @Override
     protected final VideoGameFaker getFaker() {
-        return new VideoGameFaker();
+        return faker;
     }
 }

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -1,7 +1,7 @@
 package net.datafaker.script;
 
 import net.datafaker.providers.base.AbstractProvider;
-import net.datafaker.providers.base.BaseFakerTest;
+import net.datafaker.providers.base.ProviderListTest;
 import net.datafaker.providers.base.ProviderRegistration;
 import net.datafaker.providers.entertainment.EntertainmentFakerTest;
 import net.datafaker.providers.entertainment.EntertainmentProviders;
@@ -157,9 +157,9 @@ enum ProviderType {
     ;
 
     private final Class<? extends ProviderRegistration> providerRegistryName;
-    private final Class<? extends BaseFakerTest<? extends ProviderRegistration>> testSuperclassName;
+    private final Class<? extends ProviderListTest<? extends ProviderRegistration>> testSuperclassName;
 
-    ProviderType(Class<? extends ProviderRegistration> providerRegistryName, Class<? extends BaseFakerTest<? extends ProviderRegistration>> testSuperclassName) {
+    ProviderType(Class<? extends ProviderRegistration> providerRegistryName, Class<? extends ProviderListTest<? extends ProviderRegistration>> testSuperclassName) {
         this.providerRegistryName = providerRegistryName;
         this.testSuperclassName = testSuperclassName;
     }


### PR DESCRIPTION
Fix IDEA warning "call to overridable method during object construction" in `BaseFakerTest`.

Now method `getFaker()` is final.

1. Most classes just extend `BaseFakerTest` and use protected final `faker` field.
2. Classes that actually need a custom faker extend `ProviderListTest<T>` and implement method `getFaker()`.

P.S. I think it's still not a perfect solution. Most of these tests actually need to provide list of Fakers (at least with different locales).