### PR TITLE
fix(docs): render 2.6.0 release page H1

### DIFF
--- a/docs/releases/2.6.0.md
+++ b/docs/releases/2.6.0.md
@@ -1,4 +1,4 @@
- # Datafaker 2.6.0 (17-06-2026)
+# Datafaker 2.6.0 (17-06-2026)
 
 ## What's changed
 


### PR DESCRIPTION
Leading space before the markdown heading prevented MkDocs from recognizing the title on the 2.6.0 release notes page.