### PR TITLE
Update exclude_docs format in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,9 +79,9 @@ plugins:
       minify_html: true
 
 # Files to exclude from the built site
-exclude_docs:
-  - releases/.RELEASE-template.md
-  - releases/.SNAPSHOT-template.md
+exclude_docs: |
+  releases/.RELEASE-template.md
+  releases/.SNAPSHOT-template.md
 
 # Customization
 extra:


### PR DESCRIPTION
Changed exclude_docs format to a multi-line string.

```
Run mkdocs build 
ERROR - Config value 'exclude_docs': Expected a multiline string, but a <class 'list'> was given. Aborted with a configuration error! 
Error: Process completed with exit code 1.
```