### PR TITLE
avoid '&' in company domain names

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Company.java
+++ b/src/main/java/net/datafaker/providers/base/Company.java
@@ -80,7 +80,7 @@ public class Company extends AbstractProvider<BaseProviders> {
         for (int i = 0; i < res.length; i++) {
             final char c = res[i];
             switch (c) {
-                case '.', ',', '\'', ' ', ']' -> offset++;
+                case '.', ',', '\'', ' ', ']', '&' -> offset++;
                 default -> res[i - offset] = res[i];
             }
         }


### PR DESCRIPTION
Company domain names are created based on the company name and therefore might contain '&' (e.g. for German company names). So we have to remove them from the according domain name.