### PR TITLE
Creates new Credential provider; Deprecated Internet provider methods

### DIFF
--- a/src/main/java/net/datafaker/providers/base/BaseProviders.java
+++ b/src/main/java/net/datafaker/providers/base/BaseProviders.java
@@ -137,6 +137,10 @@ public interface BaseProviders extends ProviderRegistration {
         return getProvider(CPF.class, CPF::new);
     }
 
+    default Credential credential() {
+        return getProvider(Credential.class, Credential::new);
+    }
+
     default CryptoCoin cryptoCoin() {
         return getProvider(CryptoCoin.class, CryptoCoin::new);
     }

--- a/src/main/java/net/datafaker/providers/base/Credential.java
+++ b/src/main/java/net/datafaker/providers/base/Credential.java
@@ -1,0 +1,169 @@
+package net.datafaker.providers.base;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Generates credentials such as usernames, uids and passwords.
+ * 
+ * @since 2.4.5
+ */
+public class Credential extends AbstractProvider<BaseProviders> {
+
+    public static final int MIN_PASSWORD_LENGTH = 8;
+    public static final int MAX_PASSWORD_LENGTH = 16;
+
+    protected Credential(BaseProviders faker) {
+        super(faker);
+    }
+    
+    /**
+     * A lowercase username composed of the first_name and last_name joined with a '.'. Some examples are:
+     * <ul>
+     *     <li>(template) {@link Name#firstName()}.{@link Name#lastName()}</li>
+     *     <li>jim.jones</li>
+     *     <li>jason.leigh</li>
+     *     <li>tracy.jordan</li>
+     * </ul>
+     *
+     * @return a random two part username.
+     * @see Name#firstName()
+     * @see Name#lastName()
+     */
+    public String username() {
+        StringBuilder result = new StringBuilder();
+        final Name name = faker.name();
+        final String firstName = name.firstName().toLowerCase(faker.getContext().getLocale())
+            + "." + name.lastName().toLowerCase(faker.getContext().getLocale());
+        for (int i = 0; i < firstName.length(); i++) {
+            final char c = firstName.charAt(i);
+            if (c == '\'' || Character.isWhitespace(c)) {
+                continue;
+            }
+            result.append(c);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Generates a password, only with lowercase letters, numbers and
+     * with length between 8 and 16 characters.
+     *
+     * @return A randomly generated password
+     */
+    public String password() {
+        return password(MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH);
+    }
+
+    /**
+     * Generates a password, only with lowercase letters and optionally numbers
+     * with length between 8 and 16 characters.
+     *
+     * @param includeDigit if true, the password will contain at least one digit
+     * @return A randomly generated password
+     */
+    public String password(boolean includeDigit) {
+        return password(MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH, false, false, includeDigit);
+    }
+
+    /**
+     * Generates a password, only with lowercase letters, numbers and 
+     * with min and max length defined by the user.
+     *
+     * @param minimumLength the minimum length of the password
+     * @param maximumLength the maximum length of the password
+     * @return A randomly generated password
+     */
+    public String password(int minimumLength, int maximumLength) {
+        return password(minimumLength, maximumLength, false);
+    }
+
+    /**
+     * Generates a password with lowercase and optionally uppercase letters, numbers
+     * and with min and max length defined by the user.
+     *
+     * @param minimumLength    the minimum length of the password
+     * @param maximumLength    the maximum length of the password
+     * @param includeUppercase if true, the password will contain at least one uppercase letter
+     * @return A randomly generated password
+     */
+    public String password(int minimumLength, int maximumLength, boolean includeUppercase) {
+        return password(minimumLength, maximumLength, includeUppercase, false);
+    }
+
+    /**
+     * Generates a password with lowercase letters, numbers and optionally uppercase letters and 
+     * special characters and with min and max length defined by the user.
+     *
+     * @param minimumLength    the minimum length of the password
+     * @param maximumLength    the maximum length of the password
+     * @param includeUppercase if true, the password will contain at least one uppercase letter
+     * @param includeSpecial   if true, the password will contain at least one special character
+     * @return A randomly generated password
+     */
+    public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial) {
+        return password(minimumLength, maximumLength, includeUppercase, includeSpecial, true);
+    }
+
+    /**
+     * Generates a password with lowercase letters and optionally uppercase letters, numbers and 
+     * special characters and with min and max length defined by the user.
+     *
+     * @param minimumLength    the minimum length of the password
+     * @param maximumLength    the maximum length of the password
+     * @param includeUppercase if true, the password will contain at least one uppercase letter
+     * @param includeSpecial   if true, the password will contain at least one special character
+     * @param includeDigit     if true, the password will contain at least one digit
+     * @return A randomly generated password
+     */
+    public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
+        return faker.text().text(minimumLength, maximumLength, includeUppercase, includeSpecial, includeDigit);
+    }
+
+    /**
+     * Returns a weak password from a pre-defined list of common weak passwords.
+     * 
+     * Some examples are:
+     * <ul>
+     *     <li>123456</li>
+     *     <li>password</li>
+     *     <li>qwerty</li>
+     * </ul>
+     * 
+     * @return a random weak password.
+     */
+    public String weakPassword() {
+        return resolve("credential.weak_password");
+    }
+
+    /**
+     * Generates a user ID based on the regex pattern defined in the resource file.
+     * If the regex is null or invalid, it returns null.
+     *
+     * @return A randomly generated user ID based on the regex or null if the regex is null or invalid
+     */
+    public String userId() {
+        return userId(resolve("credential.uid_pattern"));
+    }
+
+    /**
+     * Generates a user ID based on the provided regex pattern.
+     * If the regex is null or invalid, it returns null.
+     *
+     * @param regex The regex pattern to generate the user ID
+     * @return A randomly generated user ID based on the regex or null if the regex is null or invalid
+     */
+    public String userId(String regex) {
+        if(regex == null) {
+            return null;
+        }
+
+        try {
+            Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            return null;
+        }
+
+        return faker.regexify(regex);
+    }
+}

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -40,6 +40,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
      * @see Name#firstName()
      * @see Name#lastName()
      */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String username() {
         StringBuilder result = new StringBuilder();
         final Name name = faker.name();
@@ -259,26 +260,50 @@ public class Internet extends AbstractProvider<BaseProviders> {
         return resolve("internet.http_method");
     }
 
+    /**
+     * @deprecated since 2.4.5. Use {@link net.datafaker.providers.base.Credential#password()} instead.
+     */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String password() {
         return password(8, 16);
     }
 
+    /**
+     * @deprecated since 2.4.5. Use {@link net.datafaker.providers.base.Credential#password(boolean)} instead.
+     */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String password(boolean includeDigit) {
         return password(8, 16, false, false, includeDigit);
     }
 
+    /**
+     * @deprecated since 2.4.5. Use {@link net.datafaker.providers.base.Credential#password(int, int)} instead.
+     */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String password(int minimumLength, int maximumLength) {
         return password(minimumLength, maximumLength, false);
     }
 
+    /**
+     * @deprecated since 2.4.5. Use {@link net.datafaker.providers.base.Credential#password(int, int, boolean)} instead.
+     */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String password(int minimumLength, int maximumLength, boolean includeUppercase) {
         return password(minimumLength, maximumLength, includeUppercase, false);
     }
 
+    /**
+     * @deprecated since 2.4.5. Use {@link net.datafaker.providers.base.Credential#password(int, int, boolean, boolean)} instead.
+     */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial) {
         return password(minimumLength, maximumLength, includeUppercase, includeSpecial, true);
     }
 
