### PR TITLE
make Brazilian ID Number accessible via `faker.idNumber()`

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/BrazilIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/BrazilIdNumber.java
@@ -1,0 +1,31 @@
+package net.datafaker.idnumbers;
+
+import net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil;
+import net.datafaker.providers.base.BaseProviders;
+import net.datafaker.providers.base.IdNumber.IdNumberRequest;
+import net.datafaker.providers.base.PersonIdNumber;
+
+import static net.datafaker.idnumbers.Utils.birthday;
+import static net.datafaker.idnumbers.Utils.gender;
+
+/**
+ * Brazilian individual taxpayer number
+ */
+public class BrazilIdNumber implements IdNumberGenerator {
+    @Override
+    public String countryCode() {
+        return "BR";
+    }
+
+    @Override
+    public String generateInvalid(final BaseProviders faker) {
+        return IdNumberGeneratorPtBrUtil.cpf(faker, true, false);
+    }
+
+    @Override
+    public PersonIdNumber generateValid(BaseProviders faker, IdNumberRequest request) {
+        String idNumber = IdNumberGeneratorPtBrUtil.cpf(faker, true, true);
+        return new PersonIdNumber(idNumber,
+            birthday(faker, request), gender(faker, request));
+    }
+}

--- a/src/main/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtil.java
+++ b/src/main/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtil.java
@@ -102,7 +102,6 @@ public final class IdNumberGeneratorPtBrUtil {
         int d1 = digit(calculateWeight(cnpjUnmask, 9, 4, cnpjPartialLength) + calculateWeight(cnpjUnmask, 5, 0, 4));
         int d2 = digit((d1 * 2) + calculateWeight(cnpjUnmask, 9, 5, cnpjPartialLength) + calculateWeight(cnpjUnmask, 6, 0, 5));
 
-
         final String other = d1 + "" + d2;
         return cnpjUnmask.regionMatches(cnpjPartialLength, other, 0, other.length());
     }
@@ -126,7 +125,7 @@ public final class IdNumberGeneratorPtBrUtil {
     }
 
 
