### PR TITLE
Docs: sentence-case headings and cleaner release nav

### DIFF
--- a/.github/workflows/version-updates.yml
+++ b/.github/workflows/version-updates.yml
@@ -74,30 +74,13 @@ jobs:
           echo "ERROR: $RELEASE_MD already exists; refusing to overwrite."
           exit 1
         fi
-        cp docs/releases/.RELEASE-template.md "$RELEASE_MD"
-        sed -i "s/X\.Y\.Z/$RELEASED_VERSION/" "$RELEASE_MD"
-        sed -i "s/dd-mm-yyyy/$TODAY/" "$RELEASE_MD"
-
-        # Write release body to temp file (safer for complex markdown)
         RELEASE_BODY_FILE=$(mktemp)
         echo "$RELEASE_BODY" > "$RELEASE_BODY_FILE"
-
-        # Insert body and strip # from bullets
-        awk -v bodyfile="$RELEASE_BODY_FILE" '
-          /## What'\''s Changed/ {
-              print
-              print ""
-              while ((getline line < bodyfile) > 0) {
-                  if (line ~ /^[[:space:]]*[-*][[:space:]]*#[0-9]/)
-                      sub(/#/, "", line)
-                  print line
-              }
-              close(bodyfile)
-              next
-          }
-          { print }
-        ' "$RELEASE_MD" > "$RELEASE_MD.tmp" && mv "$RELEASE_MD.tmp" "$RELEASE_MD"
-
+        ./mvnw test-compile exec:java \
+          -Dexec.mainClass="net.datafaker.script.ReleaseNotesGenerator" \
+          -Dexec.classpathScope=test \
+          -Dexec.args="${RELEASED_VERSION} ${TODAY} docs/releases/.RELEASE-template.md ${RELEASE_MD} ${RELEASE_BODY_FILE}" \
+          -q
         rm -f "$RELEASE_BODY_FILE"
         git add "$RELEASE_MD"
 
@@ -112,24 +95,14 @@ jobs:
         sed -i "s/dd-mm-yyyy/$TODAY/" "$SNAPSHOT_MD"
         git add "$SNAPSHOT_MD"
 
-        # Update mkdocs.yml
+        # Update mkdocs.yml version metadata and Releases navigation
         sed -i '/datafaker:/,/^[^ ]/{s/^\( *version: \).*/\1'"$RELEASED_VERSION"'/}' mkdocs.yml
         sed -i '/datafaker:/,/^[^ ]/{s/^\( *snapshot: \).*/\1'"${NEXT_VERSION}-SNAPSHOT"'/}' mkdocs.yml
-
-        # Add to Releases navigation
-        awk -v rel="$RELEASED_VERSION" -v snap="${NEXT_VERSION}-SNAPSHOT" '
-          $0 ~ ("- " snap ":") { found_snap=1 }
-          $0 ~ ("- " rel ":") { found_rel=1 }
-          /Releases:/ { print; in_releases=1; next }
-           in_releases && /^[[:space:]]*-[[:space:]]*[0-9]/ {
-              if (!added) {
-                if (!found_snap) print "    - " snap ": releases/" snap ".md"
-                if (!found_rel)  print "    - " rel ": releases/" rel ".md"
-                added=1
-              }
-          }
-          { print }
-        ' mkdocs.yml > mkdocs.yml.tmp && mv mkdocs.yml.tmp mkdocs.yml
+        ./mvnw test-compile exec:java \
+          -Dexec.mainClass="net.datafaker.script.MkdocsReleaseNavUpdater" \
+          -Dexec.classpathScope=test \
+          -Dexec.args="${RELEASED_VERSION} ${NEXT_VERSION}-SNAPSHOT mkdocs.yml" \
+          -q
         git add mkdocs.yml
 
         git commit -m "Released Datafaker $RELEASED_VERSION" \

--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -92,7 +92,7 @@ This will return a random insect name but based on the provided weights
 Driver ant
 ```
 
-## Custom provider using Yaml file
+## Custom provider using YAML file
 
 In case you have a large set of data to load, it might be better to use a Yaml file.
 
@@ -101,7 +101,7 @@ To create a custom provider of data fom a file, you'll need to do the following 
 * Create a custom provider of data
 * Create your own custom faker which extends `Faker` and register custom provider
 
-### Yaml provider
+### YAML provider
 
 First, create the custom provider which loads the data from a file:
 

--- a/docs/documentation/expressions.md
+++ b/docs/documentation/expressions.md
@@ -64,7 +64,7 @@ Faker faker = new Faker();
 faker.expression("#{options.option 'ABC','2','5','$'}"); // could give $
 faker.expression("#{options.option '23','2','5','$','%','*'}"); // could give *
 ```
-## Csv
+## CSV
 This is available since 1.4.0
 
 The expression will return generated csv based on input parameters
@@ -78,7 +78,7 @@ faker.expression("#{csv ' ### ','\"','false','3','name_column','#{Name.first_nam
 // "Sybil" ### "Connelly"
 ```
 
-## Json
+## JSON
 This is available since 1.4.0
 
 The expression will return generated json based on input parameters

--- a/docs/documentation/formats.md
+++ b/docs/documentation/formats.md
@@ -1,4 +1,4 @@
-# Formats (This is DEPRECATED functionality! Please have a look at Transformation Schemas instead)
+# Formats (This is DEPRECATED functionality! Please have a look at Transformation schemas instead)
 
 Since version 1.2.0 of Datafaker it's possible to export generated data to a file format of your choice.
 

--- a/docs/documentation/performance140.md
+++ b/docs/documentation/performance140.md
@@ -3,7 +3,7 @@
 This page is trying to go through some performance metrics and see how better/worse Datafaker is in compare with Java
 Faker and other similar projects.
 
-## Hardware & Software
+## Hardware & software
 
 All the tests are done with help of JMH at Fedora 36 for different JDKs (mentioned in tables below).
 The laptop has 32Gb of RAM, AMD Ryzen 7 PRO 5850U with Radeon Graphics.
@@ -37,7 +37,7 @@ Ok, let's start with the similar test here. Similar, because we are going to use
 If applicable we try to execute same tests we did for previous section. So let's start with the original test from
 Kotlin Faker
 
-### Original Kotlin Faker Test
+### Original Kotlin Faker test
 
 (for different libs there should be different classes, for more details look in the code):
 `net.datafaker.benchmark.kotlinfakerbenchmark`
@@ -277,7 +277,7 @@ for parsed args.
 It makes sense to keep in mind that these tests do not cover all possible use cases and could be considered only as a
 starting point for analysis.
 
-## More Fun
+## More fun
 
 There is an [issue](https://github.com/DiUS/java-faker/issues/663) in Java Faker about generation of 100M of objects.
 Of course, the task could be solved with concurrent generation in multiple threads.

--- a/docs/documentation/performance170.md
+++ b/docs/documentation/performance170.md
@@ -3,7 +3,7 @@
 This page is trying to go through some performance metrics and see how better/worse Datafaker is in compare with Java
 Faker and other similar projects.
 
-## Hardware & Software
+## Hardware & software
 
 All the tests are done with help of JMH at Fedora 37 for different JDKs (mentioned in tables below).
 The laptop has 32Gb of RAM, AMD Ryzen 7 PRO 5850U with Radeon Graphics.
@@ -37,7 +37,7 @@ Ok, let's start with the similar test here. Similar, because we are going to use
 If applicable we try to execute same tests we did for previous section. So let's start with the original test from
 Kotlin Faker
 
-### Original Kotlin Faker Test
+### Original Kotlin Faker test
 
 (for different libs there should be different classes, for more details look in the code):
 `net.datafaker.benchmark.kotlinfakerbenchmark`

--- a/docs/documentation/providers.md
+++ b/docs/documentation/providers.md
@@ -1,4 +1,4 @@
-# Fake Data Providers
+# Fake data providers
 
 #### Provider groups:
 

--- a/docs/documentation/schemas.md
+++ b/docs/documentation/schemas.md
@@ -161,7 +161,7 @@ Example of JSON generation:
 
 To use composite fields it should be defined on `Schema` level and nothing more.
 
-## SQL Transformation
+## SQL transformation
 
 Note: right now only `INSERT` is supported. 
 
@@ -383,7 +383,7 @@ address:
   streetAddress: 6510 Duncan Landing
 ```
 
-## Java Object transformation
+## Java object transformation
 
 Java Object transformer could be built with help of JavaObjectTransformer. 
 
@@ -443,7 +443,7 @@ Then you should provide a schema for the class.
 
 will generate object with fields populated with random values based on specified suppliers.
 
-### Populating Java Object with predefined Schema
+### Populating Java object with predefined schema
 
 You can use predefined schema to populate Java Object or default schema for the class.
 Schema should be declared as a static method with return type `Schema<Object, ?>`.

--- a/docs/documentation/unique-values.md
+++ b/docs/documentation/unique-values.md
@@ -1,4 +1,4 @@
-# Unique Values
+# Unique values
 
 ## Values from YAML files
 

--- a/docs/releases/.RELEASE-template.md
+++ b/docs/releases/.RELEASE-template.md
@@ -1,12 +1,12 @@
 # Datafaker X.Y.Z (dd-mm-yyyy)
 
-## What's Changed
+## What's changed
 
-## New Contributors
+## New contributors
 
 * TBD
 
-## Providers Added
+## Providers added
 
 * TBD
 

--- a/docs/releases/.SNAPSHOT-template.md
+++ b/docs/releases/.SNAPSHOT-template.md
@@ -1,12 +1,12 @@
 # Datafaker X.Y.Z-SNAPSHOT (dd-mm-yyyy)
 
-## What's Changed
+## What's changed
 * TBD
 
-## New Contributors
+## New contributors
 * TBD
 
-## Providers Added
+## Providers added
 
 * TBD
 

--- a/docs/releases/1.6.0.md
+++ b/docs/releases/1.6.0.md
@@ -9,7 +9,7 @@ Also @panilya fixed the documentation using a generator, so now [our list of pro
 
 We've also received contributions from 5 new contributors! We appreciate all contributions, thank you all!
 
-## New Contributors
+## New contributors
 
 * @andrinmeier made their first contribution in https://github.com/datafaker-net/datafaker/pull/286
 * @p4pupro made their first contribution in https://github.com/datafaker-net/datafaker/pull/289
@@ -17,7 +17,7 @@ We've also received contributions from 5 new contributors! We appreciate all con
 * @redhell made their first contribution in https://github.com/datafaker-net/datafaker/pull/307
 * @yuokada made their first contribution in https://github.com/datafaker-net/datafaker/pull/328
 
-## What's Changed
+## What's changed
 
 ### Phone number fixes
 

--- a/docs/releases/1.7.0.md
+++ b/docs/releases/1.7.0.md
@@ -17,7 +17,7 @@ In this release, you'll find many new features, such as:
 
 Have fun with this release!
 
-## What's Changed
+## What's changed
 
 * Apply renaming master to main by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/343
 * Enrich ja.yml by @yuokada in https://github.com/datafaker-net/datafaker/pull/345
@@ -181,7 +181,7 @@ Have fun with this release!
 * Update Emoji provider with cats by @ghusta in https://github.com/datafaker-net/datafaker/pull/558
 * Restaurant names were generated incorrectly. Drone attributes were ge… by @bodiam in https://github.com/datafaker-net/datafaker/pull/559
 
-## New Contributors
+## New contributors
 
 * @jaapcoomans made their first contribution in https://github.com/datafaker-net/datafaker/pull/352
 * @CucumisSativus made their first contribution in https://github.com/datafaker-net/datafaker/pull/360

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -9,7 +9,7 @@ while Java 17 might have some more interesting features, such as records, compac
 and who knows, maybe some other features. Just to be clear: our 1.x branch will no longer be supported 
 or maintained.
 
-## New Contributors
+## New contributors
 
 A special shout out to @kingthorin, who has contributed numerous improvements in Datafaker, and 
 who is now a co-maintainer of Datafaker. Rick, welcome to the team, and absolutely appreciate 
@@ -26,7 +26,7 @@ your amazing work!
 * @kingthorin made their first contribution in https://github.com/datafaker-net/datafaker/pull/657
 * @AlexJFerreira made their first contribution in https://github.com/datafaker-net/datafaker/pull/661
 
-## What's Changed
+## What's changed
 
 * Documentation update by @bodiam in https://github.com/datafaker-net/datafaker/pull/560
 * Update spotless-maven-plugin to 2.28.0 by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/563

--- a/docs/releases/1.9.0.md
+++ b/docs/releases/1.9.0.md
@@ -2,7 +2,7 @@
 
 A small maintenance release for Java 1.8 with some fixes and updated dependendencies. 
 
-## What's Changed
+## What's changed
 * Update dependencies for 1.x by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/771
 * Add annotation support for data classes based on JavaObjectTransformer by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/773
 * Backport of determenistic methods issue and add url issue to 1.x by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/776

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -18,7 +18,7 @@ and besides the change in Java version, no (or not many...) breaking changes sho
 Thanks to all our users for the great support; it's been a great journey so far, 
 and here's to many more Datafaker releases!
 
-## Breaking Change
+## Breaking change
 
 `internet().url()` will now return a web URL. The previous implementation returned just a domain name.
 
@@ -39,7 +39,7 @@ https://www.logan-yundt.org/fuga?quaerat=voluptas&est=ipsa
 
 For further details see: <https://github.com/datafaker-net/datafaker/issues/840>.
 
-## New Contributors
+## New contributors
 
 A big shout to our new contributors, without who Datafaker wouldn't be the project which it is today.
 
@@ -54,7 +54,7 @@ A big shout to our new contributors, without who Datafaker wouldn't be the proje
 
 Thank you all for helping out, your contributions are appreciated!
 
-## What's Changed
+## What's changed
 
 * Documentation 1.8/2.0 update. by @bodiam in https://github.com/datafaker-net/datafaker/pull/688
 * Java 17 by @bodiam in https://github.com/datafaker-net/datafaker/pull/689

--- a/docs/releases/2.0.1.md
+++ b/docs/releases/2.0.1.md
@@ -1,6 +1,6 @@
 # Datafaker 2.0.1 (18 June 2023)
 
-## What's Changed
+## What's changed
 
 This is a bugfix release. It was no longer possible to specify the type of credit card and the type of compass due to 
 a missing `public` keyword. Also, there was a small typo in the list of IATA airlines. Both items have been fixed now.

--- a/docs/releases/2.0.2.md
+++ b/docs/releases/2.0.2.md
@@ -1,6 +1,6 @@
 # Datafaker 2.0.2 (3 October 2023)
 
-## What's Changed
+## What's changed
 
 Various bugfixes and performance enhancements.
 

--- a/docs/releases/2.1.0.md
+++ b/docs/releases/2.1.0.md
@@ -1,6 +1,6 @@
 # Datafaker 2.1.0 (22 February 2024)
 
-## What's Changed
+## What's changed
 
 Various bugfixes and performance enhancements.
 

--- a/docs/releases/2.2.0.md
+++ b/docs/releases/2.2.0.md
@@ -4,7 +4,7 @@ After reaching our 1000 star milestone, we figured it was time for another relea
 bigger improvements. With a new Pronoun faker, language updates, and lots of smaller fixes under the hood,
 we hope this release will fall in good hands and we'd love to hear what you use Datafaker for!
 
-## What's Changed
+## What's changed
 
 * Use initial capacity for map if possible by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/1057
 * Use bitwise operations by @snuyanzin in https://github.com/datafaker-net/datafaker/pull/1062
@@ -35,7 +35,7 @@ we hope this release will fall in good hands and we'd love to hear what you use 
 * Disabling wildcard imports on Intellij IDE by @eduhoribe in https://github.com/datafaker-net/datafaker/pull/1160
 * Proper Apache 2.0 LICENSE by @bodiam in https://github.com/datafaker-net/datafaker/pull/1166
 
-## New Contributors
+## New contributors
 
 Big shout out to our existing and new contributors, we thank you for your efforts!
 

--- a/docs/releases/2.2.1.md
+++ b/docs/releases/2.2.1.md
@@ -1,6 +1,6 @@
 # Datafaker 2.2.1 (24 April 2024)
 
-## What's Changed
+## What's changed
 
 Bugfix release to address an issue related to the shadowing of our regular expresion library.
 

--- a/docs/releases/2.2.2.md
+++ b/docs/releases/2.2.2.md
@@ -1,6 +1,6 @@
 # Datafaker 2.2.2 (25 April 2024)
 
-## What's Changed
+## What's changed
 
 A fix was applied to address issue #1170:
 - Parent filename could be null for resources in jar #1172

--- a/docs/releases/2.3.0.md
+++ b/docs/releases/2.3.0.md
@@ -8,7 +8,7 @@ Datafaker a bit easier.
 The most notable contributions are done this release by Andrei Solntsev, who not only did his first contribution 
 this release, but is now also a maintainer for Datafaker. Welcome to the team Andrei, your contribution is amazing!
 
-## New Contributors
+## New contributors
 
 * @filipowm made their first contribution in https://github.com/datafaker-net/datafaker/pull/1179
 * @marcelofilipov made their first contribution in https://github.com/datafaker-net/datafaker/pull/1186

--- a/docs/releases/2.3.1.md
+++ b/docs/releases/2.3.1.md
@@ -2,10 +2,10 @@
 
 A few small bugs, mostly related to performance and JPMS, sneaked into our 2.3.0 release, and this release should address most of them.
 
-## New Contributors
+## New contributors
 * @vitaly-ivanov made their first contribution in https://github.com/datafaker-net/datafaker/pull/1286
 
-## What's Changed
+## What's changed
 
 * Unify `TimeAndDate` provider API by @valfirst in https://github.com/datafaker-net/datafaker/pull/1282
 * Improve performance when generating with a specific locale by @vitaly-ivanov in https://github.com/datafaker-net/datafaker/pull/1286

--- a/docs/releases/2.4.0.md
+++ b/docs/releases/2.4.0.md
@@ -4,7 +4,7 @@ We've now reached the milestone of 250 different data providers! General words, 
 
 Did you know it's even possible to generate fake images (JPG, PNG, SVG and more) using Datafaker?
 
-## New Contributors
+## New contributors
 
 Thank you all for your contributions, we couldn't have done it without you. A special shout out to our new contributors:
 
@@ -12,7 +12,7 @@ Thank you all for your contributions, we couldn't have done it without you. A sp
 * @ly1012 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1354
 * @ksy-ke made their first contribution in https://github.com/datafaker-net/datafaker/pull/1357
 
-## What's Changed
+## What's changed
 * 2.3.1 Release documentation by @bodiam in https://github.com/datafaker-net/datafaker/pull/1299
 * Cleaned up some unused configuration, and added some initial support … by @bodiam in https://github.com/datafaker-net/datafaker/pull/1300
 * Fixed JPG MIME. by @bodiam in https://github.com/datafaker-net/datafaker/pull/1302

--- a/docs/releases/2.4.1.md
+++ b/docs/releases/2.4.1.md
@@ -2,14 +2,14 @@
 
 "Bug fixes and various stability improvements"
 
-## New Contributors
+## New contributors
 
 * @badoken made their first contribution in https://github.com/datafaker-net/datafaker/pull/1375
 * @sann3 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1378
 * @senocak made their first contribution in https://github.com/datafaker-net/datafaker/pull/1389
 * @shanjuren made their first contribution in https://github.com/datafaker-net/datafaker/pull/1402
 
-## What's Changed
+## What's changed
 
 * 2.4.0 Documentation by @bodiam in https://github.com/datafaker-net/datafaker/pull/1363
 * #1368 fix "Duplicate key error" when a custom faker has multiple methods with the same return type. by @asolntsev in https://github.com/datafaker-net/datafaker/pull/1369

--- a/docs/releases/2.4.2.md
+++ b/docs/releases/2.4.2.md
@@ -2,10 +2,10 @@
 
 "More bug fixes and various stability improvements"
 
-## New Contributors
+## New contributors
 * @TrueJacobG made their first contribution in https://github.com/datafaker-net/datafaker/pull/1434
 
-## What's Changed
+## What's changed
 * Add greek translations for Measurement provider & other Greek tests by @gvrettos in https://github.com/datafaker-net/datafaker/pull/1410
 * fix: University tests by @kingthorin in https://github.com/datafaker-net/datafaker/pull/1411
 * Feature/name el gr by @gvrettos in https://github.com/datafaker-net/datafaker/pull/1415

--- a/docs/releases/2.4.3.md
+++ b/docs/releases/2.4.3.md
@@ -1,6 +1,6 @@
 # Datafaker 2.4.3 (13-07-2025)
 
-## What's Changed
+## What's changed
 * Cleanup release process. by @bodiam in https://github.com/datafaker-net/datafaker/pull/1533
 * Update docs for date faking by @n-0 in https://github.com/datafaker-net/datafaker/pull/1534
 * Bump com.diffplug.spotless:spotless-maven-plugin from 2.44.3 to 2.44.4 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1536
@@ -48,7 +48,7 @@
 * Bump commons-validator:commons-validator from 1.9.0 to 1.10.0 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1585
 * Bump org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1586
 
-## New Contributors
+## New contributors
 * @n-0 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1534
 * @JammyJims made their first contribution in https://github.com/datafaker-net/datafaker/pull/1540
 * @paulofranklins2 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1549

--- a/docs/releases/2.4.4.md
+++ b/docs/releases/2.4.4.md
@@ -1,6 +1,6 @@
 # Datafaker 2.4.4 (13-07-2025)
 
-## What's Changed
+## What's changed
 * Cleanup release process. by @bodiam in https://github.com/datafaker-net/datafaker/pull/1533
 * Update docs for date faking by @n-0 in https://github.com/datafaker-net/datafaker/pull/1534
 * Bump com.diffplug.spotless:spotless-maven-plugin from 2.44.3 to 2.44.4 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1536
@@ -48,7 +48,7 @@
 * Bump commons-validator:commons-validator from 1.9.0 to 1.10.0 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1585
 * Bump org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1586
 
-## New Contributors
+## New contributors
 * @n-0 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1534
 * @JammyJims made their first contribution in https://github.com/datafaker-net/datafaker/pull/1540
 * @paulofranklins2 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1549

--- a/docs/releases/2.5.0.md
+++ b/docs/releases/2.5.0.md
@@ -1,6 +1,6 @@
 # Datafaker 2.5.0 (16-09-2025)
 
-## What's Changed
+## What's changed
 
 * Updated release documentation and set autopublish while publishing to… by @bodiam in https://github.com/datafaker-net/datafaker/pull/1588
 * Add some new titles to the Zelda game list by @yuokada in https://github.com/datafaker-net/datafaker/pull/1589
@@ -32,7 +32,7 @@
 * Remove unneeded test `testNoDuplications` by @asolntsev in https://github.com/datafaker-net/datafaker/pull/1652
 * Refactoring: eliminate recursive provider calls by @asolntsev in https://github.com/datafaker-net/datafaker/pull/1650
 
-## New Contributors
+## New contributors
 * @abudevich made their first contribution in https://github.com/datafaker-net/datafaker/pull/1615
 * @rcriosbr made their first contribution in https://github.com/datafaker-net/datafaker/pull/1624
 * @Chanwon-Seo made their first contribution in https://github.com/datafaker-net/datafaker/pull/1635

--- a/docs/releases/2.5.1.md
+++ b/docs/releases/2.5.1.md
@@ -1,6 +1,6 @@
 # Datafaker 2.5.1 (24-09-2025)
 
-## What's Changed
+## What's changed
 
 * Add ability to use whitelist conditions [by @snuyanzin](https://github.com/datafaker-net/datafaker/pull/1668)
 * Update `_PL.yml` with country phone code [by @kopernic-pl](https://github.com/datafaker-net/datafaker/pull/1663)
@@ -9,7 +9,7 @@
 * Fix possible issue with "tr" locale in `testUsernameWithSpaces` [by @snuyanzin](https://github.com/datafaker-net/datafaker/pull/1669)
 * Stop using `Internet#username()` internally [by @kingthorin](https://github.com/datafaker-net/datafaker/pull/1671)
 
-## New Contributors
+## New contributors
 
 * @maxandersen made their [first contribution](https://github.com/datafaker-net/datafaker/pull/1661)
 * @kopernic-pl made their [first contribution](https://github.com/datafaker-net/datafaker/pull/1663)

--- a/docs/releases/2.5.2.md
+++ b/docs/releases/2.5.2.md
@@ -1,12 +1,12 @@
 # Datafaker 2.5.2 (11-10-2025)
 
-## What's Changed
+## What's changed
 * Retrieve the no-argument constructor [by @mt657-jpg](https://github.com/datafaker-net/datafaker/pull/1690)
 * Add Personal Identification Number generator for Norway (NO) [#1681](https://github.com/datafaker-net/datafaker/pull/1681)
 * refactoring: remove unused setting "country_by_code" [by @asolntsev](https://github.com/datafaker-net/datafaker/pull/1693)
 * Bump libphonenumber 9.0.14 -> 9.0.16
 
-## New Contributors
+## New contributors
 * @mt657-jpg made their [first contribution](https://github.com/datafaker-net/datafaker/pull/1690)
 
 

--- a/docs/releases/2.5.3.md
+++ b/docs/releases/2.5.3.md
@@ -1,12 +1,12 @@
 # Datafaker 2.5.3 (26-10-2025)
 
-## What's Changed
+## What's changed
 * Add Apple types and colours [by Sergejs Visockis](https://github.com/datafaker-net/datafaker/pull/1697)
 * Add an ice-cream specification [by Sergejs Visockis](https://github.com/datafaker-net/datafaker/pull/1698)
 * Add "Gravity Falls" provider [by Victoria Ivanova](https://github.com/datafaker-net/datafaker/pull/1701)
 * Ukrainian Locale Enhancements [by Victoria Ivanova](https://github.com/datafaker-net/datafaker/pull/1704)
 
-## New Contributors
+## New contributors
 * @sergejsvisockis made their [first contribution](https://github.com/datafaker-net/datafaker/pull/1697)
 * @vicky-iv made their [first contribution](https://github.com/datafaker-net/datafaker/pull/1701)
 

--- a/docs/releases/2.5.4.md
+++ b/docs/releases/2.5.4.md
@@ -1,6 +1,6 @@
 # Datafaker 2.5.4 (11-02-2026)
 
-## What's Changed
+## What's changed
 
 * Enhance Commerce Provider testing with Ukrainian locale support by @vicky-iv in https://github.com/datafaker-net/datafaker/pull/1708
 * Improved address generation for Republic of Ireland by @89snake89 in https://github.com/datafaker-net/datafaker/pull/1714
@@ -10,7 +10,7 @@
 * Add new device models to device.yml by @yuokada in https://github.com/datafaker-net/datafaker/pull/1750
 * Fix avoid '&' in company domain names by @fhueter in https://github.com/datafaker-net/datafaker/pull/1757
 
-## New Contributors
+## New contributors
 
 * @ferclager made their first contribution in https://github.com/datafaker-net/datafaker/pull/1723
 * @tkachuksergiy8 made their first contribution in https://github.com/datafaker-net/datafaker/pull/1748

--- a/docs/releases/2.6.0.md
+++ b/docs/releases/2.6.0.md
@@ -1,6 +1,6 @@
  # Datafaker 2.6.0 (17-06-2026)
 
-## What's Changed
+## What's changed
 
 * Released Datafaker 2.5.4 by @github-actions[bot] in https://github.com/datafaker-net/datafaker/pull/1759
 * Docs update for 2.5.4 release & copyright to 2026 by @kingthorin in https://github.com/datafaker-net/datafaker/pull/1760
@@ -68,7 +68,7 @@
 * Bump org.sonatype.central:central-publishing-maven-plugin from 0.10.0 to 0.11.0 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1836
 * Bump com.diffplug.spotless:spotless-maven-plugin from 3.6.0 to 3.7.0 by @dependabot[bot] in https://github.com/datafaker-net/datafaker/pull/1837
 
-## New Contributors
+## New contributors
 
 * @ThanosTsiamis made their first contribution in https://github.com/datafaker-net/datafaker/pull/1788
 * @mvanhorn made their first contribution in https://github.com/datafaker-net/datafaker/pull/1794
@@ -76,7 +76,7 @@
 * @spannm made their first contribution in https://github.com/datafaker-net/datafaker/pull/1805
 * @yeoeol made their first contribution in https://github.com/datafaker-net/datafaker/pull/1812
 
-## Providers Added
+## Providers added
 
 * Aviation provider: added #uldType and #uldCode.
 * Photography provider: added more Canon and Nikon cameras.

--- a/docs/releases/2.7.0-SNAPSHOT.md
+++ b/docs/releases/2.7.0-SNAPSHOT.md
@@ -1,12 +1,12 @@
 # Datafaker 2.7.0-SNAPSHOT (dd-mm-yyyy)
 
-## What's Changed
+## What's changed
 * TBD
 
-## New Contributors
+## New contributors
 * TBD
 
-## Providers Added
+## Providers added
 * TBD
 
 See https://www.datafaker.net/documentation/providers/

--- a/material/partials/nav-item.html
+++ b/material/partials/nav-item.html
@@ -9,7 +9,7 @@
   {% if nav_item.children %}
     {% if "navigation.sections" in features and level == 1 + (
       "navigation.tabs" in features
-    ) %}
+    ) and nav_item.title not in ["2.x", "1.x"] %}
       {% set class = class ~ " md-nav__item--section" %}
     {% endif %}
     <li class="{{ class }} md-nav__item--nested">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,34 +119,36 @@ nav:
   - Releases:
     - 2.7.0-SNAPSHOT: releases/2.7.0-SNAPSHOT.md
     - 2.6.0: releases/2.6.0.md
-    - 2.5.4: releases/2.5.4.md
-    - 2.5.3: releases/2.5.3.md
-    - 2.5.2: releases/2.5.2.md
-    - 2.5.1: releases/2.5.1.md
-    - 2.5.0: releases/2.5.0.md
-    - 2.4.4: releases/2.4.4.md
-    - 2.4.3: releases/2.4.3.md
-    - 2.4.2: releases/2.4.2.md
-    - 2.4.1: releases/2.4.1.md
-    - 2.4.0: releases/2.4.0.md
-    - 2.3.1: releases/2.3.1.md
-    - 2.3.0: releases/2.3.0.md
-    - 2.2.2: releases/2.2.2.md
-    - 2.2.1: releases/2.2.1.md
-    - 2.2.0: releases/2.2.0.md
-    - 2.1.0: releases/2.1.0.md
-    - 2.0.2: releases/2.0.2.md
-    - 2.0.1: releases/2.0.1.md
-    - 2.0.0: releases/2.0.0.md
-    - 1.9.0: releases/1.9.0.md
-    - 1.8.0: releases/1.8.0.md
-    - 1.7.0: releases/1.7.0.md
-    - 1.6.0: releases/1.6.0.md
-    - 1.5.0: releases/1.5.0.md
-    - 1.4.0: releases/1.4.0.md
-    - 1.3.0: releases/1.3.0.md
-    - 1.2.0: releases/1.2.0.md
-    - 1.1.0: releases/1.1.0.md
-    - 1.0.0: releases/1.0.0.md
-    - 0.9.0: releases/0.9.0.md
+    - 2.x:
+      - 2.5.4: releases/2.5.4.md
+      - 2.5.3: releases/2.5.3.md
+      - 2.5.2: releases/2.5.2.md
+      - 2.5.1: releases/2.5.1.md
+      - 2.5.0: releases/2.5.0.md
+      - 2.4.4: releases/2.4.4.md
+      - 2.4.3: releases/2.4.3.md
+      - 2.4.2: releases/2.4.2.md
+      - 2.4.1: releases/2.4.1.md
+      - 2.4.0: releases/2.4.0.md
+      - 2.3.1: releases/2.3.1.md
+      - 2.3.0: releases/2.3.0.md
+      - 2.2.2: releases/2.2.2.md
+      - 2.2.1: releases/2.2.1.md
+      - 2.2.0: releases/2.2.0.md
+      - 2.1.0: releases/2.1.0.md
+      - 2.0.2: releases/2.0.2.md
+      - 2.0.1: releases/2.0.1.md
+      - 2.0.0: releases/2.0.0.md
+    - 1.x:
+      - 1.9.0: releases/1.9.0.md
+      - 1.8.0: releases/1.8.0.md
+      - 1.7.0: releases/1.7.0.md
+      - 1.6.0: releases/1.6.0.md
+      - 1.5.0: releases/1.5.0.md
+      - 1.4.0: releases/1.4.0.md
+      - 1.3.0: releases/1.3.0.md
+      - 1.2.0: releases/1.2.0.md
+      - 1.1.0: releases/1.1.0.md
+      - 1.0.0: releases/1.0.0.md
+      - 0.9.0: releases/0.9.0.md
   - In the news: in-the-media/links.md

--- a/src/test/java/net/datafaker/script/MkdocsReleaseNavUpdater.java
+++ b/src/test/java/net/datafaker/script/MkdocsReleaseNavUpdater.java
@@ -1,0 +1,130 @@
+package net.datafaker.script;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Updates the Releases navigation in {@code mkdocs.yml} as part of the post-release workflow.
+ *
+ * <p>Invoked from {@code .github/workflows/version-updates.yml} via {@code mvn exec:java} after
+ * the workflow has already:
+ * <ul>
+ *   <li>derived {@code RELEASED_VERSION} from the latest GitHub release tag</li>
+ *   <li>bumped {@code pom.xml} and derived {@code NEXT_VERSION} for the next snapshot</li>
+ *   <li>created {@code docs/releases/{RELEASED_VERSION}.md} and
+ *       {@code docs/releases/{NEXT_VERSION}-SNAPSHOT.md}</li>
+ *   <li>updated {@code extra.datafaker.version} and {@code extra.datafaker.snapshot} in
+ *       {@code mkdocs.yml}</li>
+ * </ul>
+ *
+ * <p>Expects {@code mkdocs.yml} to use the grouped Releases nav layout ({@code 2.x} section,
+ * top-level snapshot + latest stable entries). Nav links point at {@code releases/{version}.md}
+ * files that the workflow creates in the same run.
+ *
+ * <p>Usage: {@code MkdocsReleaseNavUpdater <released> <nextSnapshot> <mkdocs.yml>}
+ */
+public final class MkdocsReleaseNavUpdater {
+
+    private static final Pattern RELEASES_HEADER = Pattern.compile("^  - Releases:\\s*$");
+    private static final Pattern NEXT_TOP_LEVEL_NAV = Pattern.compile("^  - \\S");
+    private static final Pattern GROUP_2_X = Pattern.compile("^    - 2\\.x:\\s*$");
+    private static final Pattern TOP_SNAPSHOT = Pattern.compile("^    - \\d+\\.\\d+\\.\\d+-SNAPSHOT:");
+    private static final Pattern TOP_STABLE = Pattern.compile("^    - \\d+\\.\\d+\\.\\d+:");
+    private static final Pattern STABLE_VERSION = Pattern.compile("^    - (\\d+\\.\\d+\\.\\d+):");
+
+    private MkdocsReleaseNavUpdater() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 3) {
+            System.err.println("Usage: MkdocsReleaseNavUpdater <released> <nextSnapshot> <mkdocs.yml>");
+            System.exit(1);
+        }
+        Path path = Path.of(args[2]);
+        List<String> updated = updateNav(Files.readAllLines(path), args[0], args[1]);
+        Files.writeString(path, String.join("\n", updated) + "\n");
+    }
+
+    static List<String> updateNav(List<String> lines, String releasedVersion, String nextSnapshot) {
+        String oldSnapshot = releasedVersion + "-SNAPSHOT";
+        String previousStable = findPreviousStable(lines, releasedVersion);
+
+        List<String> out = new ArrayList<>(lines.size() + 2);
+        boolean inReleases = false;
+        for (String line : lines) {
+            if (RELEASES_HEADER.matcher(line).matches()) {
+                out.add(line);
+                inReleases = true;
+                if (!containsLine(lines, topLevelEntry(nextSnapshot))) {
+                    out.add(topLevelEntry(nextSnapshot));
+                }
+                if (!containsLine(lines, topLevelEntry(releasedVersion))) {
+                    out.add(topLevelEntry(releasedVersion));
+                }
+                continue;
+            }
+            if (inReleases && NEXT_TOP_LEVEL_NAV.matcher(line).matches()) {
+                inReleases = false;
+            }
+            if (inReleases && line.equals(topLevelEntry(oldSnapshot))) {
+                continue;
+            }
+            if (previousStable != null && line.equals(topLevelEntry(previousStable))) {
+                continue;
+            }
+            out.add(line);
+            if (previousStable != null
+                && GROUP_2_X.matcher(line).matches()
+                && !containsLine(lines, in2xEntry(previousStable))) {
+                out.add(in2xEntry(previousStable));
+            }
+        }
+        return out;
+    }
+
+    private static String findPreviousStable(List<String> lines, String releasedVersion) {
+        boolean inReleases = false;
+        for (String line : lines) {
+            if (RELEASES_HEADER.matcher(line).matches()) {
+                inReleases = true;
+                continue;
+            }
+            if (inReleases && NEXT_TOP_LEVEL_NAV.matcher(line).matches()) {
+                break;
+            }
+            if (inReleases && GROUP_2_X.matcher(line).matches()) {
+                break;
+            }
+            if (inReleases && TOP_SNAPSHOT.matcher(line).matches()) {
+                continue;
+            }
+            if (inReleases && TOP_STABLE.matcher(line).lookingAt() && !line.contains("-SNAPSHOT")) {
+                Matcher matcher = STABLE_VERSION.matcher(line);
+                if (matcher.find()) {
+                    String version = matcher.group(1);
+                    if (!version.equals(releasedVersion)) {
+                        return version;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean containsLine(List<String> lines, String entry) {
+        return lines.stream().anyMatch(entry::equals);
+    }
+
+    private static String topLevelEntry(String version) {
+        return "    - " + version + ": releases/" + version + ".md";
+    }
+
+    private static String in2xEntry(String version) {
+        return "      - " + version + ": releases/" + version + ".md";
+    }
+}

--- a/src/test/java/net/datafaker/script/MkdocsReleaseNavUpdaterTest.java
+++ b/src/test/java/net/datafaker/script/MkdocsReleaseNavUpdaterTest.java
@@ -1,0 +1,64 @@
+package net.datafaker.script;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MkdocsReleaseNavUpdaterTest {
+
+    private static final List<String> SAMPLE = List.of(
+        "nav:",
+        "  - Releases:",
+        "    - 2.7.0-SNAPSHOT: releases/2.7.0-SNAPSHOT.md",
+        "    - 2.6.0: releases/2.6.0.md",
+        "    - 2.x:",
+        "      - 2.5.4: releases/2.5.4.md",
+        "  - In the news: in-the-media/links.md"
+    );
+
+    @Test
+    void updateNavOnRelease() {
+        List<String> updated = MkdocsReleaseNavUpdater.updateNav(SAMPLE, "2.7.0", "2.8.0-SNAPSHOT");
+
+        assertEquals(List.of(
+            "nav:",
+            "  - Releases:",
+            "    - 2.8.0-SNAPSHOT: releases/2.8.0-SNAPSHOT.md",
+            "    - 2.7.0: releases/2.7.0.md",
+            "    - 2.x:",
+            "      - 2.6.0: releases/2.6.0.md",
+            "      - 2.5.4: releases/2.5.4.md",
+            "  - In the news: in-the-media/links.md"
+        ), updated);
+        assertFalse(updated.contains("    - 2.7.0-SNAPSHOT: releases/2.7.0-SNAPSHOT.md"));
+    }
+
+    @Test
+    void updateNavIsIdempotentWhenEntriesExist() {
+        List<String> current = MkdocsReleaseNavUpdater.updateNav(SAMPLE, "2.7.0", "2.8.0-SNAPSHOT");
+        List<String> again = MkdocsReleaseNavUpdater.updateNav(current, "2.7.0", "2.8.0-SNAPSHOT");
+
+        assertEquals(current, again);
+    }
+
+    @Test
+    void updateNavWhenNoPreviousStableAtTopLevel() {
+        List<String> nav = List.of(
+            "  - Releases:",
+            "    - 2.7.0-SNAPSHOT: releases/2.7.0-SNAPSHOT.md",
+            "    - 2.x:",
+            "      - 2.5.4: releases/2.5.4.md"
+        );
+
+        List<String> updated = MkdocsReleaseNavUpdater.updateNav(nav, "2.7.0", "2.8.0-SNAPSHOT");
+
+        assertTrue(updated.contains("    - 2.8.0-SNAPSHOT: releases/2.8.0-SNAPSHOT.md"));
+        assertTrue(updated.contains("    - 2.7.0: releases/2.7.0.md"));
+        assertFalse(updated.contains("    - 2.7.0-SNAPSHOT: releases/2.7.0-SNAPSHOT.md"));
+        assertEquals("      - 2.5.4: releases/2.5.4.md", updated.get(updated.indexOf("    - 2.x:") + 1));
+    }
+}

--- a/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
+++ b/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
@@ -274,7 +274,7 @@ public class ProvidersDocsGenerator {
     }
 
     private enum TextBlock {
-        HEADER("# Fake Data Providers\n"),
+        HEADER("# Fake data providers\n"),
         GROUP_DESCRIPTIONS("""
 
             #### Provider groups:

--- a/src/test/java/net/datafaker/script/ReleaseNotesGenerator.java
+++ b/src/test/java/net/datafaker/script/ReleaseNotesGenerator.java
@@ -1,0 +1,73 @@
+package net.datafaker.script;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds a release notes markdown file for the post-release workflow.
+ *
+ * <p>Invoked from {@code .github/workflows/version-updates.yml} via {@code mvn exec:java}.
+ * The workflow supplies:
+ * <ul>
+ *   <li>{@code RELEASED_VERSION} — from the latest GitHub release tag</li>
+ *   <li>{@code TODAY} — current date in {@code dd-mm-yyyy} format</li>
+ *   <li>{@code docs/releases/.RELEASE-template.md} — placeholders {@code X.Y.Z} and
+ *       {@code dd-mm-yyyy}, plus a {@code ## What's changed} heading where the body is inserted</li>
+ *   <li>a temp file containing the GitHub release body ({@code gh release view ... --json body})</li>
+ *   <li>output path {@code docs/releases/{RELEASED_VERSION}.md} (must not already exist)</li>
+ * </ul>
+ *
+ * <p>Strips {@code #} from bullet lines like {@code * #1234 ...} so issue numbers are not
+ * treated as markdown headings.
+ *
+ * <p>Usage: {@code ReleaseNotesGenerator <version> <date> <template> <output> <body>}
+ */
+public final class ReleaseNotesGenerator {
+
+    static final String WHATS_CHANGED = "## What's changed";
+    private static final Pattern ISSUE_HASH_BULLET = Pattern.compile("^(\\s*[-*]\\s*)#(\\d+)");
+
+    private ReleaseNotesGenerator() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 5) {
+            System.err.println("Usage: ReleaseNotesGenerator <version> <date> <template> <output> <body>");
+            System.exit(1);
+        }
+        String template = Files.readString(Path.of(args[2]));
+        String body = Files.readString(Path.of(args[4]));
+        Files.writeString(Path.of(args[3]), generate(template, args[0], args[1], body));
+    }
+
+    static String generate(String template, String version, String date, String releaseBody) {
+        List<String> bodyLines = releaseBody.isEmpty() ? List.of() : List.of(releaseBody.split("\n", -1));
+        return generate(List.of(template.split("\n", -1)), version, date, bodyLines);
+    }
+
+    static String generate(List<String> templateLines, String version, String date, List<String> bodyLines) {
+        List<String> out = new ArrayList<>(templateLines.size() + bodyLines.size());
+        boolean inserted = false;
+        for (String line : templateLines) {
+            out.add(line.replace("X.Y.Z", version).replace("dd-mm-yyyy", date));
+            if (!inserted && WHATS_CHANGED.equals(out.get(out.size() - 1))) {
+                out.add("");
+                for (String bodyLine : bodyLines) {
+                    out.add(stripIssueHash(bodyLine));
+                }
+                inserted = true;
+            }
+        }
+        return String.join("\n", out) + "\n";
+    }
+
+    static String stripIssueHash(String line) {
+        Matcher matcher = ISSUE_HASH_BULLET.matcher(line);
+        return matcher.find() ? matcher.replaceFirst("$1$2") : line;
+    }
+}

--- a/src/test/java/net/datafaker/script/ReleaseNotesGeneratorTest.java
+++ b/src/test/java/net/datafaker/script/ReleaseNotesGeneratorTest.java
@@ -1,0 +1,90 @@
+package net.datafaker.script;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReleaseNotesGeneratorTest {
+
+    private static final List<String> TEMPLATE = List.of(
+        "# Datafaker X.Y.Z (dd-mm-yyyy)",
+        "",
+        ReleaseNotesGenerator.WHATS_CHANGED,
+        "",
+        "## New contributors",
+        "",
+        "* TBD"
+    );
+
+    @Test
+    void generateReplacesPlaceholdersAndInsertsBody() {
+        String result = ReleaseNotesGenerator.generate(
+            TEMPLATE,
+            "2.7.0",
+            "18-06-2026",
+            List.of("* Fix bug", "* Add feature")
+        );
+
+        assertTrue(result.startsWith("# Datafaker 2.7.0 (18-06-2026)\n"));
+        assertTrue(result.contains("""
+            ## What's changed
+
+            * Fix bug
+            * Add feature
+
+            ## New contributors
+            """));
+    }
+
+    @Test
+    void generateStripsIssueHashFromBullets() {
+        String result = ReleaseNotesGenerator.generate(
+            TEMPLATE,
+            "2.7.0",
+            "18-06-2026",
+            List.of("* #1756 generate airport codes", "- #42 answer")
+        );
+
+        assertTrue(result.contains("* 1756 generate airport codes"));
+        assertTrue(result.contains("- 42 answer"));
+    }
+
+    @Test
+    void generateLeavesNonMatchingLinesUntouched() {
+        String result = ReleaseNotesGenerator.generate(
+            TEMPLATE,
+            "2.7.0",
+            "18-06-2026",
+            List.of("## Not a bullet", "* no hash here")
+        );
+
+        assertTrue(result.contains("## Not a bullet"));
+        assertTrue(result.contains("* no hash here"));
+    }
+
+    @Test
+    void generateFromStringBody() {
+        String result = ReleaseNotesGenerator.generate(
+            String.join("\n", TEMPLATE),
+            "2.7.0",
+            "18-06-2026",
+            "* one\n* two"
+        );
+
+        assertEquals("""
+            # Datafaker 2.7.0 (18-06-2026)
+
+            ## What's changed
+
+            * one
+            * two
+
+            ## New contributors
+
+            * TBD
+            """, result);
+    }
+}


### PR DESCRIPTION
- Standardize docs and release note headings to sentence case
- Group older releases under collapsible 2.x and 1.x sections in the sidebar
- Replace fragile awk scripts in the release workflow with small Java helpers (with tests)

> [!NOTE]
> I did setup mkdocs and test the site changes locally.