### PR TITLE
Fix error "Unable to resolve #{female_first_name}"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 bin/
 site
 .mvn/wrapper/maven-wrapper.jar
+/.claude/settings.local.json

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -1,12 +1,14 @@
 package net.datafaker.service;
 
 import net.datafaker.internal.helper.LazyEvaluated;
+import net.datafaker.internal.helper.WordUtils;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +42,9 @@ public class FakeValues implements FakeValuesInterface {
             return null;
         }
         try (InputStream stream = url.openStream()) {
-            return readFromStream(stream);
+            Map<String, Object> result = readFromStream(stream);
+            enrichMapWithJavaNames(result);
+            return result;
         } catch (IOException e) {
             throw new RuntimeException("Failed to read fake values from %s".formatted(url), e);
         }
@@ -90,6 +94,7 @@ public class FakeValues implements FakeValuesInterface {
                 if (entry.getValue() instanceof Map) {
                     @SuppressWarnings("unchecked")
                     Map<String, Object> entryMap = (Map<String, Object>) entry.getValue();
+                    prefixUnqualifiedExpressions(entryMap, key);
                     Map<String, Object> nestedMap = new HashMap<>(entryMap.size());
                     for (Map.Entry<String, Object> e: entryMap.entrySet()) {
                         nestedMap.put(toJavaNames(e.getKey(), true), e.getValue());
@@ -106,6 +111,66 @@ public class FakeValues implements FakeValuesInterface {
             }
             if (map != null) {
                 result.putAll(map);
+            }
+        }
+    }
+
+    /**
+     * Rewrites unqualified expressions like {@code #{first_name}} inside string lists under a
+     * provider section into qualified ones like {@code #{Name.firstName}}. The provider name comes
+     * from the top-level YAML key (e.g. {@code name}, {@code address}). Doing this once at load
+     * time avoids racy in-place mutation of cached lists during concurrent fetches.
+     */
+    static void prefixUnqualifiedExpressions(Object node, String providerKey) {
+        if (node instanceof Map<?, ?> nested) {
+            for (Object v : nested.values()) {
+                prefixUnqualifiedExpressions(v, providerKey);
+            }
+        } else if (node instanceof List<?> rawList) {
+            @SuppressWarnings("unchecked")
+            List<Object> list = (List<Object>) rawList;
+            rewriteList(list, providerKey);
+        }
+    }
+
+    private static void rewriteList(List<Object> list, String providerKey) {
+        final String capitalizedProvider = WordUtils.capitalize(providerKey);
+        for (int i = 0; i < list.size(); i++) {
+            Object item = list.get(i);
+            if (!(item instanceof String itemStr)) {
+                break;
+            }
+            final int itemStrLength = itemStr.length();
+            if (itemStrLength < 2) {
+                break;
+            }
+            int j = 0;
+            StringBuilder sb = null;
+            int start = 0;
+            while (j < itemStrLength) {
+                char c;
+                while (j < itemStrLength - 2 && (itemStr.charAt(j) != '#' || itemStr.charAt(j + 1) != '{')) j++;
+                int startWord = j + 2;
+                boolean letterOrDigitOnly = true;
+                j = startWord;
+                while (j < itemStrLength && (c = itemStr.charAt(j)) != '}') {
+                    letterOrDigitOnly &= Character.isLetter(c) || Character.isDigit(c) || c == '_';
+                    j++;
+                }
+                if (start < itemStrLength && startWord < itemStrLength && letterOrDigitOnly) {
+                    if (sb == null) {
+                        sb = new StringBuilder();
+                    }
+                    sb.append(itemStr, start, startWord);
+                    sb.append(capitalizedProvider).append(".").append(toJavaNames(itemStr.substring(startWord, j), true)).append("}");
+                    start = j + 1;
+                }
+            }
+            if (sb != null) {
+                if (start < itemStrLength) {
+                    sb.append(itemStr, start, itemStrLength);
+                }
+                list.set(i, sb.toString());
             }
         }
     }

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -136,39 +136,41 @@ public class FakeValues implements FakeValuesInterface {
     private static void rewriteList(List<Object> list, String providerKey) {
         final String capitalizedProvider = WordUtils.capitalize(providerKey);
         for (int i = 0; i < list.size(); i++) {
-            Object item = list.get(i);
-            if (!(item instanceof String itemStr)) {
+            Object itemValue = list.get(i);
+            if (!(itemValue instanceof String item)) {
                 break;
             }
-            final int itemStrLength = itemStr.length();
-            if (itemStrLength < 2) {
+            final int itemLength = item.length();
+            if (itemLength < 2) {
                 break;
             }
             int j = 0;
             StringBuilder sb = null;
             int start = 0;
-            while (j < itemStrLength) {
+            while (j < itemLength) {
                 char c;
-                while (j < itemStrLength - 2 && (itemStr.charAt(j) != '#' || itemStr.charAt(j + 1) != '{')) j++;
+                while (j < itemLength - 2 && !(item.charAt(j) == '#' && item.charAt(j + 1) == '{')) {
+                    j++;
+                }
                 int startWord = j + 2;
                 boolean letterOrDigitOnly = true;
                 j = startWord;
-                while (j < itemStrLength && (c = itemStr.charAt(j)) != '}') {
+                while (j < itemLength && (c = item.charAt(j)) != '}') {
                     letterOrDigitOnly &= Character.isLetter(c) || Character.isDigit(c) || c == '_';
                     j++;
                 }
-                if (start < itemStrLength && startWord < itemStrLength && letterOrDigitOnly) {
+                if (start < itemLength && startWord < itemLength && letterOrDigitOnly) {
                     if (sb == null) {
                         sb = new StringBuilder();
                     }
-                    sb.append(itemStr, start, startWord);
-                    sb.append(capitalizedProvider).append(".").append(toJavaNames(itemStr.substring(startWord, j), true)).append("}");
+                    sb.append(item, start, startWord);
+                    sb.append(capitalizedProvider).append(".").append(toJavaNames(item.substring(startWord, j), true)).append("}");
                     start = j + 1;
                 }
             }
             if (sb != null) {
-                if (start < itemStrLength) {
-                    sb.append(itemStr, start, itemStrLength);
+                if (start < itemLength) {
+                    sb.append(item, start, itemLength);
                 }
                 list.set(i, sb.toString());
             }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -3,7 +3,6 @@ package net.datafaker.service;
 import com.github.curiousoddman.rgxgen.RgxGen;
 import net.datafaker.internal.helper.CopyOnWriteMap;
 import net.datafaker.internal.helper.SingletonLocale;
-import net.datafaker.internal.helper.WordUtils;
 import net.datafaker.providers.base.AbstractProvider;
 import net.datafaker.providers.base.Address;
 import net.datafaker.providers.base.BaseFaker;
@@ -49,7 +48,6 @@ import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
-import static net.datafaker.internal.helper.JavaNames.toJavaNames;
 import static net.datafaker.transformations.Field.field;
 
 public class FakeValuesService {
@@ -273,46 +271,6 @@ public class FakeValuesService {
             key2fetchedObject
                 .computeIfAbsent(local2Add, (__) -> MAP_STRING_OBJECT_SUPPLIER.get())
                 .computeIfAbsent(key, (__) -> valueToCache);
-        }
-        if (result instanceof List list) {
-            for (int i = 0; i < list.size(); i++) {
-                Object item = list.get(i);
-                if (!(item instanceof String itemStr)) {
-                    break;
-                }
-                final int itemStrLength = itemStr.length();
-                if (itemStrLength < 2) {
-                    break;
-                }
-                int j = 0;
-                StringBuilder sb = null;
-                int start = 0;
-                while (j < itemStrLength) {
-                    char c;
-                    while (j < itemStrLength - 2 && ((itemStr.charAt(j)) != '#' || itemStr.charAt(j + 1) != '{')) j++;
-                    int startWord = j + 2;
-                    boolean letterOrDigitOnly = true;
-                    j = startWord;
-                    while (j < itemStrLength && (c = itemStr.charAt(j)) != '}') {
-                        letterOrDigitOnly &= Character.isLetter(c) || Character.isDigit(c) || c == '_';
-                        j++;
-                    }
-                    if (start < itemStrLength&&  startWord < itemStrLength && letterOrDigitOnly) {
-                        if (sb == null) {
-                            sb = new StringBuilder();
-                        }
-                        sb.append(itemStr, start, startWord);
-                        sb.append(WordUtils.capitalize(path[0])).append(".").append(toJavaNames(itemStr.substring(startWord, j), true)).append("}");
-                        start = j + 1;
-                    }
-                }
-                if (sb != null) {
-                    if (start < itemStrLength) {
-                        sb.append(itemStr, start, itemStrLength);
-                    }
-                    list.set(i, sb.toString());
-                }
-            }
         }
         return (T) result;
     }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -936,8 +936,8 @@ public class FakeValuesService {
         });
 
         Collection<Method> methods = classMethodsMap.getOrDefault(name, emptyList());
-        if (methods == null) {
-            LOG.fine(() -> "Didn't accessor named %s on %s with args %s (methods=%s)".formatted(accessorName, clazz.getSimpleName(), Arrays.toString(args), null));
+        if (methods.isEmpty()) {
+            LOG.fine(() -> "Didn't find accessor named %s on %s with args %s".formatted(accessorName, clazz.getSimpleName(), Arrays.toString(args)));
             return null;
         }
         LOG.fine(() -> "Found accessor named %s on %s in cache: %s".formatted(accessorName, clazz.getSimpleName(), methods));
@@ -956,7 +956,7 @@ public class FakeValuesService {
         if (mostRestrictive != null) {
             return new MethodAndCoercedArgs(mostRestrictive, coercedArgumentsForMostRestrictive);
         }
-        LOG.fine(() -> "Didn't accessor named %s on %s with args %s (methods=%s)".formatted(accessorName, clazz.getSimpleName(), Arrays.toString(args), methods));
+        LOG.fine(() -> "Didn't find accessor named %s on %s with args %s (methods=%s)".formatted(accessorName, clazz.getSimpleName(), Arrays.toString(args), methods));
         return null;
     }
 

--- a/src/test/java/net/datafaker/service/FakeValuesTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesTest.java
@@ -11,7 +11,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -103,85 +102,58 @@ class FakeValuesTest {
     @Nested
     @SuppressWarnings("unchecked")
     class PrefixUnqualifiedExpressions {
-        @Test
-        void rewritesSimpleUnqualifiedExpressionInList() {
-            List<String> list = mutableList("#{first_name}");
 
-            FakeValues.prefixUnqualifiedExpressions(list, "name");
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("listCases")
+        void rewritesListItems(String description, List<String> input, String providerName, List<String> expected) {
+            List<String> list = new ArrayList<>(input);
 
-            assertThat(list).containsExactly("#{Name.firstName}");
+            FakeValues.prefixUnqualifiedExpressions(list, providerName);
+
+            assertThat(list).containsExactlyElementsOf(expected);
         }
 
-        @Test
-        void rewritesMultipleExpressionsInsideOneString() {
-            List<String> list = mutableList("#{first_name} #{last_name}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "name");
-
-            assertThat(list).containsExactly("#{Name.firstName} #{Name.lastName}");
-        }
-
-        @Test
-        void convertsSnakeCaseKeyToCamelCaseMethodName() {
-            List<String> list = mutableList("#{some_long_yaml_key}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "p");
-
-            assertThat(list).containsExactly("#{P.someLongYamlKey}");
-        }
-
-        @Test
-        void capitalizesProviderName() {
-            List<String> list = mutableList("#{x}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "myProvider");
-
-            assertThat(list).containsExactly("#{MyProvider.x}");
-        }
-
-        @Test
-        void leavesAlreadyQualifiedExpressionsUntouched() {
-            // The dot inside the {...} disqualifies the expression from rewriting.
-            List<String> list = mutableList("#{Name.firstName}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "address");
-
-            assertThat(list).containsExactly("#{Name.firstName}");
-        }
-
-        @Test
-        void leavesExpressionsWithArgumentsUntouched() {
-            // The space and quotes inside the {...} disqualify the expression from rewriting.
-            List<String> list = mutableList("#{numerify '#-####'}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "code");
-
-            assertThat(list).containsExactly("#{numerify '#-####'}");
-        }
-
-        @Test
-        void leavesPlainStringsUntouched() {
-            List<String> list = mutableList("Aaron", "Bob", "Charlie");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "name");
-
-            assertThat(list).containsExactly("Aaron", "Bob", "Charlie");
-        }
-
-        @Test
-        void rewritesUnqualifiedAndPreservesQualifiedInTheSameString() {
-            // Mixed expression: "#{city_prefix}" gets prefixed, "#{Name.firstName}" stays as is.
-            List<String> list = mutableList("#{city_prefix} #{Name.firstName}#{city_suffix}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "address");
-
-            assertThat(list).containsExactly("#{Address.cityPrefix} #{Name.firstName}#{Address.citySuffix}");
+        static Stream<Arguments> listCases() {
+            return Stream.of(
+                of("rewrites simple unqualified expression in list",
+                    List.of("#{first_name}"), "name",
+                    List.of("#{Name.firstName}")),
+                of("rewrites multiple expressions inside one string",
+                    List.of("#{first_name} #{last_name}"), "name",
+                    List.of("#{Name.firstName} #{Name.lastName}")),
+                of("converts snake_case key to camelCase method name",
+                    List.of("#{some_long_yaml_key}"), "p",
+                    List.of("#{P.someLongYamlKey}")),
+                of("capitalizes provider name",
+                    List.of("#{x}"), "myProvider",
+                    List.of("#{MyProvider.x}")),
+                // The dot inside the {...} disqualifies the expression from rewriting.
+                of("leaves already-qualified expressions untouched",
+                    List.of("#{Name.firstName}"), "address",
+                    List.of("#{Name.firstName}")),
+                // The space and quotes inside the {...} disqualify the expression from rewriting.
+                of("leaves expressions with arguments untouched",
+                    List.of("#{numerify '#-####'}"), "code",
+                    List.of("#{numerify '#-####'}")),
+                of("leaves plain strings untouched",
+                    List.of("Aaron", "Bob", "Charlie"), "name",
+                    List.of("Aaron", "Bob", "Charlie")),
+                // Mixed expression: "#{city_prefix}" gets prefixed, "#{Name.firstName}" stays as is.
+                of("rewrites unqualified and preserves qualified in the same string",
+                    List.of("#{city_prefix} #{Name.firstName}#{city_suffix}"), "address",
+                    List.of("#{Address.cityPrefix} #{Name.firstName}#{Address.citySuffix}")),
+                // The exact scenario from issue #1477 — name.first_name is a list of two
+                // unqualified delegations to sibling YAML keys.
+                of("rewrites name.first_name redirect list (issue #1477)",
+                    List.of("#{female_first_name}", "#{male_first_name}"), "name",
+                    List.of("#{Name.femaleFirstName}", "#{Name.maleFirstName}"))
+            );
         }
 
         @Test
         void recursesIntoNestedMapsAndRewritesListsAtAnyDepth() {
             Map<String, Object> inner = new LinkedHashMap<>();
-            inner.put("title", mutableList("#{first_name}"));
+            inner.put("title", new ArrayList<>(List.of("#{first_name}")));
             Map<String, Object> middle = new LinkedHashMap<>();
             middle.put("nested", inner);
             Map<String, Object> root = new LinkedHashMap<>();
@@ -198,29 +170,13 @@ class FakeValuesTest {
             // Only items inside Lists are rewritten. A bare String value in a Map is left alone.
             Map<String, Object> map = new HashMap<>();
             map.put("scalar", "#{first_name}");
-            map.put("list", mutableList("#{first_name}"));
+            map.put("list", new ArrayList<>(List.of("#{first_name}")));
 
             FakeValues.prefixUnqualifiedExpressions(map, "name");
 
             assertThat(map.get("scalar")).isEqualTo("#{first_name}");
-            @SuppressWarnings("unchecked")
             List<Object> rewrittenList = (List<Object>) map.get("list");
             assertThat(rewrittenList).containsExactly("#{Name.firstName}");
-        }
-
-        @Test
-        void rewritesNameFirstNameRedirectList_issue1477() {
-            // The exact scenario from issue #1477 — name.first_name is a list of two
-            // unqualified delegations to sibling YAML keys.
-            List<String> list = mutableList("#{female_first_name}", "#{male_first_name}");
-
-            FakeValues.prefixUnqualifiedExpressions(list, "name");
-
-            assertThat(list).containsExactly("#{Name.femaleFirstName}", "#{Name.maleFirstName}");
-        }
-
-        private static List<String> mutableList(String... items) {
-            return new ArrayList<>(Arrays.asList(items));
         }
     }
 

--- a/src/test/java/net/datafaker/service/FakeValuesTest.java
+++ b/src/test/java/net/datafaker/service/FakeValuesTest.java
@@ -1,14 +1,23 @@
 package net.datafaker.service;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,6 +72,156 @@ class FakeValuesTest {
     void getAValueFromALocaleThatCantBeLoaded() {
         FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(new Locale("nothing")));
         assertThat(fakeValues.get(PATH)).isNull();
+    }
+
+    /**
+     * Regression test for issue <a href="http://github.com/datafaker-net/datafaker/issues/1477">#1477</a>
+     * (race condition in {@code FakeValuesService.fetchObject}).
+     *
+     * <p>Unqualified template references like {@code #{female_first_name}} that appear in YAML
+     * lists must be rewritten to fully-qualified form like {@code #{Name.femaleFirstName}} at
+     * <b>load time</b>, not lazily on first fetch. The buggy implementation rewrote them lazily,
+     * after the list had already been published to the cache, which let concurrent readers see
+     * un-rewritten items and fail with {@code Unable to resolve #{female_first_name}}.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void loadFromUrl_rewritesUnqualifiedTemplateReferencesAtLoadTime() {
+        String yml = "/en/name.yml";
+        URL nameYmlUrl = Objects.requireNonNull(getClass().getResource(yml), () -> "Resource not found: " + yml);
+        FakeValues fakeValues = FakeValues.of(FakeValuesContext.of(Locale.ENGLISH, nameYmlUrl));
+
+        Map<String, Object> nameMap = fakeValues.get("name");
+        assertThat(nameMap).as("name provider map").isNotNull();
+
+        List<String> firstNames = (List<String>) nameMap.get("first_name");
+        assertThat(firstNames)
+            .as("name.first_name entries must already be qualified after loadFromUrl()")
+            .containsExactlyInAnyOrder("#{Name.femaleFirstName}", "#{Name.maleFirstName}");
+    }
+
+    @Nested
+    @SuppressWarnings("unchecked")
+    class PrefixUnqualifiedExpressions {
+        @Test
+        void rewritesSimpleUnqualifiedExpressionInList() {
+            List<String> list = mutableList("#{first_name}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "name");
+
+            assertThat(list).containsExactly("#{Name.firstName}");
+        }
+
+        @Test
+        void rewritesMultipleExpressionsInsideOneString() {
+            List<String> list = mutableList("#{first_name} #{last_name}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "name");
+
+            assertThat(list).containsExactly("#{Name.firstName} #{Name.lastName}");
+        }
+
+        @Test
+        void convertsSnakeCaseKeyToCamelCaseMethodName() {
+            List<String> list = mutableList("#{some_long_yaml_key}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "p");
+
+            assertThat(list).containsExactly("#{P.someLongYamlKey}");
+        }
+
+        @Test
+        void capitalizesProviderName() {
+            List<String> list = mutableList("#{x}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "myProvider");
+
+            assertThat(list).containsExactly("#{MyProvider.x}");
+        }
+
+        @Test
+        void leavesAlreadyQualifiedExpressionsUntouched() {
+            // The dot inside the {...} disqualifies the expression from rewriting.
+            List<String> list = mutableList("#{Name.firstName}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "address");
+
+            assertThat(list).containsExactly("#{Name.firstName}");
+        }
+
+        @Test
+        void leavesExpressionsWithArgumentsUntouched() {
+            // The space and quotes inside the {...} disqualify the expression from rewriting.
+            List<String> list = mutableList("#{numerify '#-####'}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "code");
+
+            assertThat(list).containsExactly("#{numerify '#-####'}");
+        }
+
+        @Test
+        void leavesPlainStringsUntouched() {
+            List<String> list = mutableList("Aaron", "Bob", "Charlie");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "name");
+
+            assertThat(list).containsExactly("Aaron", "Bob", "Charlie");
+        }
+
+        @Test
+        void rewritesUnqualifiedAndPreservesQualifiedInTheSameString() {
+            // Mixed expression: "#{city_prefix}" gets prefixed, "#{Name.firstName}" stays as is.
+            List<String> list = mutableList("#{city_prefix} #{Name.firstName}#{city_suffix}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "address");
+
+            assertThat(list).containsExactly("#{Address.cityPrefix} #{Name.firstName}#{Address.citySuffix}");
+        }
+
+        @Test
+        void recursesIntoNestedMapsAndRewritesListsAtAnyDepth() {
+            Map<String, Object> inner = new LinkedHashMap<>();
+            inner.put("title", mutableList("#{first_name}"));
+            Map<String, Object> middle = new LinkedHashMap<>();
+            middle.put("nested", inner);
+            Map<String, Object> root = new LinkedHashMap<>();
+            root.put("deeply", middle);
+
+            FakeValues.prefixUnqualifiedExpressions(root, "name");
+
+            List<Object> rewritten = (List<Object>) inner.get("title");
+            assertThat(rewritten).containsExactly("#{Name.firstName}");
+        }
+
+        @Test
+        void doesNotRewriteScalarStringsOutsideLists() {
+            // Only items inside Lists are rewritten. A bare String value in a Map is left alone.
+            Map<String, Object> map = new HashMap<>();
+            map.put("scalar", "#{first_name}");
+            map.put("list", mutableList("#{first_name}"));
+
+            FakeValues.prefixUnqualifiedExpressions(map, "name");
+
+            assertThat(map.get("scalar")).isEqualTo("#{first_name}");
+            @SuppressWarnings("unchecked")
+            List<Object> rewrittenList = (List<Object>) map.get("list");
+            assertThat(rewrittenList).containsExactly("#{Name.firstName}");
+        }
+
+        @Test
+        void rewritesNameFirstNameRedirectList_issue1477() {
+            // The exact scenario from issue #1477 — name.first_name is a list of two
+            // unqualified delegations to sibling YAML keys.
+            List<String> list = mutableList("#{female_first_name}", "#{male_first_name}");
+
+            FakeValues.prefixUnqualifiedExpressions(list, "name");
+
+            assertThat(list).containsExactly("#{Name.femaleFirstName}", "#{Name.maleFirstName}");
+        }
+
+        private static List<String> mutableList(String... items) {
+            return new ArrayList<>(Arrays.asList(items));
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This PR fixes race condition https://github.com/datafaker-net/datafaker/issues/1477 in `FakeValuesService.fetchObject`.

Unqualified template references like `#{female_first_name}` that appear in YAML lists must be rewritten to fully-qualified form like `#{Name.femaleFirstName}` **at load time**, not lazily on first fetch.

The buggy implementation rewrote them lazily, after the list had already been published to the cache, which let concurrent readers see the un-rewritten items and fail with exception `Unable to resolve #{female_first_name}`.