-    public static int calculateWeight(final String num, final int weight, int start, int end) {
+    private static int calculateWeight(final String num, final int weight, int start, int end) {
         int sum = 0;
         int weightAux = weight;
 
@@ -136,12 +135,11 @@ public final class IdNumberGeneratorPtBrUtil {
         return sum;
     }
 
-    public static int digit(int verifyingDigit) {
+    private static int digit(int verifyingDigit) {
         int remainder = verifyingDigit % 11;
         if (remainder == 0 || remainder == 1)
             return 0;
         else
             return 11 - remainder;
     }
-
 }

--- a/src/main/java/net/datafaker/providers/base/IdNumber.java
+++ b/src/main/java/net/datafaker/providers/base/IdNumber.java
@@ -147,7 +147,7 @@ public class IdNumber extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Generate a valid Chinese id number
+     * Generate a valid Portuguese ID number
      *
      * @deprecated Instead of calling this method directly, use faker with locale:
      * <pre>
@@ -202,6 +202,14 @@ public class IdNumber extends AbstractProvider<BaseProviders> {
     /**
      * Generates a valid PESEL number for a person of random gender and age between
      * 0 and 100.
+     *
+     * @deprecated Instead of calling this method directly, use faker with locale:
+     * <pre>
+     * {@code
+     *   Faker faker = new Faker(new Locale("pl", "PL"));
+     *   String idNumber = faker.idNumber().valid();
+     * }
+     * </pre>
      *
      * @return A valid PESEL number
      */

--- a/src/main/resources/META-INF/services/net.datafaker.idnumbers.IdNumberGenerator
+++ b/src/main/resources/META-INF/services/net.datafaker.idnumbers.IdNumberGenerator
@@ -1,6 +1,7 @@
 net.datafaker.idnumbers.AlbanianIdNumber
 net.datafaker.idnumbers.AmericanIdNumber
 net.datafaker.idnumbers.BulgarianIdNumber
+net.datafaker.idnumbers.BrazilIdNumber
 net.datafaker.idnumbers.ChineseIdNumber
 net.datafaker.idnumbers.EstonianIdNumber
 net.datafaker.idnumbers.FrenchIdNumber

--- a/src/test/java/net/datafaker/helpers/IdNumberPatterns.java
+++ b/src/test/java/net/datafaker/helpers/IdNumberPatterns.java
@@ -12,5 +12,7 @@ public class IdNumberPatterns {
     public static final Pattern POLISH = Pattern.compile("\\d{11}");
     public static final Pattern IRISH = Pattern.compile("\\d{7}[A-Z]{1,2}$");
     public static final Pattern HUNGARIAN = Pattern.compile("[1-4]\\d{9}");
+    public static final Pattern ESTONIAN = Pattern.compile("[1-6][0-9]{10}");
+    public static final Pattern BRAZILIAN = Pattern.compile("\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}");
 
 }

--- a/src/test/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtilTest.java
+++ b/src/test/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtilTest.java
@@ -1,0 +1,16 @@
+package net.datafaker.idnumbers.pt.br;
+
+import org.junit.jupiter.api.Test;
+
+import static net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil.isCPFValid;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdNumberGeneratorPtBrUtilTest {
+    @Test
+    void samples() {
+        assertThat(isCPFValid("529.982.247-25")).isTrue();
+        assertThat(isCPFValid("168.995.350-09")).isTrue();
+        assertThat(isCPFValid("862.883.667-57")).isTrue();
+        assertThat(isCPFValid("746.971.314-01")).isTrue();
+    }
+}

--- a/src/test/java/net/datafaker/providers/base/CPFTest.java
+++ b/src/test/java/net/datafaker/providers/base/CPFTest.java
@@ -3,15 +3,13 @@ package net.datafaker.providers.base;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.RepeatedTest;
 
-import java.util.regex.Pattern;
-
+import static net.datafaker.helpers.IdNumberPatterns.BRAZILIAN;
 import static net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil.isCPFValid;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 class CPFTest {
 
-    public static final Pattern CPF_EXPRESSION = Pattern.compile("(^\\d{3}\\x2E\\d{3}\\x2E\\d{3}\\x2D\\d{2}$)");
     private final Faker faker = new Faker();
 
     /**
@@ -36,9 +34,9 @@ class CPFTest {
      */
     @RepeatedTest(100)
     void formattedCPF() {
-        assertThat(faker.cpf().valid()).matches(CPF_EXPRESSION);
-        assertThat(faker.cpf().valid(true)).matches(CPF_EXPRESSION);
-        assertThat(faker.cpf().invalid()).matches(CPF_EXPRESSION);
-        assertThat(faker.cpf().invalid(true)).matches(CPF_EXPRESSION);
+        assertThat(faker.cpf().valid()).matches(BRAZILIAN);
+        assertThat(faker.cpf().valid(true)).matches(BRAZILIAN);
+        assertThat(faker.cpf().invalid()).matches(BRAZILIAN);
+        assertThat(faker.cpf().invalid(true)).matches(BRAZILIAN);
     }
 }

--- a/src/test/java/net/datafaker/providers/base/IdNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/IdNumberTest.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 
 import static java.lang.Integer.parseInt;
 import static java.time.format.DateTimeFormatter.ofPattern;
+import static net.datafaker.idnumbers.pt.br.IdNumberGeneratorPtBrUtil.isCPFValid;
 import static net.datafaker.providers.base.IdNumber.GenderRequest.ANY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -39,6 +40,7 @@ class IdNumberTest {
     private static final Faker FRENCH = new Faker(new Locale("fr", "FR"));
     private static final Faker ITALIAN = new Faker(new Locale("it", "IT"));
     private static final Faker HUNGARIAN = new Faker(new Locale("hu", "HU"));
+    private static final Faker BRAZILIAN = new Faker(new Locale("pt", "BR"));
 
     @Test
     void testValid() {
@@ -117,12 +119,26 @@ class IdNumberTest {
 
     @RepeatedTest(100)
     void estonianPersonalCode_valid() {
-        assertThatPin(ESTONIAN.idNumber().valid()).matches("[1-6][0-9]{10}");
+        assertThatPin(ESTONIAN.idNumber().valid()).matches(IdNumberPatterns.ESTONIAN);
     }
 
     @RepeatedTest(100)
     void estonianPersonalCode_invalid() {
-        assertThatPin(ESTONIAN.idNumber().invalid()).matches("[1-6][0-9]{10}");
+        assertThatPin(ESTONIAN.idNumber().invalid()).matches(IdNumberPatterns.ESTONIAN);
+    }
+
+    @RepeatedTest(100)
+    void brazilianPersonalCode_valid() {
+        String actual = BRAZILIAN.idNumber().valid();
+        assertThatPin(actual).matches(IdNumberPatterns.BRAZILIAN);
+        assertThat(isCPFValid(actual)).describedAs(() -> "Current value " + actual).isTrue();
+    }
+
+    @RepeatedTest(100)
+    void brazilianPersonalCode_invalid() {
+        String actual = BRAZILIAN.idNumber().invalid();
+        assertThatPin(actual).matches(IdNumberPatterns.BRAZILIAN);
+        assertThat(isCPFValid(actual)).describedAs(() -> "Current value " + actual).isFalse();
     }
 
     @RepeatedTest(100)


### PR DESCRIPTION
Brazilian ID Number (aka CPF) was already available via 

```java
faker.cpf().valid()
```

but now it's also available via more generic 
```java
new Faker(new Locale("pt", "BR")).idNumber().valid()
```