+    /**
+     * @deprecated since 2.4.5. Use {@link net.datafaker.providers.base.Credential#password(int, int, boolean, boolean, boolean)} instead.
+     */
+    @Deprecated(since = "2.4.5", forRemoval = true)
     public String password(int minimumLength, int maximumLength, boolean includeUppercase, boolean includeSpecial, boolean includeDigit) {
         return faker.text().text(minimumLength, maximumLength, includeUppercase, includeSpecial, includeDigit);
     }

--- a/src/main/java/net/datafaker/service/files/EnFile.java
+++ b/src/main/java/net/datafaker/service/files/EnFile.java
@@ -77,6 +77,7 @@ public class EnFile {
         "cosmere.yml",
         "country.yml",
         "cowboy_bebop.yml",
+        "credential.yml",
         "cricket.yml",
         "crypto_coin.yml",
         "culture_series.yml",

--- a/src/main/resources/en/credential.yml
+++ b/src/main/resources/en/credential.yml
@@ -1,0 +1,32 @@
+en:
+  faker:
+    credential:
+      weak_password:
+      - "123456"
+      - "password"
+      - "123456789"
+      - "12345678"
+      - "12345"
+      - "111111"
+      - "1234567"
+      - "sunshine"
+      - "qwerty"
+      - "iloveyou"
+      - "princess"
+      - "admin"
+      - "welcome"
+      - "666666"
+      - "abc123"
+      - "football"
+      - "123123"
+      - "monkey"
+      - "654321"
+      - "!@#$%^&*"
+      - "charlie"
+      - "aa123456"
+      - "donald"
+      - "password1"
+      - "qwerty123"
+      uid_pattern:
+      - "\\d{6}"
+      - "[A-Z]{1}\\d{5}"

--- a/src/test/java/net/datafaker/providers/base/CredentialTest.java
+++ b/src/test/java/net/datafaker/providers/base/CredentialTest.java
@@ -1,0 +1,144 @@
+package net.datafaker.providers.base;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class CredentialTest {
+    private final BaseFaker faker = new BaseFaker();
+
+    @RepeatedTest(100)
+    void testUsername() {
+        assertThat(faker.credential().username()).matches("^(\\w+)\\.(\\w+)$");
+    }
+
+    @Test
+    void testUsernameWithSpaces() {
+        Name name = mock();
+        doReturn("Jin Quan").when(name).firstName();
+        doReturn("D'Artagnan").when(name).lastName();
+
+        BaseFaker mockedFaker = new BaseFaker() {
+            @Override
+            public Name name() {
+                return name;
+            }
+        };
+        assertThat(mockedFaker.credential().username())
+            .doesNotContain(" ", "'")
+            .matches("^(\\w+)\\.(\\w+)$")
+            .matches("^\\p{javaLowerCase}+\\.\\p{javaLowerCase}+$");
+    }
+
+    @RepeatedTest(100)
+    void testPassword() {
+        assertThat(faker.credential().password()).hasSizeBetween(8, 16).matches("^[a-z0-9]+$");
+    }
+
+    @RepeatedTest(100)
+    void testPasswordWithoutDigits() {
+        assertThat(faker.credential().password(false)).hasSizeBetween(8, 16).matches("^[a-z]+$");
+    }
+
+    @RepeatedTest(100)
+    void testPasswordWithSpecificSize() {
+        assertThat(faker.credential().password(3, 7)).hasSizeBetween(3, 7).matches("^[a-z0-9]+$");
+    }
+
+    @RepeatedTest(100)
+    void testPasswordWithSpecificSizeAndUppercase() {
+        assertThat(faker.credential().password(8, 16, true)).hasSizeBetween(8, 16).matches("^[a-zA-Z0-9]+$");
+    }
+
+    @Test
+    void testPassword1000() {
+        final Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
+        final Pattern digitPattern = Pattern.compile("[0-9]");
+        for (int i = 0; i < 1000; i++) {
+            String password = faker.credential().password(8, 16, true, true, true);
+            Matcher specialCharacterMatcher = specialCharacterPattern.matcher(password);
+            Matcher digitMatcher = digitPattern.matcher(password);
+
+            boolean isPasswordContainsSpecialCharacter = specialCharacterMatcher.find();
+            boolean isPasswordContainsDigit = digitMatcher.find();
+
+            assertThat(isPasswordContainsDigit).isTrue();
+            assertThat(isPasswordContainsSpecialCharacter).isTrue();
+        }
+    }
+
+    @Test
+    void passwordSpecial() {
+        boolean check = true;
+        for (int i = 0; i < 10; i++) {
+            String password = faker.credential().password(8, 16, true, true, true);
+            Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
+            Matcher specialCharacterMatcher = specialCharacterPattern.matcher(password);
+            if (!specialCharacterMatcher.find()) {
+                check = false;
+                break;
+            }
+
+        }
+        assertThat(check).isTrue();
+    }
+
+    @Test
+    void passwordMix() {
+        boolean check = true;
+        for (int i = 0; i < 10; i++) {
+            String password = faker.credential().password(8, 16, true, true, true);
+            Pattern specialCharacterPattern = Pattern.compile("[^a-zA-Z0-9]");
+            Matcher specialCharacterMatcher = specialCharacterPattern.matcher(password);
+            Pattern digitPattern = Pattern.compile("[0-9]");
+            Matcher digitMatcher = digitPattern.matcher(password);
+            if (!specialCharacterMatcher.find()) {
+                check = false;
+                break;
+            }
+            if (!digitMatcher.find()) {
+                check = false;
+                break;
+            }
+        }
+        assertThat(check).isTrue();
+    }
+
+    @Test
+    void weakPassword() {
+        Object obj = faker.fakeValuesService().fetchObject("credential.weak_password", faker.getContext());
+        final List<String> list = (obj instanceof List<?> l
+                && l.stream().allMatch(String.class::isInstance))
+                        ? l.stream().map(String.class::cast).toList()
+                        : Collections.emptyList();
+
+        assertThat(faker.credential().weakPassword()).isIn(list);
+    }
+
+    @RepeatedTest(100)
+    void testUserId() {
+        String uid = faker.credential().userId();
+        assertThat(uid).matches("^([A-Z]{1})?[0-9]{5,6}$");
+    }
+
+    @Test
+    void userIdWithParameter() {
+        String uid = faker.credential().userId(null);
+        assertThat(uid).isNull();
+
+        uid = faker.credential().userId("*");
+        assertThat(uid).isNull();
+
+        uid = faker.credential().userId("");
+        assertThat(uid).isEmpty();
+        System.out.println(uid);
+    }
+}

--- a/src/test/java/net/datafaker/providers/base/CredentialTest.java
+++ b/src/test/java/net/datafaker/providers/base/CredentialTest.java
@@ -139,6 +139,5 @@ class CredentialTest {
 
         uid = faker.credential().userId("");
         assertThat(uid).isEmpty();
-        System.out.println(uid);
     }
 }

