### PR TITLE
Stop using Internet#username() interally

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -48,7 +48,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     public String emailAddress() {
-        return emailAddress(username());
+        return emailAddress(faker.credentials().username());
     }
 
     /**
@@ -76,7 +76,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
     }
 
     public String safeEmailAddress() {
-        return safeEmailAddress(username());
+        return safeEmailAddress(faker.credentials().username());
     }
 
     /**

--- a/src/main/java/net/datafaker/providers/base/Name.java
+++ b/src/main/java/net/datafaker/providers/base/Name.java
@@ -154,6 +154,6 @@ public class Name extends AbstractProvider<BaseProviders> {
     @Deprecated(since = "2.5.0", forRemoval = true)
     @SuppressWarnings("removal")
     public String username() {
-        return faker.internet().username();
+        return faker.credentials().username();
     }
 }


### PR DESCRIPTION
Since Internet#usernam() was already changed to use Credentials#username() all internal use may as well do the same thing so that DF itself isn't using deprecated methods.