### PR TITLE
#1623 fix flaky test WeightedRandomSelectorTest

### DIFF
--- a/src/test/java/net/datafaker/service/EvenlyDistributedRandomGenerator.java
+++ b/src/test/java/net/datafaker/service/EvenlyDistributedRandomGenerator.java
@@ -1,0 +1,48 @@
+package net.datafaker.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static java.util.Collections.shuffle;
+
+/**
+ * Implementation of {@link java.util.random.RandomGenerator}
+ * that guarantees an evenly distributed set of values in a random order.
+ *
+ * Good for using in tests instead of just {@link java.util.Random}
+ */
+public class EvenlyDistributedRandomGenerator extends Random {
+    private final List<Double> values;
+    private int index;
+
+    /**
+     * Create a Random instance that splits [lower, upper) to N equal intervals,
+     * picks a single value from each interval, and returns them in random order.
+     */
+    public EvenlyDistributedRandomGenerator(int lowerInclusive, int upperExclusive, int count) {
+        this.values = fillEvenly(lowerInclusive, upperExclusive, count);
+        shuffle(values);
+    }
+
+    private static List<Double> fillEvenly(int lowerInclusive, int upperExclusive, int count) {
+        List<Double> values = new ArrayList<>(count);
+
+        Random random = new Random();
+        double step = 1.0d * (upperExclusive - lowerInclusive) / count;
+        for (int i = 0; i < count; i++) {
+            values.add(lowerInclusive + i * step + random.nextDouble(step));
+        }
+        return values;
+    }
+
+    @Override
+    public double nextDouble() {
+        return values.get(index++);
+    }
+
+    @Override
+    public int nextInt(int bound) {
+        return (int) values.get(index++).doubleValue();
+    }
+}

--- a/src/test/java/net/datafaker/service/WeightedRandomSelectorTest.java
+++ b/src/test/java/net/datafaker/service/WeightedRandomSelectorTest.java
@@ -115,13 +115,13 @@ class WeightedRandomSelectorTest {
     @ParameterizedTest
     @MethodSource("multipleElementsProvider")
     void testWeightedArrayElementWithMultipleElements(List<Map<String, Object>> items, Map<String, Integer> expectedCounts) {
-        WeightedRandomSelector selector = new WeightedRandomSelector(new Random());
+        WeightedRandomSelector selector = new WeightedRandomSelector(new EvenlyDistributedRandomGenerator(0, 1, ITERATIONS));
 
         Map<String, Integer> counts = countResults(selector, items);
 
         assertThat(counts.keySet()).containsExactlyInAnyOrderElementsOf(expectedCounts.keySet());
         for (String element : expectedCounts.keySet()) {
-            assertThat(counts.get(element)).isCloseTo(expectedCounts.get(element), withinPercentage(20));
+            assertThat(counts.get(element)).isCloseTo(expectedCounts.get(element), withinPercentage(1));
         }
     }
 


### PR DESCRIPTION
instead of using `Random` which can sometimes generate too "un-random" values, we now user custom `EvenlyDistributedRandomGenerator` which returns values in random order, but guarantees that all possible values are covered.