### PR TITLE
fix formatting of 2.5.1 release notes

### DIFF
--- a/docs/releases/2.5.1.md
+++ b/docs/releases/2.5.1.md
@@ -4,10 +4,10 @@
 
 * Add ability to use whitelist conditions [by @snuyanzin](https://github.com/datafaker-net/datafaker/pull/1668)
 * Update `_PL.yml` with country phone code [by @kopernic-pl](https://github.com/datafaker-net/datafaker/pull/1663)
-* #1659 fix method `faker.text().text(1, 64, ...)` [by @asolntsev](https://github.com/datafaker-net/datafaker/pull/1660)
-* Added missing link for deprecation warning [by @bodiam](https://github.com/datafaker-net/datafaker/pull/1662)
-* Fix possible issue with tr locale in testUsernameWithSpaces [by @snuyanzin](https://github.com/datafaker-net/datafaker/pull/1669)
-* Stop using Internet#username() internally [by @kingthorin](https://github.com/datafaker-net/datafaker/pull/1671)
+* fix method `faker.text().text(1, 64, ...)` [by @asolntsev](https://github.com/datafaker-net/datafaker/pull/1660) (#1659)
+* Added missing link for deprecation warning [by @bodiam](https://github.com/datafaker-net/datafaker/pull/1662) (#1658)
+* Fix possible issue with "tr" locale in `testUsernameWithSpaces` [by @snuyanzin](https://github.com/datafaker-net/datafaker/pull/1669)
+* Stop using `Internet#username()` internally [by @kingthorin](https://github.com/datafaker-net/datafaker/pull/1671)
 
 ## New Contributors
 


### PR DESCRIPTION
Remove "#1659" from release notes - it seems that markdown treats it as a header, and shows this line with too big font.