### PR TITLE
mark all APIs nullable/non-nullable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
         <jbanking.version>4.3.0</jbanking.version>
         <junit.version>6.0.3</junit.version>
         <libphonenumber.version>9.0.25</libphonenumber.version>
+        <jspecify.version>1.0.0</jspecify.version>
+        <error_prone.version>2.42.0</error_prone.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -87,6 +89,20 @@
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
             <version>${libphonenumber.version}</version>
+        </dependency>
+
+        <!-- Annotations for nullability etc. -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>${error_prone.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,20 @@
             <version>${libphonenumber.version}</version>
         </dependency>
 
+        <!-- Annotations for nullability etc. -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>${error_prone.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <jbanking.version>4.3.0</jbanking.version>
         <junit.version>6.1.1</junit.version>
         <libphonenumber.version>9.0.34</libphonenumber.version>
+        <jspecify.version>1.0.0</jspecify.version>
+        <error_prone.version>2.42.0</error_prone.version>
 
         <releaseJavaVersion>17</releaseJavaVersion>
         <buildJavaVersion>17</buildJavaVersion>

--- a/src/main/java/net/datafaker/annotations/FakeResolver.java
+++ b/src/main/java/net/datafaker/annotations/FakeResolver.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import net.datafaker.internal.helper.CopyOnWriteMap;
 import net.datafaker.transformations.JavaObjectTransformer;
 import net.datafaker.transformations.Schema;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -24,12 +25,14 @@ public class FakeResolver<T> {
         this.clazz = clazz;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> FakeResolver<T> of(Class<T> clazz) {
         var fakeFactory = CLASS_2_FAKE_RESOLVER.computeIfAbsent(clazz, k -> new FakeResolver<>(clazz));
         return (FakeResolver<T>) fakeFactory;
     }
 
-    public T generate(Schema<Object, ?> schema) {
+    @SuppressWarnings("unchecked")
+    public T generate(@Nullable Schema<Object, ?> schema) {
         if (schema == null) {
             return generateFromDefaultSchema();
         }
@@ -37,6 +40,7 @@ public class FakeResolver<T> {
         return (T) JAVA_OBJECT_TRANSFORMER.apply(clazz, schema);
     }
 
+    @SuppressWarnings("unchecked")
     private T generateFromDefaultSchema() {
         Schema<Object, ?> useSchema = DEFAULT_SCHEMA_CACHE.computeIfAbsent(clazz, (__) -> {
             FakeForSchema fakeForSchemaAnnotation = checkFakeAnnotation(clazz);
@@ -46,28 +50,27 @@ public class FakeResolver<T> {
         return (T) JAVA_OBJECT_TRANSFORMER.apply(clazz, useSchema);
     }
 
+    @SuppressWarnings("unchecked")
     private Schema<Object, T> getSchema(String pathToSchema) {
-        if (pathToSchema != null) {
-            try {
-                // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
-                final int sharpIndex = pathToSchema.indexOf("#");
-                final Class<?> classToCall;
-                final String methodName;
-                if (sharpIndex >= 0) {
-                    classToCall = Class.forName(pathToSchema.substring(0, sharpIndex));
-                    methodName = pathToSchema.substring(sharpIndex + 1);
-                } else {
-                    classToCall = this.clazz.getEnclosingClass();
-                    methodName = pathToSchema;
-                }
-                Method myStaticMethod = classToCall.getMethod(methodName);
-                myStaticMethod.setAccessible(true);
-                return (Schema<Object, T>) myStaticMethod.invoke(null);
-            } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                throw new RuntimeException(e);
+        requireNonNull(pathToSchema, "The path to the schema is empty.");
+
+        try {
+            // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
+            final int sharpIndex = pathToSchema.indexOf("#");
+            final Class<?> classToCall;
+            final String methodName;
+            if (sharpIndex >= 0) {
+                classToCall = Class.forName(pathToSchema.substring(0, sharpIndex));
+                methodName = pathToSchema.substring(sharpIndex + 1);
+            } else {
+                classToCall = this.clazz.getEnclosingClass();
+                methodName = pathToSchema;
             }
-        } else {
-            throw new IllegalArgumentException("The path to the schema is empty.");
+            Method myStaticMethod = classToCall.getMethod(methodName);
+            myStaticMethod.setAccessible(true);
+            return (Schema<Object, T>) myStaticMethod.invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/datafaker/annotations/package-info.java
+++ b/src/main/java/net/datafaker/annotations/package-info.java
@@ -1,0 +1,7 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.annotations;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/idnumbers/EstonianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/EstonianIdNumber.java
@@ -13,7 +13,7 @@ import static net.datafaker.idnumbers.Utils.birthday;
 import static net.datafaker.idnumbers.Utils.randomGender;
 
 /**
- * Estonian personal identification number ("Isikukood" in estonian)
+ * Estonian personal identification number ("Isikukood" in Estonian)
  * <p>
  * The number is 11 digits, with modulus 11 checksum digit.
  * There is fixed list of valid first digits to signify gender and birth century

--- a/src/main/java/net/datafaker/idnumbers/HungarianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/HungarianIdNumber.java
@@ -64,12 +64,12 @@ public class HungarianIdNumber implements IdNumberGenerator {
 
     static int getCheckDigit(String basePart) {
         char[] numbers = basePart.toCharArray();
-        int summ = 0;
+        int sum = 0;
         for (int i = 0; i < numbers.length; i++) {
-            summ += getNumericValue(numbers[i]) * (i + 1);
+            sum += getNumericValue(numbers[i]) * (i + 1);
         }
 
-        return summ % 11;
+        return sum % 11;
     }
 
     static int firstDigit(int birthYear, PersonIdNumber.Gender gender) {

--- a/src/main/java/net/datafaker/idnumbers/HungarianIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/HungarianIdNumber.java
@@ -64,12 +64,12 @@ public class HungarianIdNumber implements IdNumberGenerator {
 
     static int getCheckDigit(String basePart) {
         char[] numbers = basePart.toCharArray();
-        int sum = 0;
+        int summ = 0;
         for (int i = 0; i < numbers.length; i++) {
-            sum += getNumericValue(numbers[i]) * (i + 1);
+            summ += getNumericValue(numbers[i]) * (i + 1);
         }
 
-        return sum % 11;
+        return summ % 11;
     }
 
     static int firstDigit(int birthYear, PersonIdNumber.Gender gender) {

--- a/src/main/java/net/datafaker/idnumbers/IdNumberGenerator.java
+++ b/src/main/java/net/datafaker/idnumbers/IdNumberGenerator.java
@@ -27,7 +27,7 @@ public interface IdNumberGenerator {
     String generateInvalid(BaseProviders faker);
 
     /**
-     * Generates a valid ID number for given country corresponding to given criteria (age range, gender etc.)
+     * Generates a valid ID number for given country corresponding to given criterias (age range, gender etc.)
      *
      * @return PersonIdNumber containing a valid combination of ID, Birthday and Gender.
      * In countries where ID number doesn't contain gender and/or birthday, the latter values are just random.

--- a/src/main/java/net/datafaker/idnumbers/IdNumberGenerator.java
+++ b/src/main/java/net/datafaker/idnumbers/IdNumberGenerator.java
@@ -27,7 +27,7 @@ public interface IdNumberGenerator {
     String generateInvalid(BaseProviders faker);
 
     /**
-     * Generates a valid ID number for given country corresponding to given criterias (age range, gender etc.)
+     * Generates a valid ID number for given country corresponding to given criteria (age range, gender etc.)
      *
      * @return PersonIdNumber containing a valid combination of ID, Birthday and Gender.
      * In countries where ID number doesn't contain gender and/or birthday, the latter values are just random.

--- a/src/main/java/net/datafaker/idnumbers/PolishIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/PolishIdNumber.java
@@ -4,6 +4,7 @@ import net.datafaker.providers.base.BaseProviders;
 import net.datafaker.providers.base.IdNumber.GenderRequest;
 import net.datafaker.providers.base.IdNumber.IdNumberRequest;
 import net.datafaker.providers.base.PersonIdNumber;
+import org.jspecify.annotations.Nullable;
 
 import java.time.LocalDate;
 
@@ -52,7 +53,7 @@ public class PolishIdNumber implements IdNumberGenerator {
         return get(faker, birthDate, gender);
     }
 
-    private static PersonIdNumber.Gender pickGender(BaseProviders faker, Gender requestedGender) {
+    private static PersonIdNumber.Gender pickGender(BaseProviders faker, @Nullable Gender requestedGender) {
         return requestedGender == null ? randomGender(faker) :
             switch (requestedGender) {
                 case ANY -> randomGender(faker);

--- a/src/main/java/net/datafaker/idnumbers/package-info.java
+++ b/src/main/java/net/datafaker/idnumbers/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.idnumbers;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtil.java
+++ b/src/main/java/net/datafaker/idnumbers/pt/br/IdNumberGeneratorPtBrUtil.java
@@ -108,7 +108,7 @@ public final class IdNumberGeneratorPtBrUtil {
 
     /**
      * Return true if the CPF is valid
-     * A valid CPF is unique and have a algorithm to validate it
+     * A valid CPF is unique and have an algorithm to validate it
      * <p>
      * CPF generator could generate a valid or invalid because, sometimes, we need to test a
      * registration with invalid number

--- a/src/main/java/net/datafaker/idnumbers/pt/br/package-info.java
+++ b/src/main/java/net/datafaker/idnumbers/pt/br/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.idnumbers.pt.br;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/internal/helper/JavaNames.java
+++ b/src/main/java/net/datafaker/internal/helper/JavaNames.java
@@ -1,5 +1,7 @@
 package net.datafaker.internal.helper;
 
+import org.jspecify.annotations.Nullable;
+
 import static java.lang.Character.isLetter;
 import static java.lang.Character.toLowerCase;
 import static java.lang.Character.toUpperCase;
@@ -8,7 +10,8 @@ import static net.datafaker.internal.helper.JavaNames.Transform.TO_LOWER;
 import static net.datafaker.internal.helper.JavaNames.Transform.TO_UPPER;
 
 public class JavaNames {
-    public static String toJavaNames(String string, boolean isMethod) {
+    @Nullable
+    public static String toJavaNames(@Nullable String string, boolean isMethod) {
         if (string == null || string.isEmpty()) return string;
 
         int length = string.length();

--- a/src/main/java/net/datafaker/internal/helper/LazyEvaluated.java
+++ b/src/main/java/net/datafaker/internal/helper/LazyEvaluated.java
@@ -1,8 +1,13 @@
 package net.datafaker.internal.helper;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
+
 public class LazyEvaluated<T> {
+    @Nullable
     private volatile T value;
     private final Supplier<T> supplier;
 
@@ -18,6 +23,6 @@ public class LazyEvaluated<T> {
                 }
             }
         }
-        return value;
+        return requireNonNull(value, "Null value not allowed");
     }
 }

--- a/src/main/java/net/datafaker/internal/helper/SingletonLocale.java
+++ b/src/main/java/net/datafaker/internal/helper/SingletonLocale.java
@@ -1,15 +1,17 @@
 package net.datafaker.internal.helper;
 
-import java.util.HashMap;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class allows to use {@link java.util.IdentityHashMap} for locales.
  * To do that it guarantees one instance of {@link SingletonLocale} per {@link Locale}.
  */
 public class SingletonLocale {
-    private static final Map<Locale, SingletonLocale> LOCALE2SINGLETON_LOCALE = new HashMap<>();
+    private static final Map<Locale, SingletonLocale> LOCALE2SINGLETON_LOCALE = new ConcurrentHashMap<>();
     private final Locale locale;
 
     // Hash code is required for FakerContext where SingletonLocale is a field
@@ -19,23 +21,16 @@ public class SingletonLocale {
         this.locale = locale;
     }
 
-    public static SingletonLocale get(Locale locale) {
+    @Nullable
+    public static SingletonLocale get(@Nullable Locale locale) {
         if (locale == null) {
             return null;
         }
-        SingletonLocale res = LOCALE2SINGLETON_LOCALE.get(locale);
-        if (res != null) {
-            return res;
-        }
-        synchronized (SingletonLocale.class) {
-            res = LOCALE2SINGLETON_LOCALE.get(locale);
-            if (res != null) {
-                return res;
-            }
-            res = new SingletonLocale(locale);
-            LOCALE2SINGLETON_LOCALE.put(locale, res);
-            return res;
-        }
+        return getRequired(locale);
+    }
+
+    public static SingletonLocale getRequired(Locale locale) {
+        return LOCALE2SINGLETON_LOCALE.computeIfAbsent(locale, (__) -> new SingletonLocale(locale));
     }
 
     public Locale getLocale() {

--- a/src/main/java/net/datafaker/internal/helper/SingletonLocale.java
+++ b/src/main/java/net/datafaker/internal/helper/SingletonLocale.java
@@ -30,7 +30,19 @@ public class SingletonLocale {
     }
 
     public static SingletonLocale getRequired(Locale locale) {
-        return LOCALE2SINGLETON_LOCALE.computeIfAbsent(locale, (__) -> new SingletonLocale(locale));
+        SingletonLocale res = LOCALE2SINGLETON_LOCALE.get(locale);
+        if (res != null) {
+            return res;
+        }
+        synchronized (SingletonLocale.class) {
+            res = LOCALE2SINGLETON_LOCALE.get(locale);
+            if (res != null) {
+                return res;
+            }
+            res = new SingletonLocale(locale);
+            LOCALE2SINGLETON_LOCALE.put(locale, res);
+            return res;
+        }
     }
 
     public Locale getLocale() {

--- a/src/main/java/net/datafaker/internal/helper/WordUtils.java
+++ b/src/main/java/net/datafaker/internal/helper/WordUtils.java
@@ -1,10 +1,21 @@
 package net.datafaker.internal.helper;
 
+import org.jspecify.annotations.Nullable;
 
 public class WordUtils {
 
-    public static String capitalize(String input) {
+    /**
+     * @deprecated Use {@link #capitalizeWords(String)} instead -
+     *      it doesn't accept nulls, and doesn't return nulls.
+     */
+    @Deprecated
+    @Nullable
+    public static String capitalize(@Nullable String input) {
         if (input == null) return null;
+        return capitalizeWords(input);
+    }
+
+    public static String capitalizeWords(String input) {
         if (input.isEmpty()) return input;
         final char ch0 = input.charAt(0);
         if (Character.isUpperCase(ch0)) return input;

--- a/src/main/java/net/datafaker/internal/helper/package-info.java
+++ b/src/main/java/net/datafaker/internal/helper/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.internal.helper;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/package-info.java
+++ b/src/main/java/net/datafaker/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/base/Animal.java
+++ b/src/main/java/net/datafaker/providers/base/Animal.java
@@ -1,6 +1,6 @@
 package net.datafaker.providers.base;
 
-import net.datafaker.internal.helper.WordUtils;
+import static net.datafaker.internal.helper.WordUtils.capitalizeWords;
 
 /**
  * @since 0.8.0
@@ -20,7 +20,7 @@ public class Animal extends AbstractProvider<BaseProviders> {
     }
 
     public String genus() {
-        return WordUtils.capitalize(faker.resolve("creature.animal.genus"));
+        return capitalizeWords(faker.resolve("creature.animal.genus"));
     }
 
     public String species() {

--- a/src/main/java/net/datafaker/providers/base/Barcode.java
+++ b/src/main/java/net/datafaker/providers/base/Barcode.java
@@ -55,9 +55,9 @@ public class Barcode extends AbstractProvider<BaseProviders> {
         while (number > 0) {
             i++;
             if (i % 2 == 1) {
-                odd += (int) (number % 10);
+                odd += number % 10;
             } else {
-                even += (int) (number % 10);
+                even += number % 10;
             }
 
             number /= 10;

--- a/src/main/java/net/datafaker/providers/base/Barcode.java
+++ b/src/main/java/net/datafaker/providers/base/Barcode.java
@@ -55,9 +55,9 @@ public class Barcode extends AbstractProvider<BaseProviders> {
         while (number > 0) {
             i++;
             if (i % 2 == 1) {
-                odd += number % 10;
+                odd += (int) (number % 10);
             } else {
-                even += number % 10;
+                even += (int) (number % 10);
             }
 
             number /= 10;

--- a/src/main/java/net/datafaker/providers/base/BaseFaker.java
+++ b/src/main/java/net/datafaker/providers/base/BaseFaker.java
@@ -8,6 +8,7 @@ import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.FakerContext;
 import net.datafaker.service.RandomService;
 import net.datafaker.transformations.Schema;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -47,7 +48,7 @@ public class BaseFaker implements BaseProviders {
         this(Locale.ENGLISH, random);
     }
 
-    public BaseFaker(Locale locale, Random random) {
+    public BaseFaker(Locale locale, @Nullable Random random) {
         this(locale, new RandomService(random));
     }
 
@@ -59,7 +60,7 @@ public class BaseFaker implements BaseProviders {
         this(fakeValuesService, context, EVERY_PROVIDER_ALLOWED);
     }
 
-    public BaseFaker(FakeValuesService fakeValuesService, FakerContext context, Predicate<Class<?>> whiteListPredicate) {
+    public BaseFaker(FakeValuesService fakeValuesService, FakerContext context, @Nullable Predicate<Class<?>> whiteListPredicate) {
         this.fakeValuesService = fakeValuesService;
         this.context = context;
         this.whiteListPredicate = whiteListPredicate == null ? EVERY_PROVIDER_ALLOWED : whiteListPredicate;
@@ -430,7 +431,8 @@ public class BaseFaker implements BaseProviders {
         return (B) this;
     }
 
-    public static Method getMethod(AbstractProvider<?> ap, String methodName) {
+    @Nullable
+    public static Method getMethod(@Nullable AbstractProvider<?> ap, String methodName) {
         return ap == null ? null : ObjectMethods.getMethodByName(ap, methodName);
     }
 

--- a/src/main/java/net/datafaker/providers/base/BaseFaker.java
+++ b/src/main/java/net/datafaker/providers/base/BaseFaker.java
@@ -8,6 +8,7 @@ import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.FakerContext;
 import net.datafaker.service.RandomService;
 import net.datafaker.transformations.Schema;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -49,7 +50,7 @@ public class BaseFaker implements BaseProviders {
         this(Locale.ENGLISH, random);
     }
 
-    public BaseFaker(Locale locale, Random random) {
+    public BaseFaker(Locale locale, @Nullable Random random) {
         this(locale, new RandomService(random));
     }
 
@@ -61,7 +62,7 @@ public class BaseFaker implements BaseProviders {
         this(fakeValuesService, context, EVERY_PROVIDER_ALLOWED);
     }
 
-    public BaseFaker(FakeValuesService fakeValuesService, FakerContext context, Predicate<Class<?>> whiteListPredicate) {
+    public BaseFaker(FakeValuesService fakeValuesService, FakerContext context, @Nullable Predicate<Class<?>> whiteListPredicate) {
         this.fakeValuesService = fakeValuesService;
         this.context = context;
         this.whiteListPredicate = whiteListPredicate == null ? EVERY_PROVIDER_ALLOWED : whiteListPredicate;
@@ -432,7 +433,8 @@ public class BaseFaker implements BaseProviders {
         return (B) this;
     }
 
-    public static Method getMethod(AbstractProvider<?> ap, String methodName) {
+    @Nullable
+    public static Method getMethod(@Nullable AbstractProvider<?> ap, String methodName) {
         return ap == null ? null : ObjectMethods.getMethodByName(ap, methodName);
     }
 

--- a/src/main/java/net/datafaker/providers/base/Compass.java
+++ b/src/main/java/net/datafaker/providers/base/Compass.java
@@ -1,5 +1,7 @@
 package net.datafaker.providers.base;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @since 1.7.0
  */
@@ -18,6 +20,7 @@ public class Compass extends AbstractProvider<BaseProviders> {
         }
     }
 
+    @Nullable
     private CompassPoint compassPoint;
 
     protected Compass(BaseProviders faker) {

--- a/src/main/java/net/datafaker/providers/base/Credentials.java
+++ b/src/main/java/net/datafaker/providers/base/Credentials.java
@@ -144,7 +144,6 @@ public class Credentials extends AbstractProvider<BaseProviders> {
 
     /**
      * Generates a user ID based on the regex pattern defined in the resource file.
-     * If the regex is null or invalid, it returns null.
      *
      * @return A randomly generated user ID
      */

--- a/src/main/java/net/datafaker/providers/base/Credentials.java
+++ b/src/main/java/net/datafaker/providers/base/Credentials.java
@@ -149,8 +149,7 @@ public class Credentials extends AbstractProvider<BaseProviders> {
      * @return A randomly generated user ID
      */
     public String userId() {
-        String regex = resolve("credentials.uid_pattern");
-        return faker.regexify(regex);
+        return faker.regexify(resolve("credentials.uid_pattern"));
     }
 
     /**

--- a/src/main/java/net/datafaker/providers/base/Credentials.java
+++ b/src/main/java/net/datafaker/providers/base/Credentials.java
@@ -1,7 +1,12 @@
 package net.datafaker.providers.base;
 
+import org.jspecify.annotations.Nullable;
+
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import static java.util.logging.Level.WARNING;
 
 /**
  * Generates credentials such as usernames, uids and passwords.
@@ -12,6 +17,7 @@ public class Credentials extends AbstractProvider<BaseProviders> {
 
     public static final int MIN_PASSWORD_LENGTH = 8;
     public static final int MAX_PASSWORD_LENGTH = 16;
+    private static final Logger log = Logger.getLogger(Credentials.class.getName());
 
     protected Credentials(BaseProviders faker) {
         super(faker);
@@ -142,6 +148,7 @@ public class Credentials extends AbstractProvider<BaseProviders> {
      *
      * @return A randomly generated user ID based on the regex or null if the regex is null or invalid
      */
+    @Nullable
     public String userId() {
         return userId(resolve("credentials.uid_pattern"));
     }
@@ -153,7 +160,8 @@ public class Credentials extends AbstractProvider<BaseProviders> {
      * @param regex The regex pattern to generate the user ID
      * @return A randomly generated user ID based on the regex or null if the regex is null or invalid
      */
-    public String userId(String regex) {
+    @Nullable
+    public String userId(@Nullable String regex) {
         if(regex == null) {
             return null;
         }
@@ -161,6 +169,7 @@ public class Credentials extends AbstractProvider<BaseProviders> {
         try {
             Pattern.compile(regex);
         } catch (PatternSyntaxException e) {
+            log.log(WARNING, e, () -> "Invalid regex pattern: " + regex);
             return null;
         }
 

--- a/src/main/java/net/datafaker/providers/base/Credentials.java
+++ b/src/main/java/net/datafaker/providers/base/Credentials.java
@@ -146,11 +146,11 @@ public class Credentials extends AbstractProvider<BaseProviders> {
      * Generates a user ID based on the regex pattern defined in the resource file.
      * If the regex is null or invalid, it returns null.
      *
-     * @return A randomly generated user ID based on the regex or null if the regex is null or invalid
+     * @return A randomly generated user ID
      */
-    @Nullable
     public String userId() {
-        return userId(resolve("credentials.uid_pattern"));
+        String regex = resolve("credentials.uid_pattern");
+        return faker.regexify(regex);
     }
 
     /**

--- a/src/main/java/net/datafaker/providers/base/File.java
+++ b/src/main/java/net/datafaker/providers/base/File.java
@@ -1,5 +1,7 @@
 package net.datafaker.providers.base;
 
+import org.jspecify.annotations.Nullable;
+
 import java.nio.file.FileSystems;
 
 /**
@@ -23,7 +25,7 @@ public class File extends AbstractProvider<BaseProviders> {
         return fileName(null, null, null, null);
     }
 
-    public String fileName(String dirOrNull, String nameOrNull, String extensionOrNull, String separatorOrNull) {
+    public String fileName(@Nullable String dirOrNull, @Nullable String nameOrNull, @Nullable String extensionOrNull, @Nullable String separatorOrNull) {
         final String sep = separatorOrNull == null ? FileSystems.getDefault().getSeparator() : separatorOrNull;
         final String dir = dirOrNull == null ? faker.internet().slug() : dirOrNull;
         final String name = nameOrNull == null ? faker.lorem().word().toLowerCase(faker.getContext().getLocale()) : nameOrNull;

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -2,6 +2,7 @@ package net.datafaker.providers.base;
 
 import net.datafaker.internal.helper.FakerIDN;
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -339,7 +340,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
      * @param prefix a prefix to put on the front of the address
      * @return a correctly formatted MAC address
      */
-    public String macAddress(String prefix) {
+    public String macAddress(@Nullable String prefix) {
         final String tmp = (prefix == null) ? "" : prefix;
         final int prefixLength = tmp.trim().isEmpty()
             ? 0
@@ -498,7 +499,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
      * @param glueOrNull  if null, "_"
      * @return a slug string combining wordsOrNull with glueOrNull (ex. x_y)
      */
-    public String slug(List<String> wordsOrNull, String glueOrNull) {
+    public String slug(@Nullable List<String> wordsOrNull, @Nullable String glueOrNull) {
         final String glue = glueOrNull == null
             ? "_"
             : glueOrNull;
@@ -575,7 +576,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         return src[faker.random().nextInt(src.length)];
     }
 
-    public String userAgent(UserAgent userAgent) {
+    public String userAgent(@Nullable UserAgent userAgent) {
         UserAgent agent = userAgent;
 
         if (agent == null) {
@@ -618,7 +619,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         }
     }
 
-    public String botUserAgent(BotUserAgent vendor) {
+    public String botUserAgent(@Nullable BotUserAgent vendor) {
         BotUserAgent agent = vendor;
 
         if (agent == null) {
@@ -648,9 +649,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         }
 
         private static BotUserAgent any(BaseProviders faker) {
-            BotUserAgent[] agents = BotUserAgent.values();
-            int randomIndex = (int) (faker.random().nextDouble() * agents.length);
-            return agents[randomIndex];
+            return faker.random().nextEnum(BotUserAgent.class);
         }
 
         @Override

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -2,6 +2,7 @@ package net.datafaker.providers.base;
 
 import net.datafaker.internal.helper.FakerIDN;
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -338,7 +339,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
      * @param prefix a prefix to put on the front of the address
      * @return a correctly formatted MAC address
      */
-    public String macAddress(String prefix) {
+    public String macAddress(@Nullable String prefix) {
         final String tmp = (prefix == null) ? "" : prefix;
         final int prefixLength = tmp.trim().isEmpty()
             ? 0
@@ -497,7 +498,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
      * @param glueOrNull  if null, "_"
      * @return a slug string combining wordsOrNull with glueOrNull (ex. x_y)
      */
-    public String slug(List<String> wordsOrNull, String glueOrNull) {
+    public String slug(@Nullable List<String> wordsOrNull, @Nullable String glueOrNull) {
         final String glue = glueOrNull == null
             ? "_"
             : glueOrNull;
@@ -574,7 +575,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         return src[faker.random().nextInt(src.length)];
     }
 
-    public String userAgent(UserAgent userAgent) {
+    public String userAgent(@Nullable UserAgent userAgent) {
         UserAgent agent = userAgent;
 
         if (agent == null) {
@@ -617,7 +618,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         }
     }
 
-    public String botUserAgent(BotUserAgent vendor) {
+    public String botUserAgent(@Nullable BotUserAgent vendor) {
         BotUserAgent agent = vendor;
 
         if (agent == null) {
@@ -647,9 +648,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         }
 
         private static BotUserAgent any(BaseProviders faker) {
-            BotUserAgent[] agents = BotUserAgent.values();
-            int randomIndex = (int) (faker.random().nextDouble() * agents.length);
-            return agents[randomIndex];
+            return faker.random().nextEnum(BotUserAgent.class);
         }
 
         @Override

--- a/src/main/java/net/datafaker/providers/base/Lorem.java
+++ b/src/main/java/net/datafaker/providers/base/Lorem.java
@@ -1,9 +1,9 @@
 package net.datafaker.providers.base;
 
-import net.datafaker.internal.helper.WordUtils;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import static net.datafaker.internal.helper.WordUtils.capitalizeWords;
 
 
 /**
@@ -113,9 +113,9 @@ public class Lorem extends AbstractProvider<BaseProviders> {
     public String sentence(int wordCount, int randomWordsToAdd) {
         int numberOfWordsToAdd = randomWordsToAdd == 0 ? 0 : faker.random().nextInt(randomWordsToAdd);
         final int totalWordCount = wordCount + numberOfWordsToAdd;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(wordCount * 9);
         if (totalWordCount > 0) {
-            sb.append(WordUtils.capitalize(word()));
+            sb.append(capitalizeWords(word()));
         }
         for (int i = 1; i < totalWordCount; i++) {
             sb.append(" ").append(word());

--- a/src/main/java/net/datafaker/providers/base/Lorem.java
+++ b/src/main/java/net/datafaker/providers/base/Lorem.java
@@ -113,7 +113,7 @@ public class Lorem extends AbstractProvider<BaseProviders> {
     public String sentence(int wordCount, int randomWordsToAdd) {
         int numberOfWordsToAdd = randomWordsToAdd == 0 ? 0 : faker.random().nextInt(randomWordsToAdd);
         final int totalWordCount = wordCount + numberOfWordsToAdd;
-        StringBuilder sb = new StringBuilder(wordCount * 9);
+        StringBuilder sb = new StringBuilder();
         if (totalWordCount > 0) {
             sb.append(capitalizeWords(word()));
         }

--- a/src/main/java/net/datafaker/providers/base/Name.java
+++ b/src/main/java/net/datafaker/providers/base/Name.java
@@ -152,7 +152,6 @@ public class Name extends AbstractProvider<BaseProviders> {
      * @see Name#lastName()
      */
     @Deprecated(since = "2.5.0", forRemoval = true)
-    @SuppressWarnings("removal")
     public String username() {
         return faker.credentials().username();
     }

--- a/src/main/java/net/datafaker/providers/base/ObjectMethods.java
+++ b/src/main/java/net/datafaker/providers/base/ObjectMethods.java
@@ -1,5 +1,7 @@
 package net.datafaker.providers.base;
 
+import org.jspecify.annotations.Nullable;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.IdentityHashMap;
@@ -44,11 +46,13 @@ public class ObjectMethods {
         return METHODS_BY_NAME.computeIfAbsent(object.getClass(), ObjectMethods::scanMethodsByName).get(methodName);
     }
 
+    @Nullable
     private static Method getMethodByReturnType(Object object, String returnTypeSimpleName) {
         return METHODS_BY_RETURN_TYPE.computeIfAbsent(object.getClass(), ObjectMethods::scanMethodsByReturnType).get(returnTypeSimpleName);
     }
 
     @SuppressWarnings("unchecked")
+    @Nullable
     public static <T> T executeMethodByReturnType(Object object, String returnTypeSimpleName) {
         try {
             Method method = getMethodByReturnType(object, returnTypeSimpleName);

--- a/src/main/java/net/datafaker/providers/base/ObjectMethods.java
+++ b/src/main/java/net/datafaker/providers/base/ObjectMethods.java
@@ -1,5 +1,7 @@
 package net.datafaker.providers.base;
 
+import org.jspecify.annotations.Nullable;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.IdentityHashMap;
@@ -45,11 +47,13 @@ public class ObjectMethods {
         return METHODS_BY_NAME.computeIfAbsent(object.getClass(), ObjectMethods::scanMethodsByName).get(methodName);
     }
 
+    @Nullable
     private static Method getMethodByReturnType(Object object, String returnTypeSimpleName) {
         return METHODS_BY_RETURN_TYPE.computeIfAbsent(object.getClass(), ObjectMethods::scanMethodsByReturnType).get(returnTypeSimpleName);
     }
 
     @SuppressWarnings("unchecked")
+    @Nullable
     public static <T> T executeMethodByReturnType(Object object, String returnTypeSimpleName) {
         try {
             Method method = getMethodByReturnType(object, returnTypeSimpleName);

--- a/src/main/java/net/datafaker/providers/base/Options.java
+++ b/src/main/java/net/datafaker/providers/base/Options.java
@@ -71,6 +71,7 @@ public class Options extends AbstractProvider<BaseProviders> {
      * If size is zero then an empty subset will be returned.
      * If size is larger than a unique set from options then all options will be returned.
      */
+    @SuppressWarnings("unchecked")
     public final <E> Set<E> subset(int size, E... options) {
         if (size < 0) {
             throw new IllegalArgumentException("size should be not negative: " + size);

--- a/src/main/java/net/datafaker/providers/base/Options.java
+++ b/src/main/java/net/datafaker/providers/base/Options.java
@@ -70,6 +70,7 @@ public class Options extends AbstractProvider<BaseProviders> {
      * If size is zero then an empty subset will be returned.
      * If size is larger than a unique set from options then all options will be returned.
      */
+    @SuppressWarnings("unchecked")
     public final <E> Set<E> subset(int size, E... options) {
         if (size < 0) {
             throw new IllegalArgumentException("size should be not negative: " + size);

--- a/src/main/java/net/datafaker/providers/base/ProviderRegistration.java
+++ b/src/main/java/net/datafaker/providers/base/ProviderRegistration.java
@@ -3,6 +3,7 @@ package net.datafaker.providers.base;
 import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.FakerContext;
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -16,6 +17,7 @@ public interface ProviderRegistration {
 
     FakerContext getContext();
 
+    @Nullable
     default <PR extends ProviderRegistration, AP extends AbstractProvider<PR>> AP getProvider(String simpleClassName) {
         return ObjectMethods.executeMethodByReturnType(this, simpleClassName);
     }

--- a/src/main/java/net/datafaker/providers/base/Twitter.java
+++ b/src/main/java/net/datafaker/providers/base/Twitter.java
@@ -1,6 +1,7 @@
 package net.datafaker.providers.base;
 
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -100,7 +101,7 @@ public class Twitter extends AbstractProvider<BaseProviders> {
      * @param wordMaxLength     each word should be in range of the word max length.
      * @return a new fake text for the Twitter.
      */
-    public String text(String[] keywords, int sentenceMaxLength, int wordMaxLength) {
+    public String text(String @Nullable [] keywords, int sentenceMaxLength, int wordMaxLength) {
         if (wordMaxLength <= 2) {
             LOGGER.warning("Word length less than 2 is dangerous. Exceptions can be raised.");
         }

--- a/src/main/java/net/datafaker/providers/base/Vehicle.java
+++ b/src/main/java/net/datafaker/providers/base/Vehicle.java
@@ -1,6 +1,8 @@
 package net.datafaker.providers.base;
 
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -119,13 +121,13 @@ public class Vehicle extends AbstractProvider<BaseProviders> {
         return faker.bothify(faker.resolve("vehicle.license_plate")).toUpperCase(Locale.ROOT);
     }
 
+    @Nullable
     public String licensePlate(String stateAbbreviation) {
-
-        if ("".equals(stateAbbreviation)) {
+        if (stateAbbreviation.isEmpty()) {
             return null;
         }
 
         String licensePlatesByState = resolve("vehicle.license_plate_by_state." + stateAbbreviation);
-        return licensePlatesByState == null ? null : faker.bothify(licensePlatesByState).toUpperCase(Locale.ROOT);
+        return faker.bothify(licensePlatesByState).toUpperCase(Locale.ROOT);
     }
 }

--- a/src/main/java/net/datafaker/providers/base/package-info.java
+++ b/src/main/java/net/datafaker/providers/base/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers.base;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/entertainment/package-info.java
+++ b/src/main/java/net/datafaker/providers/entertainment/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers.entertainment;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/food/package-info.java
+++ b/src/main/java/net/datafaker/providers/food/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers.food;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/healthcare/package-info.java
+++ b/src/main/java/net/datafaker/providers/healthcare/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers.healthcare;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/package-info.java
+++ b/src/main/java/net/datafaker/providers/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/sport/package-info.java
+++ b/src/main/java/net/datafaker/providers/sport/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers.sport;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/providers/videogame/package-info.java
+++ b/src/main/java/net/datafaker/providers/videogame/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.providers.videogame;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/sequence/FakeCollection.java
+++ b/src/main/java/net/datafaker/sequence/FakeCollection.java
@@ -1,6 +1,7 @@
 package net.datafaker.sequence;
 
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -16,9 +17,9 @@ public class FakeCollection<T> extends FakeSequence<T> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<T> get() {
+    public List<@Nullable T> get() {
         int size = randomService.nextInt(minLength, maxLength);
-        List<T> result = new ArrayList<>(size);
+        List<@Nullable T> result = new ArrayList<>(size);
         while (result.size() < size) {
             result.add(singleton());
         }
@@ -26,7 +27,7 @@ public class FakeCollection<T> extends FakeSequence<T> {
     }
 
     @Override
-    public Iterator<T> iterator() {
+    public Iterator<@Nullable T> iterator() {
         return get().iterator();
     }
 

--- a/src/main/java/net/datafaker/sequence/FakeSequence.java
+++ b/src/main/java/net/datafaker/sequence/FakeSequence.java
@@ -1,7 +1,9 @@
 package net.datafaker.sequence;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import net.datafaker.providers.base.BaseProviders;
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -27,6 +29,7 @@ public abstract class FakeSequence<T> implements Iterable<T> {
         return false;
     }
 
+    @Nullable
     public T singleton() {
         if (nullRate == 0d || randomService.nextDouble() >= nullRate) {
             return suppliers.get(randomService.nextInt(suppliers.size())).get();
@@ -39,7 +42,7 @@ public abstract class FakeSequence<T> implements Iterable<T> {
         protected int minLength = -1;
         protected int maxLength = -1;
         protected double nullRate = 0d;
-        protected BaseProviders faker;
+        protected @Nullable BaseProviders faker;
 
         protected Builder() {
             suppliers = new ArrayList<>();
@@ -64,6 +67,7 @@ public abstract class FakeSequence<T> implements Iterable<T> {
             return this;
         }
 
+        @CanIgnoreReturnValue
         public FakeSequence.Builder<T> maxLen(int maxLength) {
             this.maxLength = maxLength;
             return this;

--- a/src/main/java/net/datafaker/sequence/FakeStream.java
+++ b/src/main/java/net/datafaker/sequence/FakeStream.java
@@ -1,6 +1,7 @@
 package net.datafaker.sequence;
 
 import net.datafaker.service.RandomService;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Iterator;
 import java.util.List;
@@ -14,7 +15,7 @@ public class FakeStream<T> extends FakeSequence<T> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Stream<T> get() {
+    public Stream<@Nullable T> get() {
         if (isInfinite()) {
             return Stream.generate(this::singleton);
         }
@@ -29,7 +30,7 @@ public class FakeStream<T> extends FakeSequence<T> {
     }
 
     @Override
-    public Iterator<T> iterator() {
+    public Iterator<@Nullable T> iterator() {
         return get().iterator();
     }
 

--- a/src/main/java/net/datafaker/sequence/package-info.java
+++ b/src/main/java/net/datafaker/sequence/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.sequence;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -1,6 +1,7 @@
 package net.datafaker.service;
 
 import net.datafaker.internal.helper.LazyEvaluated;
+import org.jspecify.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -29,11 +30,13 @@ public class FakeValues implements FakeValuesInterface {
         return FAKE_VALUES_MAP.computeIfAbsent(fakeValuesContext, FakeValues::new);
     }
 
+    @Nullable
     @Override
     public Map<String, Object> get(String key) {
         return getMap(values.get(), key);
     }
 
+    @Nullable
     private Map<String, Object> loadFromUrl() {
         final URL url = fakeValuesContext.getUrl();
         if (url == null) {
@@ -81,7 +84,7 @@ public class FakeValues implements FakeValuesInterface {
         return emptyMap();
     }
 
-    private void enrichMapWithJavaNames(Map<String, Object> result) {
+    private void enrichMapWithJavaNames(@Nullable Map<String, Object> result) {
         if (result != null) {
             Map<String, Object> map = null;
             for (Map.Entry<String, Object> entry : result.entrySet()) {
@@ -110,7 +113,8 @@ public class FakeValues implements FakeValuesInterface {
         }
     }
 
-    private Map<String, Object> readFromStream(InputStream stream) {
+    @Nullable
+    private Map<String, Object> readFromStream(@Nullable InputStream stream) {
         if (stream == null) return null;
         final Map<String, Object> valuesMap = new Yaml().loadAs(stream, Map.class);
         Map<String, Object> localeBased = getMap(valuesMap, fakeValuesContext.getLocale().getLanguage());
@@ -120,18 +124,21 @@ public class FakeValues implements FakeValuesInterface {
         return getMap(localeBased, "faker");
     }
 
+    @Nullable
     @SuppressWarnings("unchecked")
     private static Map<String, Object> getMap(Map<String, Object> map, String key) {
         return (Map<String, Object>) map.get(key);
     }
 
+    @Nullable
     Set<String> getPaths() {
         return fakeValuesContext.getPath() != null ?
             Set.of(fakeValuesContext.getPath()) :
             keysOf(values.get());
     }
 
-    private static Set<String> keysOf(Map<String, ?> map) {
+    @Nullable
+    private static Set<String> keysOf(@Nullable Map<String, ?> map) {
         return map == null || map.isEmpty() ? null : map.keySet();
     }
 

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -1,7 +1,6 @@
 package net.datafaker.service;
 
 import net.datafaker.internal.helper.LazyEvaluated;
-import net.datafaker.internal.helper.WordUtils;
 import org.jspecify.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;
 
@@ -17,6 +16,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static net.datafaker.internal.helper.JavaNames.toJavaNames;
+import static net.datafaker.internal.helper.WordUtils.capitalizeWords;
 
 public class FakeValues implements FakeValuesInterface {
     private static final Map<FakeValuesContext, FakeValues> FAKE_VALUES_MAP = new ConcurrentHashMap<>();
@@ -136,7 +136,7 @@ public class FakeValues implements FakeValuesInterface {
     }
 
     private static void rewriteList(List<Object> list, String providerKey) {
-        final String capitalizedProvider = WordUtils.capitalize(providerKey);
+        final String capitalizedProvider = capitalizeWords(providerKey);
         for (int i = 0; i < list.size(); i++) {
             Object itemValue = list.get(i);
             if (!(itemValue instanceof String item)) {

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -2,6 +2,7 @@ package net.datafaker.service;
 
 import net.datafaker.internal.helper.LazyEvaluated;
 import net.datafaker.internal.helper.WordUtils;
+import org.jspecify.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -30,11 +31,13 @@ public class FakeValues implements FakeValuesInterface {
         return FAKE_VALUES_MAP.computeIfAbsent(fakeValuesContext, FakeValues::new);
     }
 
+    @Nullable
     @Override
     public Map<String, Object> get(String key) {
         return getMap(values.get(), key);
     }
 
+    @Nullable
     private Map<String, Object> loadFromUrl() {
         final URL url = fakeValuesContext.getUrl();
         if (url == null) {
@@ -84,7 +87,7 @@ public class FakeValues implements FakeValuesInterface {
         return Map.of();
     }
 
-    private void enrichMapWithJavaNames(Map<String, Object> result) {
+    private void enrichMapWithJavaNames(@Nullable Map<String, Object> result) {
         if (result != null) {
             Map<String, Object> map = null;
             for (var entry : result.entrySet()) {
@@ -176,7 +179,8 @@ public class FakeValues implements FakeValuesInterface {
         }
     }
 
-    private Map<String, Object> readFromStream(InputStream stream) {
+    @Nullable
+    private Map<String, Object> readFromStream(@Nullable InputStream stream) {
         if (stream == null) return null;
         final Map<String, Object> valuesMap = new Yaml().loadAs(stream, Map.class);
         Map<String, Object> localeBased = getMap(valuesMap, fakeValuesContext.getLocale().getLanguage());
@@ -186,18 +190,21 @@ public class FakeValues implements FakeValuesInterface {
         return getMap(localeBased, "faker");
     }
 
+    @Nullable
     @SuppressWarnings("unchecked")
     private static Map<String, Object> getMap(Map<String, Object> map, String key) {
         return (Map<String, Object>) map.get(key);
     }
 
+    @Nullable
     Set<String> getPaths() {
         return fakeValuesContext.getPath() != null ?
             Set.of(fakeValuesContext.getPath()) :
             keysOf(values.get());
     }
 
-    private static Set<String> keysOf(Map<String, ?> map) {
+    @Nullable
+    private static Set<String> keysOf(@Nullable Map<String, ?> map) {
         return map == null || map.isEmpty() ? null : map.keySet();
     }
 

--- a/src/main/java/net/datafaker/service/FakeValuesContext.java
+++ b/src/main/java/net/datafaker/service/FakeValuesContext.java
@@ -1,18 +1,21 @@
 package net.datafaker.service;
 
 import net.datafaker.internal.helper.SingletonLocale;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 class FakeValuesContext {
     private final SingletonLocale singletonLocale;
-    private final String filename;
+    private @Nullable final String filename;
     private final int filenameHashCode;
-    private final String path;
-    private final URL url;
+    private @Nullable final String path;
+    private @Nullable final URL url;
     private final int urlHashCode;
 
     private FakeValuesContext(Locale locale) {
@@ -27,8 +30,8 @@ class FakeValuesContext {
         this(locale, filename, path, null);
     }
 
-    private FakeValuesContext(Locale locale, String filename, String path, URL url) {
-        this.singletonLocale = SingletonLocale.get(locale);
+    private FakeValuesContext(Locale locale, @Nullable String filename, @Nullable String path, @Nullable URL url) {
+        this.singletonLocale = requireNonNull(SingletonLocale.get(locale), () -> "Unsupported locale " + locale);
         this.filename = filename;
         this.path = path;
         this.url = url;
@@ -84,14 +87,17 @@ class FakeValuesContext {
         return singletonLocale.getLocale();
     }
 
+    @Nullable
     public String getFilename() {
         return filename;
     }
 
+    @Nullable
     String getPath() {
         return path;
     }
 
+    @Nullable
     public URL getUrl() {
         return url;
     }
@@ -111,7 +117,7 @@ class FakeValuesContext {
 
     @Override
     public int hashCode() {
-        int result = singletonLocale == null ? 0 : singletonLocale.hashCode();
+        int result = singletonLocale.hashCode();
         result = 31 * result + filenameHashCode;
         result = 31 * result + (path == null ? 0 : path.hashCode());
         result = 31 * result + urlHashCode;

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -1,13 +1,15 @@
 package net.datafaker.service;
 
 import net.datafaker.service.files.EnFile;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+
+import static java.util.Collections.emptyList;
 
 public final class FakeValuesGrouping implements FakeValuesInterface {
     private static final FakeValuesGrouping ENGLISH_FAKE_VALUE_GROUPING = new FakeValuesGrouping();
@@ -38,16 +40,18 @@ public final class FakeValuesGrouping implements FakeValuesInterface {
         }
     }
 
+    @Nullable
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public Map get(String key) {
-        Map result = null;
-        for (FakeValuesInterface fakeValues : fakeValues.getOrDefault(key, Collections.emptyList())) {
+    public Map<String, Object> get(String key) {
+        Map<String, Object> result = null;
+        for (FakeValuesInterface fakeValues : fakeValues.getOrDefault(key, emptyList())) {
             if (result == null) {
                 result = fakeValues.get(key);
             } else {
-                final Map newResult = fakeValues.get(key);
-                result.putAll(newResult);
+                Map<String, Object> newResult = fakeValues.get(key);
+                if (newResult != null) {
+                    result.putAll(newResult);
+                }
             }
         }
         return result;

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -6,7 +6,6 @@ import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -1,6 +1,7 @@
 package net.datafaker.service;
 
 import net.datafaker.service.files.EnFile;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -8,6 +9,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import static java.util.Collections.emptyList;
 
 public final class FakeValuesGrouping implements FakeValuesInterface {
     private static final FakeValuesGrouping ENGLISH_FAKE_VALUE_GROUPING = new FakeValuesGrouping();
@@ -38,16 +41,19 @@ public final class FakeValuesGrouping implements FakeValuesInterface {
         }
     }
 
+    @Nullable
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public Map get(String key) {
-        Map result = null;
-        for (FakeValuesInterface fakeValues : fakeValues.getOrDefault(key, List.of())) {
+    public Map<String, Object> get(String key) {
+        Map<String, Object> result = null;
+        for (FakeValuesInterface fakeValues : fakeValues.getOrDefault(key, emptyList())) {
             if (result == null) {
                 result = fakeValues.get(key);
             } else {
-                final Map newResult = fakeValues.get(key);
-                result.putAll(newResult);
+                Map<String, Object> newResult = fakeValues.get(key);
+                if (newResult != null) {
+                    result.putAll(newResult);
+                }
             }
         }
         return result;

--- a/src/main/java/net/datafaker/service/FakeValuesInterface.java
+++ b/src/main/java/net/datafaker/service/FakeValuesInterface.java
@@ -1,7 +1,10 @@
 package net.datafaker.service;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 
 public interface FakeValuesInterface {
+    @Nullable
     Map<String, Object> get(String key);
 }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -106,8 +106,9 @@ public class FakeValuesService {
      * @param path   path to a file with YAML structure
      * @throws IllegalArgumentException in case of invalid path
      */
-    public void addPath(Locale locale, @Nullable Path path) {
+    public void addPath(Locale locale, Path path) {
         requireNonNull(locale);
+        //noinspection ConstantValue
         if (path == null || Files.notExists(path) || Files.isDirectory(path) || !Files.isReadable(path)) {
             throw new IllegalArgumentException("Path should be an existing readable file: \"%s\"".formatted(path));
         }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -3,7 +3,6 @@ package net.datafaker.service;
 import com.github.curiousoddman.rgxgen.RgxGen;
 import net.datafaker.internal.helper.CopyOnWriteMap;
 import net.datafaker.internal.helper.SingletonLocale;
-import net.datafaker.internal.helper.WordUtils;
 import net.datafaker.providers.base.AbstractProvider;
 import net.datafaker.providers.base.Address;
 import net.datafaker.providers.base.BaseFaker;
@@ -15,6 +14,7 @@ import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.SimpleField;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
@@ -50,6 +50,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
 import static net.datafaker.internal.helper.JavaNames.toJavaNames;
+import static net.datafaker.internal.helper.WordUtils.capitalizeWords;
 import static net.datafaker.transformations.Field.field;
 
 public class FakeValuesService {
@@ -61,7 +62,7 @@ public class FakeValuesService {
     public static final Supplier<Map<String, String>> MAP_STRING_STRING_SUPPLIER = () -> new CopyOnWriteMap<>(() -> new WeakHashMap<>());
 
     private final Map<SingletonLocale, FakeValuesInterface> fakeValuesInterfaceMap = new CopyOnWriteMap<>(IdentityHashMap::new);
-    public static final SingletonLocale DEFAULT_LOCALE = SingletonLocale.get(Locale.ENGLISH);
+    public static final SingletonLocale DEFAULT_LOCALE = SingletonLocale.getRequired(Locale.ENGLISH);
 
     private static final Map<Class<?>, Map<String, Collection<Method>>> CLASS_2_METHODS_CACHE = new CopyOnWriteMap<>(IdentityHashMap::new);
     private static final Map<Class<?>, Constructor<?>> CLASS_2_CONSTRUCTOR_CACHE = new CopyOnWriteMap<>(IdentityHashMap::new);
@@ -105,7 +106,7 @@ public class FakeValuesService {
      * @param path   path to a file with YAML structure
      * @throws IllegalArgumentException in case of invalid path
      */
-    public void addPath(Locale locale, Path path) {
+    public void addPath(Locale locale, @Nullable Path path) {
         requireNonNull(locale);
         if (path == null || Files.notExists(path) || Files.isDirectory(path) || !Files.isReadable(path)) {
             throw new IllegalArgumentException("Path should be an existing readable file: \"%s\"".formatted(path));
@@ -125,10 +126,8 @@ public class FakeValuesService {
      * @throws IllegalArgumentException in case of invalid url
      */
     public void addUrl(Locale locale, URL url) {
-        requireNonNull(locale);
-        if (url == null) {
-            throw new IllegalArgumentException("url should be an existing readable file");
-        }
+        requireNonNull(locale, "locale is required");
+        requireNonNull(url, "url should be an existing readable file");
         final FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(locale, url));
         final SingletonLocale sLocale = SingletonLocale.get(locale);
         fakeValuesInterfaceMap.merge(sLocale, fakeValues,
@@ -143,6 +142,7 @@ public class FakeValuesService {
     /**
      * Fetch a random value from an array item specified by the key
      */
+    @Nullable
     public Object fetch(String key, FakerContext context) {
         List<?> valuesArray = null;
         final Object o = fetchObject(key, context);
@@ -163,6 +163,7 @@ public class FakeValuesService {
     /**
      * Same as {@link #fetch(String, FakerContext)} but casts the result to a String
      */
+    @Nullable
     public String fetchString(String key, FakerContext context) {
         return (String) fetch(key, context);
     }
@@ -176,6 +177,7 @@ public class FakeValuesService {
             this.context = context;
         }
 
+        @Nullable
         @Override
         public Object resolve() {
             return safeFetch(simpleDirective, context, null);
@@ -203,8 +205,9 @@ public class FakeValuesService {
      * @param defaultIfNull the value to return if the fetched value is null
      * @return see above
      */
+    @Nullable
     @SuppressWarnings("unchecked")
-    public String safeFetch(String key, FakerContext context, String defaultIfNull) {
+    public String safeFetch(String key, FakerContext context, @Nullable String defaultIfNull) {
         Object o = fetchObject(key, context);
         String str;
         if (o == null) return defaultIfNull;
@@ -229,6 +232,7 @@ public class FakeValuesService {
      * @param key key contains path to an object. Path segment is separated by
      *            dot. E.g. name.first_name
      */
+    @Nullable
     @SuppressWarnings("unchecked")
     public <T> T fetchObject(String key, FakerContext context) {
         Object result = null;
@@ -302,7 +306,7 @@ public class FakeValuesService {
                             sb = new StringBuilder();
                         }
                         sb.append(itemStr, start, startWord);
-                        sb.append(WordUtils.capitalize(path[0])).append(".").append(toJavaNames(itemStr.substring(startWord, j), true)).append("}");
+                        sb.append(capitalizeWords(path[0])).append(".").append(toJavaNames(itemStr.substring(startWord, j), true)).append("}");
                         start = j + 1;
                     }
                 }
@@ -502,7 +506,7 @@ public class FakeValuesService {
      * <p>
      * #{Person.hello_someone} will result in a method call to person.helloSomeone();
      */
-    public String resolve(String key, Object current, final ProviderRegistration root, Supplier<String> exceptionMessage, FakerContext context) {
+    public String resolve(String key, Object current, @Nullable ProviderRegistration root, Supplier<String> exceptionMessage, FakerContext context) {
         String expression;
         if (root == null) {
             expression = key2Expression
@@ -513,7 +517,7 @@ public class FakeValuesService {
         }
 
         if (expression == null) {
-            throw new RuntimeException(exceptionMessage.get());
+            throw new IllegalArgumentException(exceptionMessage.get());
         }
 
         return resolveExpression(expression, current, root, context);
@@ -618,7 +622,7 @@ public class FakeValuesService {
      * Recursive templates are supported.  if "#{x}" resolves to "#{Address.streetName}" then "#{x}" resolves to
      * {@link BaseFaker#address()}'s {@link Address#streetName()}.
      */
-    protected String resolveExpression(String expression, Object current, ProviderRegistration root, FakerContext context) {
+    protected String resolveExpression(String expression, @Nullable Object current, @Nullable ProviderRegistration root, FakerContext context) {
         // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
         if (!expression.contains("}")) {
             return expression;
@@ -1190,14 +1194,16 @@ public class FakeValuesService {
         }
     }
 
-    private record RegExpContext(String exp, ProviderRegistration root, FakerContext context) {
+    private record RegExpContext(String exp, @Nullable ProviderRegistration root, FakerContext context) {
     }
 
     private interface ValueResolver {
+        @Nullable
         Object resolve();
     }
 
-    private record ConstantResolver(String value) implements ValueResolver {
+    private record ConstantResolver(@Nullable String value) implements ValueResolver {
+        @Nullable
         @Override
         public Object resolve() {
             return value;

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -14,6 +14,7 @@ import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.SimpleField;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
@@ -45,6 +46,8 @@ import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
+import static net.datafaker.internal.helper.JavaNames.toJavaNames;
+import static net.datafaker.internal.helper.WordUtils.capitalizeWords;
 import static net.datafaker.transformations.Field.field;
 
 public class FakeValuesService {
@@ -56,7 +59,7 @@ public class FakeValuesService {
     public static final Supplier<Map<String, String>> MAP_STRING_STRING_SUPPLIER = () -> new CopyOnWriteMap<>(() -> new WeakHashMap<>());
 
     private final Map<SingletonLocale, FakeValuesInterface> fakeValuesInterfaceMap = new CopyOnWriteMap<>(IdentityHashMap::new);
-    public static final SingletonLocale DEFAULT_LOCALE = SingletonLocale.get(Locale.ENGLISH);
+    public static final SingletonLocale DEFAULT_LOCALE = SingletonLocale.getRequired(Locale.ENGLISH);
 
     private static final Map<Class<?>, Map<String, Collection<Method>>> CLASS_2_METHODS_CACHE = new CopyOnWriteMap<>(IdentityHashMap::new);
     private static final Map<Class<?>, Constructor<?>> CLASS_2_CONSTRUCTOR_CACHE = new CopyOnWriteMap<>(IdentityHashMap::new);
@@ -100,7 +103,7 @@ public class FakeValuesService {
      * @param path   path to a file with YAML structure
      * @throws IllegalArgumentException in case of invalid path
      */
-    public void addPath(Locale locale, Path path) {
+    public void addPath(Locale locale, @Nullable Path path) {
         requireNonNull(locale);
         if (path == null || Files.notExists(path) || Files.isDirectory(path) || !Files.isReadable(path)) {
             throw new IllegalArgumentException("Path should be an existing readable file: \"%s\"".formatted(path));
@@ -120,10 +123,8 @@ public class FakeValuesService {
      * @throws IllegalArgumentException in case of invalid url
      */
     public void addUrl(Locale locale, URL url) {
-        requireNonNull(locale);
-        if (url == null) {
-            throw new IllegalArgumentException("url should be an existing readable file");
-        }
+        requireNonNull(locale, "locale is required");
+        requireNonNull(url, "url should be an existing readable file");
         final FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(locale, url));
         final SingletonLocale sLocale = SingletonLocale.get(locale);
         fakeValuesInterfaceMap.merge(sLocale, fakeValues,
@@ -138,6 +139,7 @@ public class FakeValuesService {
     /**
      * Fetch a random value from an array item specified by the key
      */
+    @Nullable
     public Object fetch(String key, FakerContext context) {
         List<?> valuesArray = null;
         final Object o = fetchObject(key, context);
@@ -158,6 +160,7 @@ public class FakeValuesService {
     /**
      * Same as {@link #fetch(String, FakerContext)} but casts the result to a String
      */
+    @Nullable
     public String fetchString(String key, FakerContext context) {
         return (String) fetch(key, context);
     }
@@ -165,6 +168,7 @@ public class FakeValuesService {
     private record SafeFetchResolver(FakeValuesService service, String simpleDirective, FakerContext context)
         implements ValueResolver {
 
+        @Nullable
         @Override
         public Object resolve() {
             return service.safeFetch(simpleDirective, context, null);
@@ -187,8 +191,9 @@ public class FakeValuesService {
      * @param defaultIfNull the value to return if the fetched value is null
      * @return see above
      */
+    @Nullable
     @SuppressWarnings("unchecked")
-    public String safeFetch(String key, FakerContext context, String defaultIfNull) {
+    public String safeFetch(String key, FakerContext context, @Nullable String defaultIfNull) {
         Object o = fetchObject(key, context);
         String str;
         if (o == null) return defaultIfNull;
@@ -213,6 +218,7 @@ public class FakeValuesService {
      * @param key key contains path to an object. Path segment is separated by
      *            dot. E.g. name.first_name
      */
+    @Nullable
     @SuppressWarnings("unchecked")
     public <T> T fetchObject(String key, FakerContext context) {
         Object result = null;
@@ -446,7 +452,7 @@ public class FakeValuesService {
      * <p>
      * #{Person.hello_someone} will result in a method call to person.helloSomeone();
      */
-    public String resolve(String key, Object current, final ProviderRegistration root, Supplier<String> exceptionMessage, FakerContext context) {
+    public String resolve(String key, Object current, @Nullable ProviderRegistration root, Supplier<String> exceptionMessage, FakerContext context) {
         String expression;
         if (root == null) {
             expression = key2Expression
@@ -457,7 +463,7 @@ public class FakeValuesService {
         }
 
         if (expression == null) {
-            throw new RuntimeException(exceptionMessage.get());
+            throw new IllegalArgumentException(exceptionMessage.get());
         }
 
         return resolveExpression(expression, current, root, context);
@@ -562,7 +568,7 @@ public class FakeValuesService {
      * Recursive templates are supported.  if "#{x}" resolves to "#{Address.streetName}" then "#{x}" resolves to
      * {@link BaseFaker#address()}'s {@link Address#streetName()}.
      */
-    protected String resolveExpression(String expression, Object current, ProviderRegistration root, FakerContext context) {
+    protected String resolveExpression(String expression, @Nullable Object current, @Nullable ProviderRegistration root, FakerContext context) {
         // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
         if (!expression.contains("}")) {
             return expression;
@@ -1133,14 +1139,16 @@ public class FakeValuesService {
         }
     }
 
-    private record RegExpContext(ProviderRegistration root, FakerContext context, ValueResolver resolver) {
+    private record RegExpContext(@Nullable ProviderRegistration root, FakerContext context, ValueResolver resolver) {
     }
 
     private interface ValueResolver {
+        @Nullable
         Object resolve();
     }
 
-    private record ConstantResolver(String value) implements ValueResolver {
+    private record ConstantResolver(@Nullable String value) implements ValueResolver {
+        @Nullable
         @Override
         public Object resolve() {
             return value;

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -103,8 +103,9 @@ public class FakeValuesService {
      * @param path   path to a file with YAML structure
      * @throws IllegalArgumentException in case of invalid path
      */
-    public void addPath(Locale locale, @Nullable Path path) {
+    public void addPath(Locale locale, Path path) {
         requireNonNull(locale);
+        //noinspection ConstantValue
         if (path == null || Files.notExists(path) || Files.isDirectory(path) || !Files.isReadable(path)) {
             throw new IllegalArgumentException("Path should be an existing readable file: \"%s\"".formatted(path));
         }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -46,8 +46,6 @@ import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
-import static net.datafaker.internal.helper.JavaNames.toJavaNames;
-import static net.datafaker.internal.helper.WordUtils.capitalizeWords;
 import static net.datafaker.transformations.Field.field;
 
 public class FakeValuesService {

--- a/src/main/java/net/datafaker/service/FakerContext.java
+++ b/src/main/java/net/datafaker/service/FakerContext.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static java.util.Locale.ROOT;
+import static java.util.Objects.requireNonNull;
 import static net.datafaker.service.FakeValuesService.DEFAULT_LOCALE;
 
 /**
@@ -62,13 +63,13 @@ public class FakerContext {
      * </ul>
      */
     public FakerContext(Locale locale, RandomService randomService) {
-        this.sLocale = SingletonLocale.get(locale);
+        setLocale(locale);
         this.randomService = randomService;
         setCurrentLocale(locale);
     }
 
-    public void setLocale(Locale locale) {
-        this.sLocale = SingletonLocale.get(locale);
+    public final void setLocale(Locale locale) {
+        this.sLocale = singletonLocale(locale);
     }
 
     public void setRandomService(RandomService randomService) {
@@ -129,8 +130,8 @@ public class FakerContext {
     }
 
     public final void setCurrentLocale(Locale locale) {
-        Objects.requireNonNull(locale);
-        this.sLocale = normalizeLocale(SingletonLocale.get(locale));
+        requireNonNull(locale);
+        this.sLocale = normalizeLocale(singletonLocale(locale));
         if (LOCALE_2_LOCALES_CHAIN.containsKey(this.sLocale)) {
             return;
         }
@@ -151,7 +152,7 @@ public class FakerContext {
             return DEFAULT_SINGLETON_LOCALE_LIST;
         }
 
-        return calculateLocaleChain(normalizeLocale(SingletonLocale.get(from)));
+        return calculateLocaleChain(normalizeLocale(singletonLocale(from)));
     }
 
     protected List<SingletonLocale> localeChain() {
@@ -202,5 +203,9 @@ public class FakerContext {
     @Override
     public String toString() {
         return "FakerContext{%s, %s}".formatted(sLocale, randomService);
+    }
+
+    private static SingletonLocale singletonLocale(Locale locale) {
+        return requireNonNull(SingletonLocale.get(locale), () -> "Unsupported locale " + locale);
     }
 }

--- a/src/main/java/net/datafaker/service/RandomService.java
+++ b/src/main/java/net/datafaker/service/RandomService.java
@@ -1,8 +1,12 @@
 package net.datafaker.service;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.Random;
 import java.util.random.RandomGenerator;
+
+import static java.util.Objects.requireNonNullElse;
 
 public class RandomService {
     private static final char[] HEX_UP = "0123456789ABCDEF".toCharArray();
@@ -20,8 +24,8 @@ public class RandomService {
     /**
      * @param random If null is passed in, a default Random is assigned
      */
-    public RandomService(RandomGenerator random) {
-        this.random = random != null ? random : SHARED_RANDOM;
+    public RandomService(@Nullable RandomGenerator random) {
+        this.random = requireNonNullElse(random, SHARED_RANDOM);
     }
 
     @SuppressWarnings("unused")
@@ -158,7 +162,7 @@ public class RandomService {
     @Override
     public int hashCode() {
         if (random == SHARED_RANDOM) return 1;
-        return random != null ? random.hashCode() : 0;
+        return random.hashCode();
     }
 
     @Override

--- a/src/main/java/net/datafaker/service/WeightedRandomSelector.java
+++ b/src/main/java/net/datafaker/service/WeightedRandomSelector.java
@@ -1,11 +1,15 @@
 package net.datafaker.service;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 /**
  * A utility class for selecting a random element from a list based on assigned weights.
@@ -14,8 +18,8 @@ public record WeightedRandomSelector(Random random) {
     private static final String WEIGHT_KEY = "weight";
     private static final String VALUE_KEY = "value";
 
-    public WeightedRandomSelector(Random random) {
-        this.random = random != null ? random : new Random();
+    public WeightedRandomSelector(@Nullable Random random) {
+        this.random = requireNonNullElseGet(random, () -> new Random());
     }
 
     /**
@@ -46,6 +50,7 @@ public record WeightedRandomSelector(Random random) {
         return selectWeightedElement(randomValue, cumulativeWeights, values);
     }
 
+    @SuppressWarnings("ConstantValue")
     private static void validateItemsList(List<Map<String, Object>> items) {
         if (items == null) {
             throw new IllegalArgumentException("Input list cannot be null");
@@ -69,6 +74,7 @@ public record WeightedRandomSelector(Random random) {
         }
     }
 
+    @SuppressWarnings("ConstantValue")
     private static void validateItem(Map<String, Object> item) {
         if (item == null) {
             throw new IllegalArgumentException("Item cannot be null");
@@ -83,6 +89,7 @@ public record WeightedRandomSelector(Random random) {
         validateWeight(item.get(WEIGHT_KEY));
     }
 
+    @SuppressWarnings("ConstantValue")
     private static void validateValue(Object valueObj) {
         if (valueObj == null) {
             throw new IllegalArgumentException("Value cannot be null");
@@ -123,6 +130,7 @@ public record WeightedRandomSelector(Random random) {
         return cumulativeWeights;
     }
 
+    @SuppressWarnings("unchecked")
     static <T> T selectWeightedElement(double randomValue, double[] cumulativeWeights, Object[] values) {
         int index = Arrays.binarySearch(cumulativeWeights, randomValue);
         index = (index < 0) ? -index - 1 : index;

--- a/src/main/java/net/datafaker/service/WeightedRandomSelector.java
+++ b/src/main/java/net/datafaker/service/WeightedRandomSelector.java
@@ -1,11 +1,15 @@
 package net.datafaker.service;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 /**
  * A utility class for selecting a random element from a list based on assigned weights.
@@ -14,8 +18,8 @@ public record WeightedRandomSelector(Random random) {
     private static final String WEIGHT_KEY = "weight";
     private static final String VALUE_KEY = "value";
 
-    public WeightedRandomSelector(Random random) {
-        this.random = random != null ? random : new Random();
+    public WeightedRandomSelector(@Nullable Random random) {
+        this.random = requireNonNullElseGet(random, () -> new Random());
     }
 
     /**
@@ -45,6 +49,7 @@ public record WeightedRandomSelector(Random random) {
         return selectWeightedElement(randomValue, cumulativeWeights, values);
     }
 
+    @SuppressWarnings("ConstantValue")
     private static void validateItemsList(List<Map<String, Object>> items) {
         if (items == null) {
             throw new IllegalArgumentException("Input list cannot be null");
@@ -68,6 +73,7 @@ public record WeightedRandomSelector(Random random) {
         }
     }
 
+    @SuppressWarnings("ConstantValue")
     private static void validateItem(Map<String, Object> item) {
         if (item == null) {
             throw new IllegalArgumentException("Item cannot be null");
@@ -82,6 +88,7 @@ public record WeightedRandomSelector(Random random) {
         validateWeight(item.get(WEIGHT_KEY));
     }
 
+    @SuppressWarnings("ConstantValue")
     private static void validateValue(Object valueObj) {
         if (valueObj == null) {
             throw new IllegalArgumentException("Value cannot be null");
@@ -122,6 +129,7 @@ public record WeightedRandomSelector(Random random) {
         return cumulativeWeights;
     }
 
+    @SuppressWarnings("unchecked")
     static <T> T selectWeightedElement(double randomValue, double[] cumulativeWeights, Object[] values) {
         int index = Arrays.binarySearch(cumulativeWeights, randomValue);
         index = (index < 0) ? -index - 1 : index;

--- a/src/main/java/net/datafaker/service/files/package-info.java
+++ b/src/main/java/net/datafaker/service/files/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.service.files;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/service/package-info.java
+++ b/src/main/java/net/datafaker/service/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.service;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/transformations/CompositeField.java
+++ b/src/main/java/net/datafaker/transformations/CompositeField.java
@@ -1,24 +1,28 @@
 package net.datafaker.transformations;
 
 import net.datafaker.providers.base.AbstractProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
 public class CompositeField<MyObject extends AbstractProvider<?>, MyType> extends Schema<MyObject, MyType> implements Field<MyObject, MyType> {
+    @Nullable
     private final String name;
 
-    public CompositeField(String name, Field<MyObject, MyType>[] fields) {
+    public CompositeField(@Nullable String name, Field<MyObject, MyType>[] fields) {
         super(fields);
         this.name = name;
     }
 
+    @Nullable
     @Override
     public String getName() {
         return name;
     }
 
+    @Nullable
     @Override
-    public MyType transform(MyObject input) {
+    public MyType transform(@Nullable MyObject input) {
         return null;
     }
 

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -1,6 +1,7 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Iterator;
 
@@ -60,7 +61,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
-    private void addLine(StringBuilder sb, Object transform) {
+    private void addLine(StringBuilder sb, @Nullable Object transform) {
         if (transform instanceof CharSequence) {
             addCharSequence(sb, (CharSequence) transform);
         } else {

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -1,6 +1,7 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     public static final String DEFAULT_SEPARATOR = ";";
@@ -58,7 +59,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
-    private void addLine(StringBuilder sb, Object transform) {
+    private void addLine(StringBuilder sb, @Nullable Object transform) {
         if (transform instanceof CharSequence charSequence) {
             addCharSequence(sb, charSequence);
         } else {

--- a/src/main/java/net/datafaker/transformations/Field.java
+++ b/src/main/java/net/datafaker/transformations/Field.java
@@ -1,14 +1,17 @@
 package net.datafaker.transformations;
 
 import net.datafaker.providers.base.AbstractProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface Field<IN, OUT> {
+    @Nullable
     String getName();
 
-    OUT transform(IN input);
+    @Nullable
+    OUT transform(@Nullable IN input);
 
     static <MyObject, MyType> SimpleField<MyObject, MyType> field(
         String name, Function<MyObject, MyType> transform) {
@@ -16,13 +19,13 @@ public interface Field<IN, OUT> {
     }
 
     static <MyObject, MyType> SimpleField<MyObject, MyType> field(
-        String name, Supplier<MyType> supplier) {
+        @Nullable String name, Supplier<@Nullable MyType> supplier) {
         return new SimpleField<>(name, supplier);
     }
 
     static <MyObject extends AbstractProvider<?>, MyType>
     CompositeField<MyObject, MyType> compositeField(
-        String name, Field<MyObject, MyType>[] fields) {
+        @Nullable String name, Field<MyObject, MyType>[] fields) {
         return new CompositeField<>(name, fields);
     }
 

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -1,6 +1,7 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
@@ -26,10 +27,10 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
     @Override
     public Object apply(Object input, Schema<Object, ?> schema) {
-        Class clazz;
+        Class<?> clazz;
         Object result = null;
         if (input instanceof Class) {
-            clazz = (Class) input;
+            clazz = (Class<?>) input;
         } else {
             clazz = input.getClass();
             result = input;
@@ -119,7 +120,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
         return collection;
     }
 
-    public JavaObjectTransformer from(Class input) {
+    public JavaObjectTransformer from(Class<?> input) {
         sourceClazz = Optional.of(input);
         return this;
     }
@@ -163,7 +164,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
     private Object getObject(Schema<Object, ?> schema, Object result, Constructor<?> recordConstructor) {
         final Field<Object, ?>[] fields = schema.getFields();
-        final Object[] values = new Object[fields.length];
+        final @Nullable Object[] values = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             values[i] = fields[i].transform(result);
         }

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -1,6 +1,7 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
@@ -122,7 +123,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
         return collection;
     }
 
-    public JavaObjectTransformer from(Class input) {
+    public JavaObjectTransformer from(Class<?> input) {
         sourceClazz = Optional.of(input);
         return this;
     }
@@ -166,7 +167,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
     private Object getObject(Schema<Object, ?> schema, Object result, Constructor<?> recordConstructor) {
         final net.datafaker.transformations.Field<Object, ?>[] fields = schema.getFields();
-        final Object[] values = new Object[fields.length];
+        final @Nullable Object[] values = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             values[i] = fields[i].transform(result);
         }

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -1,6 +1,7 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -88,9 +89,9 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         return ",";
     }
 
-    private void applyValue(IN input, StringBuilder sb, Object value) {
+    private void applyValue(IN input, StringBuilder sb, @Nullable Object value) {
         if (value instanceof Collection<?>) {
-            sb.append(generate(input, (Collection) value));
+            sb.append(generate(input, (Collection<?>) value));
         } else if (value != null && value.getClass().isArray()) {
             sb.append(generate(input, Arrays.asList((Object[]) value)));
         } else {
@@ -98,7 +99,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private String generate(IN input, Collection<Object> collection) {
+    private String generate(IN input, Collection<?> collection) {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         int i = 0;
@@ -108,7 +109,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
             }
             i++;
             if (value instanceof CompositeField<?, ?>) {
-                sb.append(apply(input, ((CompositeField) value)));
+                sb.append(apply(input, (CompositeField) value));
             } else {
                 applyValue(input, sb, value);
             }
@@ -117,7 +118,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
-    private static void value2String(Object value, StringBuilder sb) {
+    private static void value2String(@Nullable Object value, StringBuilder sb) {
         if (value == null) {
             sb.append("null");
         } else if (value instanceof Integer

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -1,6 +1,7 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -89,7 +90,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         return ",";
     }
 
-    private void applyValue(IN input, StringBuilder sb, Object value) {
+    private void applyValue(IN input, StringBuilder sb, @Nullable Object value) {
         if (value instanceof Collection<?> collection) {
             sb.append(generate(input, (Collection<Object>) collection));
         } else if (value != null && value.getClass().isArray()) {
@@ -99,7 +100,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private String generate(IN input, Collection<Object> collection) {
+    private String generate(IN input, Collection<?> collection) {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         int i = 0;
@@ -108,7 +109,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
                 sb.append(", ");
             }
             i++;
-            if (value instanceof CompositeField compositeField) {
+            if (value instanceof CompositeField<?, ?> compositeField) {
                 sb.append(apply(input, compositeField));
             } else {
                 applyValue(input, sb, value);
@@ -118,7 +119,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         return sb.toString();
     }
 
-    private static void value2String(Object value, StringBuilder sb) {
+    private static void value2String(@Nullable Object value, StringBuilder sb) {
         if (value == null) {
             sb.append("null");
         } else if (value instanceof Integer

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -25,7 +25,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     @Override
-    public String apply(IN input, Schema<IN, ?> schema) {
+    public String apply(@Nullable IN input, Schema<IN, ?> schema) {
         Field<?, ?>[] fields = schema.getFields();
         StringBuilder sb = new StringBuilder();
         sb.append("{");
@@ -90,7 +90,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         return ",";
     }
 
-    private void applyValue(IN input, StringBuilder sb, @Nullable Object value) {
+    private void applyValue(@Nullable IN input, StringBuilder sb, @Nullable Object value) {
         if (value instanceof Collection<?> collection) {
             sb.append(generate(input, (Collection<Object>) collection));
         } else if (value != null && value.getClass().isArray()) {
@@ -100,7 +100,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private String generate(IN input, Collection<?> collection) {
+    private String generate(@Nullable IN input, Collection<Object> collection) {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         int i = 0;
@@ -109,7 +109,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
                 sb.append(", ");
             }
             i++;
-            if (value instanceof CompositeField<?, ?> compositeField) {
+            if (value instanceof CompositeField compositeField) {
                 sb.append(apply(input, compositeField));
             } else {
                 applyValue(input, sb, value);

--- a/src/main/java/net/datafaker/transformations/SimpleField.java
+++ b/src/main/java/net/datafaker/transformations/SimpleField.java
@@ -1,52 +1,53 @@
 package net.datafaker.transformations;
 
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
+
 public class SimpleField<MyObject, MyType> implements Field<MyObject, MyType> {
-    private final String name;
-    private final Function<MyObject, MyType> transform;
-    private final Supplier<MyType> supplier;
+    private final @Nullable String name;
+    private final @Nullable Function<MyObject, MyType> transform;
+    private final @Nullable Supplier<MyType> supplier;
 
-    protected SimpleField(String name, Function<MyObject, MyType> transform) {
-        this(name, transform, null);
-    }
-
-    protected SimpleField(String name, Supplier<MyType> supplier) {
-        this(name, null, supplier);
-    }
-
-    private SimpleField(String name, Function<MyObject, MyType> transform, Supplier<MyType> supplier) {
+    protected SimpleField(@Nullable String name, Function<MyObject, MyType> transform) {
         this.name = name;
-        this.transform = transform;
-        this.supplier = supplier;
-        if (this.transform == null && this.supplier == null) {
-            throw new IllegalArgumentException("Either transform or supplier should be non-null");
-        }
+        this.transform = requireNonNull(transform);
+        this.supplier = null;
     }
 
+    protected SimpleField(@Nullable String name, Supplier<MyType> supplier) {
+        this.name = name;
+        this.transform = null;
+        this.supplier = requireNonNull(supplier);
+    }
+
+    @Nullable
     @Override
     public String getName() {
         return name;
     }
 
+    @Nullable
     @Override
-    public MyType transform(MyObject input) {
+    public MyType transform(@Nullable MyObject input) {
         if (transform == null) {
-            return supplier.get();
+            return requireNonNull(supplier).get();
         }
-        if (input == null) {
-            throw new IllegalArgumentException("Input could be null only if suppliers are defined");
-        }
+        requireNonNull(input, "Input could be null only if suppliers are defined");
         return transform.apply(input);
     }
 
+    @Nullable
     public Function<MyObject, MyType> getTransform() {
         return transform;
     }
 
+    @Nullable
     public Supplier<MyType> getSupplier() {
         return supplier;
     }

--- a/src/main/java/net/datafaker/transformations/TomlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/TomlTransformer.java
@@ -1,13 +1,19 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 public class TomlTransformer<IN> implements Transformer<IN, String> {
     @Override
-    public String apply(IN input, Schema<IN, ?> schema) {
+    public String apply(@Nullable IN input, @Nullable Schema<IN, ?> schema) {
         if (schema == null) {
             return "";
         }
@@ -55,9 +61,9 @@ public class TomlTransformer<IN> implements Transformer<IN, String> {
         return "";
     }
 
-    private void writeSchema(StringBuilder sb, IN input, Schema<IN, ?> schema, String pathPrefix) {
+    private void writeSchema(StringBuilder sb, @Nullable IN input, Schema<IN, ?> schema, String pathPrefix) {
         Field<IN, ?>[] fields = schema.getFields();
-        Set<String> seen = new HashSet<>();
+        Set<@Nullable String> seen = new HashSet<>();
         for (Field<IN, ?> f : fields) {
             String key = f.getName();
             if (!seen.add(key)) {
@@ -68,7 +74,7 @@ public class TomlTransformer<IN> implements Transformer<IN, String> {
         }
     }
 
-    private void writeValue(StringBuilder sb, String key, String pathPrefix, Object val) {
+    private void writeValue(StringBuilder sb, @Nullable String key, String pathPrefix, @Nullable Object val) {
         String fullPath = pathPrefix.isEmpty() ? key : pathPrefix + "." + key;
 
         if (val instanceof Schema<?, ?> nested) {

--- a/src/main/java/net/datafaker/transformations/TomlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/TomlTransformer.java
@@ -1,14 +1,20 @@
 package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 public class TomlTransformer<IN> implements Transformer<IN, String> {
     @Override
-    public String apply(IN input, Schema<IN, ?> schema) {
+    public String apply(@Nullable IN input, @Nullable Schema<IN, ?> schema) {
         if (schema == null) {
             return "";
         }
@@ -56,9 +62,9 @@ public class TomlTransformer<IN> implements Transformer<IN, String> {
         return "";
     }
 
-    private void writeSchema(StringBuilder sb, IN input, Schema<IN, ?> schema, String pathPrefix) {
+    private void writeSchema(StringBuilder sb, @Nullable IN input, Schema<IN, ?> schema, String pathPrefix) {
         Field<IN, ?>[] fields = schema.getFields();
-        Set<String> seen = new HashSet<>();
+        Set<@Nullable String> seen = new HashSet<>();
         for (Field<IN, ?> f : fields) {
             String key = f.getName();
             if (!seen.add(key)) {
@@ -69,7 +75,7 @@ public class TomlTransformer<IN> implements Transformer<IN, String> {
         }
     }
 
-    private void writeValue(StringBuilder sb, String key, String pathPrefix, Object val) {
+    private void writeValue(StringBuilder sb, @Nullable String key, String pathPrefix, @Nullable Object val) {
         String fullPath = pathPrefix.isEmpty() ? key : pathPrefix + "." + key;
 
         if (val instanceof Schema<?, ?> nested) {

--- a/src/main/java/net/datafaker/transformations/Transformer.java
+++ b/src/main/java/net/datafaker/transformations/Transformer.java
@@ -1,5 +1,7 @@
 package net.datafaker.transformations;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -8,9 +10,9 @@ import java.util.stream.Stream;
 public interface Transformer<IN, OUT> {
     String LINE_SEPARATOR = System.lineSeparator();
 
-    OUT apply(IN input, Schema<IN, ?> schema);
+    OUT apply(@Nullable IN input, Schema<IN, ?> schema);
 
-    default OUT apply(IN input, Schema<IN, ?> schema, long rowId) {
+    default OUT apply(@Nullable IN input, Schema<IN, ?> schema, long rowId) {
         // ignore rowId by default
         return apply(input, schema);
     }

--- a/src/main/java/net/datafaker/transformations/XmlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/XmlTransformer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
 
@@ -21,7 +22,7 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     @Override
-    public CharSequence apply(IN input, Schema<IN, ?> schema) {
+    public CharSequence apply(@Nullable IN input, Schema<IN, ?> schema) {
         StringBuilder sb = new StringBuilder();
         Arrays.stream(schema.getFields()).forEach(it -> apply(input, sb, it));
         return sb.toString();
@@ -77,7 +78,7 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private void apply(IN input, StringBuilder sb, Field<IN, ?> xmlNode) {
+    private void apply(@Nullable IN input, StringBuilder sb, Field<IN, ?> xmlNode) {
 
         if (pretty && tagIndex > 0) {
             sb.append(System.lineSeparator()).append(offset(tagIndex));
@@ -97,7 +98,7 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
         applyTag(input, sb, xmlNode, tag);
     }
 
-    private void applyTag(IN input, StringBuilder sb, Field<IN, ?> field, String tag) {
+    private void applyTag(@Nullable IN input, StringBuilder sb, @Nullable Field<IN, ?> field, String tag) {
         if (field == null ) {
             applyValue(sb, tag, null);
             return;
@@ -127,7 +128,7 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private boolean isAttribute(String name) {
+    private boolean isAttribute(@Nullable String name) {
         return name != null;
     }
 
@@ -141,7 +142,7 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private void applyValue(StringBuilder sb, String tag, String xmlNodeValue) {
+    private void applyValue(StringBuilder sb, String tag, @Nullable String xmlNodeValue) {
         if (xmlNodeValue != null) {
             sb.append(">");
             sb.append(escape(xmlNodeValue));

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -7,13 +7,14 @@ import java.util.Set;
 import java.util.StringJoiner;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
 
     private static final String INDENTATION = "  ";
 
     @Override
-    public CharSequence apply(IN input, Schema<IN, ?> schema) {
+    public CharSequence apply(@Nullable IN input, Schema<IN, ?> schema) {
         Field<IN, ?>[] fields = schema.getFields();
 
         if (fields.length == 0) {
@@ -59,7 +60,7 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
         return "";
     }
 
-    private String apply(final StringBuilder sb, final IN input, final Field<IN, ?>[] fields, final String offset) {
+    private String apply(final StringBuilder sb, @Nullable IN input, final Field<IN, ?>[] fields, final String offset) {
         Set<String> keys = new HashSet<>();
         for (Field<IN, ?> field : fields) {
             String key = field.getName().trim();
@@ -88,7 +89,7 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
             sb.append(System.lineSeparator());
         }
     }
-    private void value2String(Object value, StringBuilder sb, String offset) {
+    private void value2String(@Nullable Object value, StringBuilder sb, String offset) {
         if (value instanceof Schema) {
             Field<IN, ?>[] fields = ((Schema<IN, ?>) value).getFields();
             apply(sb, null, fields, offset);

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -7,13 +7,14 @@ import java.util.Set;
 import java.util.StringJoiner;
 
 import net.datafaker.sequence.FakeSequence;
+import org.jspecify.annotations.Nullable;
 
 public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
 
     private static final String INDENTATION = "  ";
 
     @Override
-    public CharSequence apply(IN input, Schema<IN, ?> schema) {
+    public CharSequence apply(@Nullable IN input, Schema<IN, ?> schema) {
         Field<IN, ?>[] fields = schema.getFields();
 
         if (fields.length == 0) {
@@ -59,7 +60,7 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
         return "";
     }
 
-    private String apply(final StringBuilder sb, final IN input, final Field<IN, ?>[] fields, final String offset) {
+    private String apply(final StringBuilder sb, @Nullable IN input, final Field<IN, ?>[] fields, final String offset) {
         Set<String> keys = new HashSet<>();
         for (Field<IN, ?> field : fields) {
             String key = field.getName().trim();
@@ -88,7 +89,7 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
             sb.append(System.lineSeparator());
         }
     }
-    private void value2String(Object value, StringBuilder sb, String offset) {
+    private void value2String(@Nullable Object value, StringBuilder sb, String offset) {
         if (value instanceof Schema schemaValue) {
             Field<IN, ?>[] fields = schemaValue.getFields();
             apply(sb, null, fields, offset);

--- a/src/main/java/net/datafaker/transformations/package-info.java
+++ b/src/main/java/net/datafaker/transformations/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.transformations;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlDialect.java
@@ -1,5 +1,7 @@
 package net.datafaker.transformations.sql;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -111,17 +113,17 @@ public enum SqlDialect {
         return unquotedCasing;
     }
 
-    public static String getFirstRow(SqlDialect dialect, Supplier<String> input, Supplier<String> input2, SqlTransformer.Case keywordCase) {
+    public static String getFirstRow(@Nullable SqlDialect dialect, Supplier<String> input, Supplier<String> input2, SqlTransformer.Case keywordCase) {
         return dialect == null
             ? DEFAULT_FIRST_ROW.apply(input, input2, keywordCase) : dialect.batchFirstRow.apply(input, input2, keywordCase);
     }
 
-    public static String getOtherRow(SqlDialect dialect, Supplier<String> input, Supplier<String> input2, SqlTransformer.Case keywordCase) {
+    public static String getOtherRow(@Nullable SqlDialect dialect, Supplier<String> input, Supplier<String> input2, SqlTransformer.Case keywordCase) {
         return dialect == null
             ? DEFAULT_OTHER_ROWS.apply(input, input2, keywordCase) : dialect.batchOtherRows.apply(input, input2, keywordCase);
     }
 
-    public static String getLastRowSuffix(SqlDialect dialect, SqlTransformer.Case caze) {
+    public static String getLastRowSuffix(@Nullable SqlDialect dialect, SqlTransformer.Case caze) {
         return dialect == null ? "" : dialect.lastBatchRow.apply(caze);
     }
 

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -7,6 +7,7 @@ import net.datafaker.transformations.Field;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.SimpleField;
 import net.datafaker.transformations.Transformer;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,20 +35,20 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     private final char openSqlIdentifier;
     private final char closeSqlIdentifier;
     private final String tableName;
-    private final String schemaName;
+    private final @Nullable String schemaName;
 
     private final boolean withBatchMode;
     private final int batchSize;
     private final Case keywordCase;
     private final boolean forceSqlQuoteIdentifierUsage;
 
-    private final SqlDialect dialect;
+    private final @Nullable SqlDialect dialect;
 
     public static <IN> SqlTransformer.SqlTransformerBuilder<IN> builder() {
         return new SqlTransformer.SqlTransformerBuilder<>();
     }
 
-    private SqlTransformer(String schemaName, String tableName, char quote, SqlDialect dialect, String sqlIdentifier,
+    private SqlTransformer(String schemaName, String tableName, char quote, @Nullable SqlDialect dialect, String sqlIdentifier,
                            Casing casing, boolean withBatchMode, int batchSize, Case keywordCase, boolean forceSqlQuoteIdentifierUsage) {
         this.schemaName = schemaName;
         this.quote = quote;
@@ -194,7 +195,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         return result.toString();
     }
 
-    private String handleObject(Object value) {
+    private String handleObject(@Nullable Object value) {
         if (value == null) {
             return NULL.getValue(keywordCase);
         } else {
@@ -307,7 +308,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         return result.toString();
     }
 
-    private void appendNameToQuery(StringBuilder sb, String name) {
+    private void appendNameToQuery(StringBuilder sb, @Nullable String name) {
         if (name == null || name.isEmpty()) return;
         boolean sqlIdentifierRequired = isSqlQuoteIdentifierRequiredFor(name);
 
@@ -375,7 +376,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         throw new UnsupportedOperationException("Not supported for SQL transformer. Use generate or generateStream instead to create SQL statements.");
     }
 
-    private String generateBatchModeStatements(Schema<IN, ?> schema, List<IN> inputs, int limit) {
+    private String generateBatchModeStatements(Schema<IN, ?> schema, @Nullable List<IN> inputs, int limit) {
         StringBuilder sb = new StringBuilder();
         limit = inputs != null ? Math.min(limit, inputs.size()) : limit;
         for (int i = 0; i < limit; i++) {
@@ -452,9 +453,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         private int batchSize = -1; // no limit
         private Case keywordCase = Case.UPPERCASE;
         private boolean forceSqlQuoteIdentifierUsage = false;
-
-
-        private SqlDialect dialect;
+        private @Nullable SqlDialect dialect;
 
         public SqlTransformerBuilder<IN> dialect(SqlDialect dialect) {
             this.dialect = dialect;

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -78,12 +78,12 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     @Override
-    public CharSequence apply(IN input, Schema<IN, ?> schema) {
+    public CharSequence apply(@Nullable IN input, Schema<IN, ?> schema) {
         return apply(input, schema, 0);
     }
 
     @Override
-    public CharSequence apply(IN input, Schema<IN, ?> schema, long rowId) {
+    public CharSequence apply(@Nullable IN input, Schema<IN, ?> schema, long rowId) {
         //noinspection unchecked
         Field<?, ? extends CharSequence>[] fields = (Field<?, ? extends CharSequence>[]) schema.getFields();
         if (fields.length == 0) {
@@ -106,7 +106,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private String addValues(IN input, Field<?, ?>[] fields, Boolean isRoot) {
+    private String addValues(@Nullable IN input, Field<?, ?>[] fields, Boolean isRoot) {
         StringJoiner result = new StringJoiner(", ");
         for (int i = 0; i < fields.length; i++) {
 
@@ -433,7 +433,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
 
-    private String generateSeparatedStatements(Schema<IN, ?> schema, List<IN> inputs, int limit) {
+    private String generateSeparatedStatements(Schema<IN, ?> schema, @Nullable List<IN> inputs, int limit) {
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
         limit = inputs != null ? Math.min(limit, inputs.size()) : limit;
         for (int i = 0; i < limit; i++) {

--- a/src/main/java/net/datafaker/transformations/sql/package-info.java
+++ b/src/main/java/net/datafaker/transformations/sql/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.transformations.sql;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/datafaker/assertions/package-info.java
+++ b/src/test/java/net/datafaker/assertions/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.assertions;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -322,7 +322,7 @@ class CsvTest {
                 .header(false).separator(" : ")
                 .build()
                 .generate(schema, 1))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("Input could be null only if suppliers are defined");
     }
 }

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -320,7 +320,7 @@ class CsvTest {
                 .header(false).separator(" : ")
                 .build()
                 .generate(schema, 1))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("Input could be null only if suppliers are defined");
     }
 }

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -6,6 +6,7 @@ import net.datafaker.sequence.FakeSequence;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
 import net.datafaker.transformations.Schema;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -212,7 +213,7 @@ class JsonTest {
             of(Schema.of(field("boolean", () -> true)), "{\"boolean\": true}"),
             of(Schema.of(field("nullValue", () -> null)), "{\"nullValue\": null}"),
             of(
-                Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+                Schema.of(field("array", () -> new @Nullable String[]{null, "test", "123"})),
                 "{\"array\": [null, \"test\", \"123\"]}"),
             of(
                 Schema.of(field("array", () -> new Integer[]{123, 456, 789})),

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -6,6 +6,7 @@ import net.datafaker.sequence.FakeSequence;
 import net.datafaker.transformations.Field;
 import net.datafaker.transformations.JsonTransformer;
 import net.datafaker.transformations.Schema;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -214,7 +215,7 @@ class JsonTest {
             of(Schema.of(field("boolean", () -> true)), "{\"boolean\": true}"),
             of(Schema.of(field("nullValue", () -> null)), "{\"nullValue\": null}"),
             of(
-                Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+                Schema.of(field("array", () -> new @Nullable String[]{null, "test", "123"})),
                 "{\"array\": [null, \"test\", \"123\"]}"),
             of(
                 Schema.of(field("array", () -> new Integer[]{123, 456, 789})),

--- a/src/test/java/net/datafaker/formats/TomlTest.java
+++ b/src/test/java/net/datafaker/formats/TomlTest.java
@@ -4,6 +4,7 @@ import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.Name;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.TomlTransformer;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,7 +40,7 @@ class TomlTest {
             of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), "number = 123.123"),
             of(Schema.of(field("boolean", () -> true)), "boolean = true"),
             of(Schema.of(field("nullValue", () -> null)), "nullValue = null"),
-            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+            of(Schema.of(field("array", () -> new @Nullable String[]{null, "test", "123"})),
                 "array = [ null, \"test\", \"123\" ]"),
             of(Schema.of(field("array", () -> new Integer[]{123, 456, 789})),
                 "array = [ 123, 456, 789 ]"),

--- a/src/test/java/net/datafaker/formats/TomlTest.java
+++ b/src/test/java/net/datafaker/formats/TomlTest.java
@@ -4,6 +4,7 @@ import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.Name;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.TomlTransformer;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -38,7 +39,7 @@ class TomlTest {
             of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), "number = 123.123"),
             of(Schema.of(field("boolean", () -> true)), "boolean = true"),
             of(Schema.of(field("nullValue", () -> null)), "nullValue = null"),
-            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+            of(Schema.of(field("array", () -> new @Nullable String[]{null, "test", "123"})),
                 "array = [ null, \"test\", \"123\" ]"),
             of(Schema.of(field("array", () -> new Integer[]{123, 456, 789})),
                 "array = [ 123, 456, 789 ]"),

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -4,6 +4,7 @@ import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.Name;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.YamlTransformer;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,7 +42,7 @@ class YamlTest {
             of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), "number: 123.123" + System.lineSeparator()),
             of(Schema.of(field("boolean", () -> true)), "boolean: true" + System.lineSeparator()),
             of(Schema.of(field("nullValue", () -> null)), "nullValue: null" + System.lineSeparator()),
-            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})),
+            of(Schema.of(field("array", () -> new @Nullable String[]{null, "test", "123"})),
                 "array:" + System.lineSeparator()
                     + "  - null" + System.lineSeparator()
                     + "  - test" + System.lineSeparator()

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -4,6 +4,7 @@ import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.Name;
 import net.datafaker.transformations.Schema;
 import net.datafaker.transformations.YamlTransformer;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,7 +54,7 @@ class YamlTest {
             of(Schema.of(field("nullValue", () -> null)), lines("""
                 nullValue: null
                 """)),
-            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})), lines("""
+            of(Schema.of(field("array", () -> new @Nullable String[]{null, "test", "123"})), lines("""
                 array:
                   - null
                   - test

--- a/src/test/java/net/datafaker/formats/package-info.java
+++ b/src/test/java/net/datafaker/formats/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.formats;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/datafaker/helpers/package-info.java
+++ b/src/test/java/net/datafaker/helpers/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.helpers;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
+++ b/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
@@ -6,6 +6,7 @@ import net.datafaker.providers.base.Address;
 import net.datafaker.providers.base.App;
 import net.datafaker.providers.base.BaseFaker;
 import net.datafaker.providers.base.Name;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -74,7 +75,7 @@ class FakerIntegrationTest {
         }
     }
 
-    private Faker init(Locale locale, Random random) {
+    private Faker init(@Nullable Locale locale, @Nullable Random random) {
         if (locale != null && random != null) {
             return new Faker(locale, random);
         } else if (locale != null) {
@@ -88,7 +89,7 @@ class FakerIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("dataParameters")
-    void testAllFakerMethodsThatReturnStrings(Locale locale, Random random) throws Exception {
+    void testAllFakerMethodsThatReturnStrings(@Nullable Locale locale, @Nullable Random random) throws Exception {
         log.fine(() -> "  (%s, %s)".formatted(locale, random));
         final Faker faker = init(locale, random);
 

--- a/src/test/java/net/datafaker/integration/MostSpecificLocaleTest.java
+++ b/src/test/java/net/datafaker/integration/MostSpecificLocaleTest.java
@@ -2,6 +2,7 @@ package net.datafaker.integration;
 
 import net.datafaker.service.FakeValuesService;
 import net.datafaker.service.FakerContext;
+import net.datafaker.service.RandomService;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -16,8 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class MostSpecificLocaleTest {
 
-    private final FakerContext en = new FakerContext(new Locale("en"), null);
-    private final FakerContext en_US = new FakerContext(new Locale("en", "US"), null);
+    private final FakerContext en = new FakerContext(new Locale("en"), new RandomService());
+    private final FakerContext en_US = new FakerContext(new Locale("en", "US"), new RandomService());
 
     @Test
     void resolvesTheMostSpecificLocale() {

--- a/src/test/java/net/datafaker/integration/package-info.java
+++ b/src/test/java/net/datafaker/integration/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.integration;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/datafaker/providers/base/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/CustomFakerTest.java
@@ -70,15 +70,18 @@ class CustomFakerTest {
     }
 
     @Test
+    @SuppressWarnings("DataFlowIssue")
     void addNullExistingPath() {
         assertThatThrownBy(() -> new BaseFaker().addPath(Locale.ENGLISH, null))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Path should be an existing readable file: \"null\"");
     }
 
     @Test
     void addNonExistingPath() {
         assertThatThrownBy(() -> new BaseFaker().addPath(Locale.ENGLISH, Paths.get("non-existing-file")))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Path should be an existing readable file: \"non-existing-file\"");
     }
 
     @RepeatedTest(10)

--- a/src/test/java/net/datafaker/providers/base/CustomFakerTest.java
+++ b/src/test/java/net/datafaker/providers/base/CustomFakerTest.java
@@ -71,15 +71,18 @@ class CustomFakerTest {
     }
 
     @Test
+    @SuppressWarnings("DataFlowIssue")
     void addNullExistingPath() {
         assertThatThrownBy(() -> new BaseFaker().addPath(Locale.ENGLISH, null))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Path should be an existing readable file: \"null\"");
     }
 
     @Test
     void addNonExistingPath() {
         assertThatThrownBy(() -> new BaseFaker().addPath(Locale.ENGLISH, Paths.get("non-existing-file")))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Path should be an existing readable file: \"non-existing-file\"");
     }
 
     @RepeatedTest(10)

--- a/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
+++ b/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.comments.CommentsCollection;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.google.common.base.Strings;
 import net.datafaker.providers.base.AbstractProvider;
+import org.jspecify.annotations.Nullable;
 import org.reflections.Reflections;
 
 import java.io.BufferedWriter;
@@ -191,10 +192,10 @@ public class ProvidersDocsGenerator {
         SINCE("Since", 7, Pattern.compile("@since\\s+\\d\\.\\d+\\.\\d"), comment -> comment.group().substring("@since".length()).trim());
         private final String columnName;
         private final int length;
-        private final Pattern pattern2extract;
-        private final Function<Matcher, String> extractor;
+        private final @Nullable Pattern pattern2extract;
+        private final @Nullable Function<Matcher, String> extractor;
 
-        Column(String columnName, int length, Pattern pattern2extract, Function<Matcher, String> extractor) {
+        Column(String columnName, int length, @Nullable Pattern pattern2extract, @Nullable Function<Matcher, String> extractor) {
             this.columnName = columnName;
             this.length = length;
             this.pattern2extract = pattern2extract;

--- a/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
+++ b/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.comments.CommentsCollection;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.google.common.base.Strings;
 import net.datafaker.providers.base.AbstractProvider;
+import org.jspecify.annotations.Nullable;
 import org.reflections.Reflections;
 
 import java.io.BufferedWriter;
@@ -195,10 +196,10 @@ public class ProvidersDocsGenerator {
         SINCE("Since", 7, Pattern.compile("@since\\s+\\d\\.\\d+\\.\\d"), comment -> comment.group().substring("@since".length()).trim());
         private final String columnName;
         private final int length;
-        private final Pattern pattern2extract;
-        private final Function<Matcher, String> extractor;
+        private final @Nullable Pattern pattern2extract;
+        private final @Nullable Function<Matcher, String> extractor;
 
-        Column(String columnName, int length, Pattern pattern2extract, Function<Matcher, String> extractor) {
+        Column(String columnName, int length, @Nullable Pattern pattern2extract, @Nullable Function<Matcher, String> extractor) {
             this.columnName = columnName;
             this.length = length;
             this.pattern2extract = pattern2extract;

--- a/src/test/java/net/datafaker/script/package-info.java
+++ b/src/test/java/net/datafaker/script/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@CheckReturnValue
+package net.datafaker.script;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -210,7 +210,6 @@ class FakeValuesServiceTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void testFakerContextSetLocale() {
         final FakerContext fakerContext = new FakerContext(new Locale("en"), new RandomService());
         fakerContext.setLocale(new Locale("uk"));

--- a/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesServiceTest.java
@@ -210,6 +210,7 @@ class FakeValuesServiceTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void testFakerContextSetLocale() {
         final FakerContext fakerContext = new FakerContext(new Locale("en"), new RandomService());
         fakerContext.setLocale(new Locale("uk"));


### PR DESCRIPTION
JSpecify is de-facto standard annotations for marking nullability of variables, parameters, return values and fields. Supported by all IDEs.

All remarkable libraries have migrated to JSpecify: Spring, JUnit etc.

1. By default, we mark everything as non-nullable (see @NullMarked in package-info.java)
2. When needed, we mark the nullable parameters/fields as @Nullable.