### PR TITLE
Finance Provider - update Swift IBAN data standard from v87 to v99

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -183,85 +183,97 @@ public class Finance extends AbstractProvider<BaseProviders> {
 
     private static Map<String, String> createCountryCodeToBasicBankAccountNumberPatternMap() {
         // source: https://www.swift.com/standards/data-standards/iban
-        // version 87
+        // version 99
         Map<String, String> ibanFormats = new HashMap<>();
-        ibanFormats.put("AD", "\\d{4}\\d{4}[0-9A-Z]{12}");
-        ibanFormats.put("AE", "\\d{3}\\d{16}");
-        ibanFormats.put("AL", "\\d{8}[0-9A-Z]{16}");
-        ibanFormats.put("AT", "\\d{5}\\d{11}");
-        ibanFormats.put("AZ", "[A-Z]{4}[0-9A-Z]{20}");
-        ibanFormats.put("BA", "\\d{3}\\d{3}\\d{8}\\d{2}");
-        ibanFormats.put("BE", "\\d{3}\\d{7}\\d{2}");
-        ibanFormats.put("BG", "[A-Z]{4}\\d{4}\\d{2}[0-9A-Z]{8}");
-        ibanFormats.put("BH", "[A-Z]{4}[0-9A-Z]{14}");
-        ibanFormats.put("BR", "\\d{8}\\d{5}\\d{10}[A-Z]{1}[0-9A-Z]{1}");
-        ibanFormats.put("BY", "[0-9A-Z]{4}\\d{4}[0-9A-Z]{16}");
-        ibanFormats.put("CH", "\\d{5}[0-9A-Z]{12}");
-        ibanFormats.put("CR", "0\\d{3}\\d{14}");
-        ibanFormats.put("CY", "\\d{3}\\d{5}[0-9A-Z]{16}");
-        ibanFormats.put("CZ", "\\d{4}\\d{6}\\d{10}");
-        ibanFormats.put("DE", "\\d{8}\\d{10}");
-        ibanFormats.put("DK", "\\d{4}\\d{9}\\d{1}");
-        ibanFormats.put("DO", "[0-9A-Z]{4}\\d{20}");
-        ibanFormats.put("EE", "\\d{2}\\d{2}\\d{11}\\d{1}");
-        ibanFormats.put("EG", "\\d{4}\\d{4}\\d{17}");
-        ibanFormats.put("ES", "\\d{4}\\d{4}\\d{1}\\d{1}\\d{10}");
-        ibanFormats.put("FI", "\\d{6}\\d{7}\\d{1}");
-        ibanFormats.put("FO", "\\d{4}\\d{9}\\d{1}");
-        ibanFormats.put("FR", "\\d{5}\\d{5}[0-9A-Z]{11}\\d{2}");
-        ibanFormats.put("GB", "[A-Z]{4}\\d{6}\\d{8}");
-        ibanFormats.put("GE", "[A-Z]{2}\\d{16}");
-        ibanFormats.put("GI", "[A-Z]{4}[0-9A-Z]{15}");
-        ibanFormats.put("GL", "\\d{4}\\d{9}\\d{1}");
-        ibanFormats.put("GR", "\\d{3}\\d{4}[0-9A-Z]{16}");
-        ibanFormats.put("GT", "[0-9A-Z]{4}[0-9A-Z]{20}");
-        ibanFormats.put("HR", "\\d{7}\\d{10}");
-        ibanFormats.put("HU", "\\d{3}\\d{4}\\d{1}\\d{15}\\d{1}");
-        ibanFormats.put("IE", "[A-Z]{4}\\d{6}\\d{8}");
-        ibanFormats.put("IL", "\\d{3}\\d{3}\\d{13}");
-        ibanFormats.put("IQ", "[A-Z]{4}\\d{3}\\d{12}");
-        ibanFormats.put("IS", "\\d{4}\\d{2}\\d{6}\\d{10}");
-        ibanFormats.put("IT", "[A-Z]{1}\\d{5}\\d{5}[0-9A-Z]{12}");
-        ibanFormats.put("JO", "[A-Z]{4}\\d{4}[0-9A-Z]{18}");
-        ibanFormats.put("KW", "[A-Z]{4}[0-9A-Z]{22}");
-        ibanFormats.put("KZ", "\\d{3}[0-9A-Z]{13}");
-        ibanFormats.put("LB", "\\d{4}[0-9A-Z]{20}");
-        ibanFormats.put("LC", "[A-Z]{4}[0-9A-Z]{24}");
-        ibanFormats.put("LI", "\\d{5}[0-9A-Z]{12}");
-        ibanFormats.put("LT", "\\d{5}\\d{11}");
-        ibanFormats.put("LU", "\\d{3}[0-9A-Z]{13}");
-        ibanFormats.put("LV", "[A-Z]{4}[0-9A-Z]{13}");
-        ibanFormats.put("MC", "\\d{5}\\d{5}[0-9A-Z]{11}\\d{2}");
-        ibanFormats.put("MD", "[0-9A-Z]{2}[0-9A-Z]{18}");
-        ibanFormats.put("ME", "\\d{3}\\d{13}\\d{2}");
-        ibanFormats.put("MK", "\\d{3}[0-9A-Z]{10}\\d{2}");
-        ibanFormats.put("MR", "\\d{5}\\d{5}\\d{11}\\d{2}");
-        ibanFormats.put("MT", "[A-Z]{4}\\d{5}[0-9A-Z]{18}");
-        ibanFormats.put("MU", "[A-Z]{4}\\d{2}\\d{2}\\d{12}\\d{3}[A-Z]{3}");
-        ibanFormats.put("NL", "[A-Z]{4}\\d{10}");
-        ibanFormats.put("NO", "\\d{4}\\d{6}\\d{1}");
-        ibanFormats.put("PK", "[A-Z]{4}[0-9A-Z]{16}");
-        ibanFormats.put("PL", "\\d{8}\\d{16}");
-        ibanFormats.put("PS", "[A-Z]{4}[0-9A-Z]{21}");
-        ibanFormats.put("PT", "\\d{4}\\d{4}\\d{11}\\d{2}");
-        ibanFormats.put("QA", "[A-Z]{4}[0-9A-Z]{21}");
-        ibanFormats.put("RO", "[A-Z]{4}[0-9A-Z]{16}");
-        ibanFormats.put("RS", "\\d{3}\\d{13}\\d{2}");
-        ibanFormats.put("SA", "\\d{2}[0-9A-Z]{18}");
-        ibanFormats.put("SC", "[A-Z]{4}\\d{2}\\d{2}\\d{16}[A-Z]{3}");
-        ibanFormats.put("SE", "\\d{3}\\d{16}\\d{1}");
-        ibanFormats.put("SI", "\\d{5}\\d{8}\\d{2}");
-        ibanFormats.put("SK", "\\d{4}\\d{6}\\d{10}");
-        ibanFormats.put("SM", "[A-Z]{1}\\d{5}\\d{5}[0-9A-Z]{12}");
-        ibanFormats.put("ST", "\\d{8}\\d{11}\\d{2}");
-        ibanFormats.put("SV", "[A-Z]{4}\\d{20}");
-        ibanFormats.put("TL", "\\d{3}\\d{14}\\d{2}");
-        ibanFormats.put("TN", "\\d{2}\\d{3}\\d{13}\\d{2}");
-        ibanFormats.put("TR", "\\d{5}\\d{1}[0-9A-Z]{16}");
-        ibanFormats.put("UA", "\\d{6}[0-9A-Z]{19}");
-        ibanFormats.put("VA", "\\d{3}\\d{15}");
-        ibanFormats.put("VG", "[A-Z]{4}\\d{16}");
-        ibanFormats.put("XK", "\\d{4}\\d{10}\\d{2}");
+        ibanFormats.put("AD", "\\d{4}\\d{4}[0-9A-Z]{12}"); // 4!n4!n12!c
+        ibanFormats.put("AE", "\\d{3}\\d{16}"); // 3!n16!n
+        ibanFormats.put("AL", "\\d{8}[0-9A-Z]{16}"); // 8!n16!c
+        ibanFormats.put("AT", "\\d{5}\\d{11}"); // 5!n11!n
+        ibanFormats.put("AZ", "[A-Z]{4}[0-9A-Z]{20}"); // 4!a20!c
+        ibanFormats.put("BA", "\\d{3}\\d{3}\\d{8}\\d{2}"); // 3!n3!n8!n2!n
+        ibanFormats.put("BE", "\\d{3}\\d{7}\\d{2}"); // 3!n7!n2!n
+        ibanFormats.put("BG", "[A-Z]{4}\\d{4}\\d{2}[0-9A-Z]{8}"); // 4!a4!n2!n8!c
+        ibanFormats.put("BH", "[A-Z]{4}[0-9A-Z]{14}"); // 4!a14!c
+        ibanFormats.put("BI", "\\d{5}\\d{5}\\d{11}\\d{2}"); //5!n5!n11!n2!n
+        ibanFormats.put("BR", "\\d{8}\\d{5}\\d{10}[A-Z]{1}[0-9A-Z]{1}"); // 8!n5!n10!n1!a1!c
+        ibanFormats.put("BY", "[0-9A-Z]{4}\\d{4}[0-9A-Z]{16}"); // 4!c4!n16!c
+        ibanFormats.put("CH", "\\d{5}[0-9A-Z]{12}"); // 5!n12!c
+        ibanFormats.put("CR", "\\d{4}\\d{14}"); // 4!n14!n
+        ibanFormats.put("CY", "\\d{3}\\d{5}[0-9A-Z]{16}"); // 3!n5!n16!c
+        ibanFormats.put("CZ", "\\d{4}\\d{6}\\d{10}"); // 4!n6!n10!n
+        ibanFormats.put("DE", "\\d{8}\\d{10}"); // 8!n10!n
+        ibanFormats.put("DJ", "\\d{5}\\d{5}\\d{11}\\d{2}"); // 5!n5!n11!n2!n
+        ibanFormats.put("DK", "\\d{4}\\d{9}\\d{1}"); // 4!n9!n1!n
+        ibanFormats.put("DO", "[0-9A-Z]{4}\\d{20}"); // 4!c20!n
+        ibanFormats.put("EE", "\\d{2}\\d{14}"); // 2!n14!n
+        ibanFormats.put("EG", "\\d{4}\\d{4}\\d{17}"); // 4!n4!n17!n
+        ibanFormats.put("ES", "\\d{4}\\d{4}\\d{1}\\d{1}\\d{10}"); // 4!n4!n1!n1!n10!n
+        ibanFormats.put("FI", "\\d{3}\\d{11}"); // 3!n11!n
+        ibanFormats.put("FK", "[A-Z]{2}\\d{12}"); // 2!a12!n
+        ibanFormats.put("FO", "\\d{4}\\d{9}\\d{1}"); // 4!n9!n1!n
+        ibanFormats.put("FR", "\\d{5}\\d{5}[0-9A-Z]{11}\\d{2}"); // 5!n5!n11!c2!n
+        ibanFormats.put("GB", "[A-Z]{4}\\d{6}\\d{8}"); // 4!a6!n8!n
+        ibanFormats.put("GE", "[A-Z]{2}\\d{16}"); // 2!a16!n
+        ibanFormats.put("GI", "[A-Z]{4}[0-9A-Z]{15}"); // 4!a15!c
+        ibanFormats.put("GL", "\\d{4}\\d{9}\\d{1}"); // 4!n9!n1!n
+        ibanFormats.put("GR", "\\d{3}\\d{4}[0-9A-Z]{16}"); // 3!n4!n16!c
+        ibanFormats.put("GT", "[0-9A-Z]{4}[0-9A-Z]{20}"); // 4!c20!c
+        ibanFormats.put("HN", "[A-Z]{4}\\d{20}"); // 4!a20!n
+        ibanFormats.put("HR", "\\d{7}\\d{10}"); // 7!n10!n
+        ibanFormats.put("HU", "\\d{3}\\d{4}\\d{1}\\d{15}\\d{1}"); // 3!n4!n1!n15!n1!n
+        ibanFormats.put("IE", "[A-Z]{4}\\d{6}\\d{8}"); // 4!a6!n8!n
+        ibanFormats.put("IL", "\\d{3}\\d{3}\\d{13}"); // 3!n3!n13!n
+        ibanFormats.put("IQ", "[A-Z]{4}\\d{3}\\d{12}"); // 4!a3!n12!n
+        ibanFormats.put("IS", "\\d{4}\\d{2}\\d{6}\\d{10}"); // 4!n2!n6!n10!n
+        ibanFormats.put("IT", "[A-Z]{1}\\d{5}\\d{5}[0-9A-Z]{12}"); // 1!a5!n5!n12!c
+        ibanFormats.put("JO", "[A-Z]{4}\\d{4}[0-9A-Z]{18}"); // 4!a4!n18!c
+        ibanFormats.put("KW", "[A-Z]{4}[0-9A-Z]{22}"); // 4!a22!c
+        ibanFormats.put("KZ", "\\d{3}[0-9A-Z]{13}"); // 3!n13!c
+        ibanFormats.put("LB", "\\d{4}[0-9A-Z]{20}"); // 4!n20!c
+        ibanFormats.put("LC", "[A-Z]{4}[0-9A-Z]{24}"); // 4!a24!c
+        ibanFormats.put("LI", "\\d{5}[0-9A-Z]{12}"); // 5!n12!c
+        ibanFormats.put("LT", "\\d{5}\\d{11}"); // 5!n11!n
+        ibanFormats.put("LU", "\\d{3}[0-9A-Z]{13}"); // 3!n13!c
+        ibanFormats.put("LV", "[A-Z]{4}[0-9A-Z]{13}"); // 4!a13!c
+        ibanFormats.put("LY", "\\d{3}\\d{3}\\d{15}"); // 3!n3!n15!n
+        ibanFormats.put("MC", "\\d{5}\\d{5}[0-9A-Z]{11}\\d{2}"); // 5!n5!n11!c2!n
+        ibanFormats.put("MD", "[0-9A-Z]{2}[0-9A-Z]{18}"); // 2!c18!c
+        ibanFormats.put("ME", "\\d{3}\\d{13}\\d{2}"); // 3!n13!n2!n
+        ibanFormats.put("MK", "\\d{3}[0-9A-Z]{10}\\d{2}"); // 3!n10!c2!n
+        ibanFormats.put("MN", "\\d{4}\\d{12}"); // 4!n12!n
+        ibanFormats.put("MR", "\\d{5}\\d{5}\\d{11}\\d{2}"); // 5!n5!n11!n2!n
+        ibanFormats.put("MT", "[A-Z]{4}\\d{5}[0-9A-Z]{18}"); // 4!a5!n18!c
+        ibanFormats.put("MU", "[A-Z]{4}\\d{2}\\d{2}\\d{12}\\d{3}[A-Z]{3}"); // 4!a2!n2!n12!n3!n3!a
+        ibanFormats.put("NI", "[A-Z]{4}\\d{20}"); // 4!a20!n
+        ibanFormats.put("NL", "[A-Z]{4}\\d{10}"); // 4!a10!n
+        ibanFormats.put("NO", "\\d{4}\\d{6}\\d{1}"); // 4!n6!n1!n
+        ibanFormats.put("OM", "\\d{3}[0-9A-Z]{16}"); // 3!n16!c
+        ibanFormats.put("PK", "[A-Z]{4}[0-9A-Z]{16}"); // 4!a16!c
+        ibanFormats.put("PL", "\\d{8}\\d{16}"); // 8!n16!n
+        ibanFormats.put("PS", "[A-Z]{4}[0-9A-Z]{21}"); // 4!a21!c
+        ibanFormats.put("PT", "\\d{4}\\d{4}\\d{11}\\d{2}"); // 4!n4!n11!n2!n
+        ibanFormats.put("QA", "[A-Z]{4}[0-9A-Z]{21}"); // 4!a21!c
+        ibanFormats.put("RO", "[A-Z]{4}[0-9A-Z]{16}"); // 4!a16!c
+        ibanFormats.put("RS", "\\d{3}\\d{13}\\d{2}"); // 3!n13!n2!n
+        ibanFormats.put("RU", "\\d{9}\\d{5}[0-9A-Z]{15}"); // 9!n5!n15!c
+        ibanFormats.put("SA", "\\d{2}[0-9A-Z]{18}"); // 2!n18!c
+        ibanFormats.put("SC", "[A-Z]{4}\\d{2}\\d{2}\\d{16}[A-Z]{3}"); // 4!a2!n2!n16!n3!a
+        ibanFormats.put("SD", "\\d{2}\\d{12}"); // 2!n12!n
+        ibanFormats.put("SE", "\\d{3}\\d{16}\\d{1}"); // 3!n16!n1!n
+        ibanFormats.put("SI", "\\d{5}\\d{8}\\d{2}"); // 5!n8!n2!n
+        ibanFormats.put("SK", "\\d{4}\\d{6}\\d{10}"); // 4!n6!n10!n
+        ibanFormats.put("SM", "[A-Z]{1}\\d{5}\\d{5}[0-9A-Z]{12}"); // 1!a5!n5!n12!c
+        ibanFormats.put("SO", "\\d{2}\\d{12}"); // 2!n12!n
+        ibanFormats.put("ST", "\\d{8}\\d{11}\\d{2}"); // 8!n11!n2!n
+        ibanFormats.put("SV", "[A-Z]{4}\\d{20}"); // 4!a20!n
+        ibanFormats.put("TL", "\\d{3}\\d{14}\\d{2}"); // 3!n14!n2!n
+        ibanFormats.put("TN", "\\d{2}\\d{3}\\d{13}\\d{2}"); // 2!n3!n13!n2!n
+        ibanFormats.put("TR", "\\d{5}\\d{1}[0-9A-Z]{16}"); // 5!n1!n16!c
+        ibanFormats.put("UA", "\\d{6}[0-9A-Z]{19}"); // 6!n19!c
+        ibanFormats.put("VA", "\\d{3}\\d{15}"); // 3!n15!n
+        ibanFormats.put("VG", "[A-Z]{4}\\d{16}"); // 4!a16!n
+        ibanFormats.put("XK", "\\d{4}\\d{10}\\d{2}"); // 4!n10!n2!n
+        ibanFormats.put("YE", "[A-Z]{4}\\d{4}[0-9A-Z]{18}"); // 4!a4!n18!c
         return ibanFormats;
     }
 }

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -48,7 +48,7 @@ class FinanceTest extends BaseFakerTest {
 
     @RepeatedTest(100)
     void iban() {
-        assertThat(finance.iban()).matches("[A-Z]{2}[A-Z0-9]{13,30}");
+        assertThat(finance.iban()).matches("[A-Z]{2}[A-Z0-9]{13,31}");
     }
 
     @Test


### PR DESCRIPTION
Adds support for generating IBAN numbers for Burundi, Djibouti, Falkland Islands, Honduras, Libya, Mongolia, Nicaragua, Oman, Russia, Sudan, Somalia and Yemen.

Updates IBAN format for Finland

Adds BBAN formats to source for easier comparison next time around