### PR TITLE
Fix: the location where README.md appears broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Datafaker
 
-[![Maven Status](https://maven-badges.herokuapp.com/maven-central/net.datafaker/datafaker/badge.svg?style=flat)](http://mvnrepository.com/artifact/net.datafaker/datafaker)
+[![Maven Status](https://img.shields.io/maven-central/v/net.datafaker/datafaker?label=Maven%20Status)](http://mvnrepository.com/artifact/net.datafaker/datafaker)
 [![License](http://img.shields.io/:license-apache-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![codecov](https://codecov.io/gh/datafaker-net/datafaker/branch/main/graph/badge.svg?token=FJ6EXMUTFD)](https://codecov.io/gh/datafaker-net/datafaker)
 


### PR DESCRIPTION
## What
Fix broken Maven Central badge in README.md

## Why
The `maven-badges.herokuapp.com` service is no longer reliable due to Heroku's free tier shutdown. The badge image fails to load.

## How
Replaced the badge URL with `img.shields.io`, which is the successor service maintained by the same author.