### PR TITLE
Address JavaDoc warning

### DIFF
--- a/src/main/java/net/datafaker/service/WeightedRandomSelector.java
+++ b/src/main/java/net/datafaker/service/WeightedRandomSelector.java
@@ -21,7 +21,6 @@ public record WeightedRandomSelector(Random random) {
     /**
      * Returns a weighted random element from the given list, where each element is represented as a Map
      * containing a weight and the corresponding value.
-     * <p>
      *
      * @param items A list of maps, where each map contains:
      *              - weight: A Double representing the weight of the element, influencing its selection probability.


### PR DESCRIPTION
From recent CI etc.

```
[INFO] --- javadoc:3.12.0:jar (attach-javadocs) @ datafaker ---
Warning:  Javadoc Warnings
Warning:  /home/runner/work/datafaker/datafaker/src/main/java/net/datafaker/service/WeightedRandomSelector.java:24: warning: empty <p> tag
Warning:  * <p>
Warning:  ^
Warning: [WARNING] 1 warning
```