--- a/src/test/java/net/datafaker/providers/base/InternetTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetTest.java
@@ -1,6 +1,8 @@
 package net.datafaker.providers.base;
 
 import net.datafaker.Faker;
+import net.datafaker.service.FakeValuesService;
+
 import org.apache.commons.validator.routines.EmailValidator;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.RepeatedTest;
@@ -8,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -20,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 class InternetTest {
 
@@ -97,6 +102,34 @@ class InternetTest {
 
         emailAddress = faker.internet().emailAddress("Jeanne d’Arc");
         assertThat(emailAddress).startsWith("jeanne.darc@");
+        assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
+    }
+
+    @Test
+    void testEmailAddressTypeSafety() {
+        Faker spyedFaker = spy();
+        FakeValuesService mockedFakeValuesService = mock();
+        
+        when(spyedFaker.fakeValuesService()).thenReturn(mockedFakeValuesService);
+        when(mockedFakeValuesService.fetchObject("name.prefix", spyedFaker.getContext()))
+            .thenReturn(Collections.emptySet());
+        when(mockedFakeValuesService.fetchObject("name.suffix", spyedFaker.getContext()))
+            .thenReturn(Collections.emptySet());
+
+        String emailAddress = spyedFaker.internet().emailAddress("John McClane");
+        assertThat(emailAddress).startsWith("john.mcclane@");
+        assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
+
+        List<Integer> wrongListType = new ArrayList<>();
+        wrongListType.add(1);
+
+        when(mockedFakeValuesService.fetchObject("name.prefix", spyedFaker.getContext()))
+            .thenReturn(wrongListType);
+        when(mockedFakeValuesService.fetchObject("name.suffix", spyedFaker.getContext()))
+            .thenReturn(wrongListType);
+
+        emailAddress = spyedFaker.internet().emailAddress("John McClane");
+        assertThat(emailAddress).startsWith("john.mcclane@");
         assertThat(EmailValidator.getInstance().isValid(emailAddress)).isTrue();
     }
 


### PR DESCRIPTION
Creates a new provider, `Credential`, whose purpose is to centralize the creation of credential-related data, such as user names, IDs, passwords, keys, etc.

In addition to the methods that already existed in the `Internet `provider (which were marked as deprecated), two new methods were created to assist in the creation of weak passwords (black list) and user IDs.

Improved test coverage for `Internet `provider.