### PR TITLE
Retrieve the no-argument constructor

### DIFF
--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -61,7 +61,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
                     if (primaryConstructor != null) {
                         result = primaryConstructor.newInstance();
                     } else {
-                        throw new RuntimeException("Failed to local a parameterless constructor for class " + clazz.getName());
+                        throw new RuntimeException("Failed to locate a parameterless public constructor for class " + clazz.getName());
                     }
                 } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
                     throw new RuntimeException(e);

--- a/src/test/java/net/datafaker/transformations/JavaObjectTransformerConstructorTest.java
+++ b/src/test/java/net/datafaker/transformations/JavaObjectTransformerConstructorTest.java
@@ -1,0 +1,100 @@
+package net.datafaker.transformations;
+
+import net.datafaker.Faker;
+import org.junit.jupiter.api.Test;
+
+import static net.datafaker.transformations.Field.field;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaObjectTransformerConstructorTest {
+
+    public static class Person {
+
+        private int id;
+
+        public Person() {
+        }
+
+        public Person(int id) {
+            throw new RuntimeException("This should not be called");
+        }
+    }
+
+    public static class ProtectedPerson {
+
+        private int id;
+
+        protected ProtectedPerson() {
+            throw new RuntimeException("This should not be called");
+        }
+
+        public ProtectedPerson(int id) {
+            this.id = id;
+        }
+    }
+
+    public static class PrivatePerson {
+
+        private int id;
+
+        private PrivatePerson() {
+            throw new RuntimeException("This should not be called");
+        }
+
+        public PrivatePerson(int id) {
+            this.id = id;
+        }
+    }
+
+    private final Faker faker = new Faker();
+
+    @Test
+    void javaNoArgConstructorTest() {
+        JavaObjectTransformer jTransformer = (new JavaObjectTransformer()).from(Person.class);
+        Schema<Object, ?> schema = Schema.of(
+            field("id", () -> faker.number().positive())
+        );
+
+        jTransformer
+            .generate(schema, 10)
+            .stream()
+            .map(object -> (Person) object)
+            .forEach(person -> {
+                assertThat(person.id).isNotNull();
+            });
+
+    }
+
+    @Test
+    void javaNoArgConstructorProtectedTest() {
+        JavaObjectTransformer jTransformer = (new JavaObjectTransformer()).from(ProtectedPerson.class);
+        Schema<Object, ?> schema = Schema.of(
+            field("id", () -> faker.number().positive())
+        );
+
+        jTransformer
+            .generate(schema, 10)
+            .stream()
+            .map(object -> (ProtectedPerson) object)
+            .forEach(person -> {
+                assertThat(person.id).isNotNull();
+            });
+    }
+
+    @Test
+    void javaNoArgConstructorPrivateTest() {
+        JavaObjectTransformer jTransformer = (new JavaObjectTransformer()).from(PrivatePerson.class);
+        Schema<Object, ?> schema = Schema.of(
+            field("id", () -> faker.number().positive())
+        );
+
+        jTransformer
+            .generate(schema, 10)
+            .stream()
+            .map(object -> (PrivatePerson) object)
+            .forEach(person -> {
+                assertThat(person.id).isNotNull();
+            });
+
+    }
+}


### PR DESCRIPTION
…using a method called `getParameterlessPublicConstructor`.

This fixes #1689 where the no-argument constructor is not always the one you get