### PR TITLE
docs: fix typos, syntax, formating

### DIFF
--- a/docs/documentation/contributing.md
+++ b/docs/documentation/contributing.md
@@ -8,7 +8,8 @@ First and foremost thanks to anyone who contributes, very much appreciated.
 - Submit a PR with your change and if there are no comments, changes will be merged in.
 - If you're not sure about the change, raise an issue and have a discussion before spending time coding it up.
 - Try and make one logical change per PR. That is not make many changes in one PR. Submit multiple PRs instead.
-- Starting with Datafaker 2.x, Java 17 is our target version. If you need anything older than that, we recommend using the 1.x versions of Datafaker instead. Note that while the 1.x is stable and free of known bugs, this branch won't receive future updates.
+- Starting with Datafaker 2.x, Java 17 is our target version. If you need anything older than that, we recommend using the 1.x versions of Datafaker instead.
+  > **Note**: that while the 1.x is stable and free of known bugs, this branch won't receive future updates.
 
 ## Building
 

--- a/docs/documentation/contributing.md
+++ b/docs/documentation/contributing.md
@@ -9,7 +9,7 @@ First and foremost thanks to anyone who contributes, very much appreciated.
 - If you're not sure about the change, raise an issue and have a discussion before spending time coding it up.
 - Try and make one logical change per PR. That is not make many changes in one PR. Submit multiple PRs instead.
 - Starting with Datafaker 2.x, Java 17 is our target version. If you need anything older than that, we recommend using the 1.x versions of Datafaker instead.
-  > **Note**: that while the 1.x is stable and free of known bugs, this branch won't receive future updates.
+  > **Note**: While 1.x is stable and functional, it is not intended that that version of the code recieve any further updates.
 
 ## Building
 

--- a/docs/documentation/custom-providers.md
+++ b/docs/documentation/custom-providers.md
@@ -1,16 +1,15 @@
 # Custom providers
 
-Since version 1.2.0 of Datafaker it's possible create your own provider of data.
+Since version 1.2.0 of Datafaker it's possible to create your own provider of data.
 
 A [full example](https://github.com/datafaker-net/datafaker/blob/main/src/test/java/net/datafaker/providers/base/CustomFakerTest.java) can be found in the source code.
-
 
 ## Custom hardcoded provider
 
 To create a custom provider of data, you'll need to do the following steps:
 
-* Create custom provider of data
-* Create your own custom faker which extends `Faker` and register custom provider
+* Create custom provider of data.
+* Create your own custom faker which extends `Faker` and register custom provider.
 
 In code, this would look like the following:
 
@@ -20,16 +19,9 @@ Create a custom provider of data:
 
 === "Java"
 
-    ``` java
+    ```java
     public static class Insect extends AbstractProvider<BaseProviders> {
-        private static final WeightedRandomSelector selector = new WeightedRandomSelector(new Random());
-
         private static final String[] INSECT_NAMES = { "Ant", "Beetle", "Butterfly", "Wasp" };
-        private static final List<Map<String, Object>> WEIGHTED_INSECTS = List.of(
-            Map.of("value", "Driver ant", "weight", 6.0),
-            Map.of("value", "Fire ant", "weight", 3.0),
-            Map.of("value", "Harvester ant", "weight", 1.0)
-        );
 
         public Insect(BaseProviders faker) {
             super(faker);
@@ -37,10 +29,6 @@ Create a custom provider of data:
 
         public String nextInsectName() {
             return INSECT_NAMES[faker.random().nextInt(INSECT_NAMES.length)];
-        }
-
-        public String weightedInsectName() {
-            return selector.select(WEIGHTED_INSECTS);
         }
     }
     ```
@@ -51,7 +39,7 @@ Create your own custom faker, which extends `Faker`, and register the custom pro
 
 === "Java"
 
-    ``` java
+    ```java
     public static class MyCustomFaker extends Faker {
         public Insect insect() {
             return getProvider(Insect.class, Insect::new, this);
@@ -65,41 +53,62 @@ To use the custom faker, you can do the following:
 
 === "Java"
 
-    ``` java
+    ```java
     MyCustomFaker myFaker = new MyCustomFaker();
     System.out.println(myFaker.insect().nextInsectName());
     ```
 
 This will print something like the following:
+`Wasp`
 
-```
-Wasp
-```
+### Weighted random selection
 
-> **Usage of weigted random selector is in the POC stage and is currently available only for custom hardcoded providers.**
+> **Note**: Usage of weighted random selector is in the POC stage and is currently available only for custom hardcoded providers.
 
-To use a random selector based on weights, you can do the following:
+Since version 2.4.2 of Datafaker it's possible to use a random selector based on weights, add a `WeightedRandomSelector` and weighted values to your provider:
 
 === "Java"
 
-    ``` java
+    ```java
+    public static class Insect extends AbstractProvider<BaseProviders> {
+        private static final WeightedRandomSelector selector = new WeightedRandomSelector(new Random());
+
+        private static final List<Map<String, Object>> WEIGHTED_INSECTS = List.of(
+            Map.of("value", "Driver ant", "weight", 6.0),
+            Map.of("value", "Fire ant", "weight", 3.0),
+            Map.of("value", "Harvester ant", "weight", 1.0)
+        );
+
+        public Insect(BaseProviders faker) {
+            super(faker);
+        }
+
+        public String weightedInsectName() {
+            return selector.select(WEIGHTED_INSECTS);
+        }
+    }
+    ```
+
+Then call the weighted method on your custom faker:
+
+=== "Java"
+
+    ```java
     MyCustomFaker myFaker = new MyCustomFaker();
     System.out.println(myFaker.insect().weightedInsectName());
     ```
 
-This will return a random insect name but based on the provided weights
-```
-Driver ant
-```
+This will return a random insect name but based on the provided weights.
+`Driver ant`
 
 ## Custom provider using YAML file
 
-In case you have a large set of data to load, it might be better to use a Yaml file.
+In case you have a large set of data to load, it might be better to use a YAML file.
 
-To create a custom provider of data fom a file, you'll need to do the following steps:
+To create a custom provider of data from a file, you'll need to do the following steps:
 
-* Create a custom provider of data
-* Create your own custom faker which extends `Faker` and register custom provider
+* Create a custom provider of data.
+* Create your own custom faker which extends `Faker` and register custom provider.
 
 ### YAML provider
 
@@ -107,7 +116,7 @@ First, create the custom provider which loads the data from a file:
 
 === "Java"
 
-    ``` java
+    ```java
     public class InsectFromFile extends AbstractProvider<BaseProviders> {
         private static final String KEY = "insectsfromfile";
         
@@ -145,14 +154,13 @@ en:
       bees: ['Bumblebee', 'Euglossine bee', 'Honeybee', 'Carpenter bee', 'Leaf-cutter bee', 'Mining bee']
 ```
 
-
 ### Register provider
 
 Registering the provider would happen like this:
 
 === "Java"
 
-    ``` java
+    ```java
     public static class MyCustomFaker extends Faker {
         public InsectFromFile insectFromFile() {
             return getProvider(InsectFromFile.class, InsectFromFile::new, this);
@@ -166,13 +174,10 @@ To use the custom faker, you can do the following:
 
 === "Java"
 
-    ``` java
+    ```java
     MyCustomFaker myFaker = new MyCustomFaker();
     System.out.println(myFaker.insectFromFile().ant());
     ```
 
-This will print something like the following:
-
-```
-Honey ant
-```
+This will print something like the following: 
+`Honey ant`

--- a/docs/documentation/date-format.md
+++ b/docs/documentation/date-format.md
@@ -5,18 +5,18 @@ Since 1.2.0 Datafaker supports specifying of date formats for dates and timestam
 
 === "Java"
 
-    ``` java 
+    ```java
     Faker faker = new Faker();
     System.out.println(faker.timeAndDate().future(1, TimeUnit.HOURS, "yyyy MM.dd mm:hh:ss"));
     System.out.println(faker.timeAndDate().past(1, TimeUnit.HOURS, "yyyy-MM-dd mm:hh:ss"));
     System.out.println(faker.timeAndDate().birthday(1, 99, "yyyy/MM/dd"));
     ```
 
-And also this feature could be used in expressions like
+This feature could also be used in expressions like:
 
 === "Java"
 
-    ``` java 
+    ```java
     faker.expression("#{date.past '15','SECONDS','dd/MM/yyyy hh:mm:ss'}");
     ```
 

--- a/docs/documentation/expressions.md
+++ b/docs/documentation/expressions.md
@@ -1,97 +1,137 @@
 # Expressions
 
-Datafaker supports different kind of expressions which allows to customise the output. 
+Datafaker supports different kinds of expressions which allows to customize the output. 
 
 ## Letterify
+
 This one will replace `?` symbols with latin letters e.g.
-```java
-Faker faker = new Faker();
-faker.expression("#{letterify 'test????test'}"); // could give e.g. testqwastest
-// Also there could a third argument telling if characters should be uppercase
-faker.expression("#{letterify 'test????test','true'}"); // could give e.g. testSKDLtest
-```
+
+=== "Java"
+
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{letterify 'test????test'}"); // could give e.g. testqwastest
+    // Also there could a third argument telling if characters should be uppercase
+    faker.expression("#{letterify 'test????test','true'}"); // could give e.g. testSKDLtest
+    ```
 
 ## Numerify
-This one will replace `#` symbols with digits e.g.
-```java
-Faker faker = new Faker();
-faker.expression("#{numerify '#test#'}"); // could give e.g. 3test5
-faker.expression("#{numerify '####'}"); // could give e.g. 1234
-```
 
-##Bothify
+This one will replace `#` symbols with digits e.g.
+
+=== "Java"
+    
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{numerify '#test#'}"); // could give e.g. 3test5
+    faker.expression("#{numerify '####'}"); // could give e.g. 1234
+    ```
+
+## Bothify
+
 Applies both letterify and numerify e.g.
-```java
-Faker faker = new Faker();
-faker.expression("#{bothify '?#?#?#?#'}"); // could give a1b2c3d4
-faker.expression("#{bothify '?#?#?#?#', 'true'}"); // could give A1B2C3D4
-```
+
+=== "Java"
+
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{bothify '?#?#?#?#'}"); // could give a1b2c3d4
+    faker.expression("#{bothify '?#?#?#?#', 'true'}"); // could give A1B2C3D4
+    ```
 
 ## Templatify
-This is available since 1.2.0
+
+This is available since 1.2.0.
 
 This one will replace symbol mentioned in the second args with one of symbols mentioned after it.
-```java
-Faker faker = new Faker();
-// e.g. there is expression test and we want to replace t with q or @
-faker.expression("#{templatify 'test','t','q','@'}"); // could give @esq
-// another example there is expression test and we want to replace t with q or @ or $ or *
-faker.expression("#{templatify 'test','t','q','@','$','*'}"); // could give @esq
-```
+
+=== "Java"
+
+    ```java
+    Faker faker = new Faker();
+    // e.g. there is expression test and we want to replace t with q or @
+    faker.expression("#{templatify 'test','t','q','@'}"); // could give @esq
+    // another example there is expression test and we want to replace t with q or @ or $ or *
+    faker.expression("#{templatify 'test','t','q','@','$','*'}"); // could give @esq
+    ```
 
 ## Examplify
+
 This one will replace symbols by example: uppercase with uppercase, digit with digit, lowercase with lowercase.
-```java
-Faker faker = new Faker();
-faker.expression("#{examplify 'ABC'}"); // could give QWE
-faker.expression("#{examplify 'test'}"); // could give ghjk
-```
+
+=== "Java"
+
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{examplify 'ABC'}"); // could give QWE
+    faker.expression("#{examplify 'test'}"); // could give ghjk
+    ```
 
 ## Regexify
-This one allows generating output based on regexp, e.g.
-```java
-Faker faker = new Faker();
-faker.expression("#{regexify '(a|b){2,3}'}"); // could give ab
-faker.regexify("[a-z]{4,10}"); // could give wbevoa
-```
+
+This one allows generating output based on regular expression(s), e.g.
+
+=== "Java"
+
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{regexify '(a|b){2,3}'}"); // could give ab
+    faker.regexify("[a-z]{4,10}"); // could give wbevoa
+    ```
 
 ## Options
-This is available since 1.2.0
+
+This is available since 1.2.0.
 
 This will return one from the provided options e.g.
-```java
-Faker faker = new Faker();
-faker.expression("#{options.option 'ABC','2','5','$'}"); // could give $
-faker.expression("#{options.option '23','2','5','$','%','*'}"); // could give *
-```
-## CSV
-This is available since 1.4.0
 
-The expression will return generated csv based on input parameters
-```java
-faker.expression("#{csv '1','name_column','#{Name.first_name}','last_name_column','#{Name.last_name}'}");
-// "name_column","last_name_column"
-// "Sabrina","Kihn"
-faker.expression("#{csv ' ### ','\"','false','3','name_column','#{Name.first_name}','last_name_column','#{Name.last_name}'}");
-// "Thad" ### "Crist"
-// "Kathryne" ### "Wuckert"
-// "Sybil" ### "Connelly"
-```
+=== "Java"
+    
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{options.option 'ABC','2','5','$'}"); // could give $
+    faker.expression("#{options.option '23','2','5','$','%','*'}"); // could give *
+    ```
+
+## CSV
+
+This is available since 1.4.0.
+
+The expression will return generated csv based on input parameters.
+
+=== "Java"
+
+    ```java
+    faker.expression("#{csv '1','name_column','#{Name.first_name}','last_name_column','#{Name.last_name}'}");
+    // "name_column","last_name_column"
+    // "Sabrina","Kihn"
+    faker.expression("#{csv ' ### ','\"','false','3','name_column','#{Name.first_name}','last_name_column','#{Name.last_name}'}");
+    // "Thad" ### "Crist"
+    // "Kathryne" ### "Wuckert"
+    // "Sybil" ### "Connelly"
+    ```
 
 ## JSON
-This is available since 1.4.0
 
-The expression will return generated json based on input parameters
-```java
-faker.expression("#{json 'person','#{json ''first_name'',''#{Name.first_name}'',''last_name'',''#{Name.last_name}''}','address','#{json ''country'',''#{Address.country}'',''city'',''#{Address.city}''}'}");
-// {"person": {"first_name": "Barbie", "last_name": "Durgan"}, "address": {"country": "Albania", "city": "East Catarinahaven"}}
+This is available since 1.4.0.
 
-```
+The expression will return generated json based on input parameters.
+
+=== "Java"
+
+    ```java
+    faker.expression("#{json 'person','#{json ''first_name'',''#{Name.first_name}'',''last_name'',''#{Name.last_name}''}','address','#{json ''country'',''#{Address.country}'',''city'',''#{Address.city}''}'}");
+    // {"person": {"first_name": "Barbie", "last_name": "Durgan"}, "address": {"country": "Albania", "city": "East Catarinahaven"}}
+    ```
 
 ## Others
+
 It is possible to call methods returning string values and taking primitive or string args via expressions e.g.
-```java
-Faker faker = new Faker();
-faker.expression("#{date.birthday 'yy DDD hh:mm:ss'}");
-faker.expression("#{color.name}");
-```
+
+=== "Java"
+    
+    ```java
+    Faker faker = new Faker();
+    faker.expression("#{date.birthday 'yy DDD hh:mm:ss'}");
+    faker.expression("#{color.name}");
+    ```

--- a/docs/documentation/formats.md
+++ b/docs/documentation/formats.md
@@ -15,7 +15,7 @@ attributes using randomly generated data in the following way:
 
 === "Java"
 
-    ``` java
+    ```java
     public static void main(String[] args) {
         Faker faker = new Faker();
 
@@ -87,7 +87,7 @@ In case you only want to generate XML elements, without any attributes, that pos
 
 === "Java"
 
-    ``` java
+    ```java
     Faker faker = new Faker();
     Collection<Xml.XmlNode> address = faker.<Xml.XmlNode>collection()
             .suppliers(() -> new Xml.XmlNode("address",

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -12,7 +12,7 @@ Datafaker can be included in your project using most dependency management tools
 
 === "Maven"
 
-    ``` sh
+    ```sh
     <dependency>
         <groupId>net.datafaker</groupId>
         <artifactId>datafaker</artifactId>
@@ -22,7 +22,7 @@ Datafaker can be included in your project using most dependency management tools
 
 === "Gradle (Groovy)"
 
-    ``` sh
+    ```sh
     dependencies {
         implementation 'net.datafaker:datafaker:{{ datafaker.version }}'
     }
@@ -30,7 +30,7 @@ Datafaker can be included in your project using most dependency management tools
 
 === "Gradle (Kotlin)"
 
-    ``` sh
+    ```sh
     dependencies {
         implementation("net.datafaker:datafaker:{{ datafaker.version }}")
     }
@@ -38,10 +38,9 @@ Datafaker can be included in your project using most dependency management tools
 
 === "Ivy"
 
-    ``` sh
+    ```sh
     <dependency org="net.datafaker" name="datafaker" rev="{{ datafaker.version }}"/>
     ```
-
 
 ### Snapshot versions
 
@@ -50,7 +49,7 @@ by including the Sonatype snapshot repository in your configuration.
 
 A Gradle example can be found below:
 
-``` sh
+```sh
 repositories {
     mavenCentral()
     maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots")
@@ -67,7 +66,7 @@ To use Datafaker to generate fake data, you can use the following code as an exa
 
 === "Java"
 
-    ``` java
+    ```java
     import net.datafaker.Faker;
     
     Faker faker = new Faker();
@@ -81,7 +80,7 @@ To use Datafaker to generate fake data, you can use the following code as an exa
 
 === "Kotlin"
 
-    ```
+    ```kotlin
     import net.datafaker.Faker
     
     val faker = Faker()

--- a/docs/documentation/password.md
+++ b/docs/documentation/password.md
@@ -4,9 +4,10 @@ Starting 1.7.0 there is `Text` provider which allows to generate arbitrary strin
 Now it allows to specify different set of symbols which should be contained and minimum amount of symbols per such set.
 
 Imagine there is a need to generate a password with length 8 and containing minimum 3 digits and 2 upper case symbols from en locale.
+
 === "Java"
 
-    ``` java
+    ```java
          var faker = new Faker();
          String password = faker.text().text(Text.TextSymbolsBuilder.builder()
                              .len(8)
@@ -15,9 +16,10 @@ Imagine there is a need to generate a password with length 8 and containing mini
     ```
 It also allows to use custom symbol sets. For example this will generate a string with length between 8 and 10. 
 The string will contain min 3 lower case symbols from ru locale and minimum 5 symbols from the defined string `customSpecialSymbols`.
+
 === "Java"
 
-    ``` java
+    ```java
           final String ruLowerCase = "абвгдеёжзийклмнопрстуфхцчшщъыьэюя";
           final String customSpecialSymbols = "!@#$%^*;'][{}";
           final int ruCnt = 3;
@@ -28,4 +30,3 @@ The string will contain min 3 lower case symbols from ru locale and minimum 5 sy
               .with(customSpecialSymbols, specSmbCnt).build();
           final String text = faker.text().text(config);
     ```
-

--- a/docs/documentation/performance140.md
+++ b/docs/documentation/performance140.md
@@ -35,7 +35,7 @@ So, it looks like the only test which were done is checking `Faker.name().name()
 
 Ok, let's start with the similar test here. Similar, because we are going to use JMH which was not used in their test.
 If applicable we try to execute same tests we did for previous section. So let's start with the original test from
-Kotlin Faker
+Kotlin Faker.
 
 ### Original Kotlin Faker test
 
@@ -65,7 +65,7 @@ jdk18 Datafaker is about 20% faster. JFairy and Java Faker are far behind.
 ### Initialization
 
 It's worth to measure since initially during initialization of Faker object it requires to
-initialise all the providers objects and read all the yaml files for providers.
+initialize all the providers objects and read all the yaml files for providers.
 
 Tests for initialization could be found at `net.datafaker.benchmark.initialization`
 Initialization:
@@ -89,7 +89,7 @@ Initialization:
 
 Performance of simple method calls like `fullname`, `firstname`, `address`.
 
-Tests could be found at `net.datafaker.benchmark.simplemethods`
+Tests could be found at `net.datafaker.benchmark.simplemethods`.
 
 #### Firstname:
 
@@ -263,7 +263,7 @@ Since only Datafaker and Java Faker support method invocations, there are only t
 | Java Faker | openjdk-18.0.1.0.10-1.rolling.fc36.x86_64  | thrpt | 10  | 207.275 ± 3.522   | ops/ms |
 
 Similar example as previous, however there are 3 methods. Besides, cache of parsed methods there was also added cache
-for parsed args.
+for parsed arguments.
 
 | Project    | Java Version                               | Mode  | Cnt | Score            | Units  |
 |:-----------|:-------------------------------------------|:------|:----|:-----------------|:-------|
@@ -286,5 +286,5 @@ However, here it is interesting how much a 1 thread application can generated in
 The code below for Datafaker generates a bit more than 170M objects for 1 hour.
 The same code for Java Faker generates about 38M for 1 hour, meaning on average, Datafaker is about 4x faster than Javafaker.
 
-Kotlin Faker does not support setting of birthday and blood. Without these 2 params it generates about 90M for 1 hour.
+Kotlin Faker does not support setting of birthday and blood. Without these 2 parameters it generates about 90M for 1 hour.
 `net.datafaker.benchmark.generate_one_hour`

--- a/docs/documentation/performance170.md
+++ b/docs/documentation/performance170.md
@@ -35,7 +35,7 @@ So, it looks like the only test which were done is checking `Faker.name().name()
 
 Ok, let's start with the similar test here. Similar, because we are going to use JMH which was not used in their test.
 If applicable we try to execute same tests we did for previous section. So let's start with the original test from
-Kotlin Faker
+Kotlin Faker.
 
 ### Original Kotlin Faker test
 
@@ -67,7 +67,7 @@ Kotlin Faker
 ### Initialization
 
 It's worth to measure since initially during initialization of Faker object it requires to
-initialise all the providers objects and read all the yaml files for providers.
+initialize all the providers objects and read all the yaml files for providers.
 
 Tests for initialization could be found at `net.datafaker.benchmark.initialization`
 Initialization:
@@ -95,7 +95,7 @@ Initialization:
 
 Performance of simple method calls like `fullname`, `firstname`, `address`.
 
-Tests could be found at `net.datafaker.benchmark.simplemethods`
+Tests could be found at `net.datafaker.benchmark.simplemethods`.
 
 #### Firstname:
 
@@ -165,7 +165,7 @@ Tests could be found at `net.datafaker.benchmark.simplemethods`
 From one side Kotlin Faker and JFairy do not support expressions, from the other side Kotlin Faker supports
 numerify/bothify/letterify and regexify operations.
 
-So, the tests are done based on [Kotlin Faker's doc page](https://serpro69.github.io/kotlin-faker/wiki/extras/#random-strings-from-templates)
+So, the tests are done based on [Kotlin Faker's doc page](https://serpro69.github.io/kotlin-faker/wiki/extras/#random-strings-from-templates).
 
 #### Numerify:
 

--- a/docs/documentation/providers.md
+++ b/docs/documentation/providers.md
@@ -9,7 +9,7 @@
 - Sport (Providers for different types of sport)
 - Videogame (Video game providers)
 
-Number of providers per Datafaker version
+Number of providers per Datafaker version:
 
 | Version | Number of new providers | Total number of providers |
 |---------|-------------------------|---------------------------|

--- a/docs/documentation/schemas.md
+++ b/docs/documentation/schemas.md
@@ -23,42 +23,42 @@ Example of schema definition:
 
 === "Java"
 
-    ``` java
-        Schema<String, String> schema =
-            Schema.of(
-                field("first_name", () -> faker.name().firstName()),
-                field("last_name", () -> faker.name().lastName()),
-                field("address", () -> faker.address().streetAddress()));
+    ```java
+    Schema<String, String> schema =
+        Schema.of(
+            field("first_name", () -> faker.name().firstName()),
+            field("last_name", () -> faker.name().lastName()),
+            field("address", () -> faker.address().streetAddress()));
     ```
 
 === "Kotlin"
 
-    ``` kotlin
-        val faker = BaseFaker()
+    ```kotlin
+    val faker = BaseFaker()
 
-        val schema = Schema.of(
-            field("first_name",
-                Supplier { faker.name().firstName() }),
-            field("last_name",
-                Supplier { faker.name().lastName() }),
-            field<String, String>("address",
-                Supplier { faker.address().streetAddress() })
-        )
+    val schema = Schema.of(
+        field("first_name",
+            Supplier { faker.name().firstName() }),
+        field("last_name",
+            Supplier { faker.name().lastName() }),
+        field<String, String>("address",
+            Supplier { faker.address().streetAddress() })
+    )
     ```
 
 It is also supported nested(composite) fields e.g.:
 
 === "Java"
 
-    ``` java
-        Schema.of(
-            compositeField("key", new Field[]{field("key", () -> "value")}));
+    ```java
+    Schema.of(
+        compositeField("key", new Field[]{field("key", () -> "value")}));
     ```
 
 === "Kotlin"
 
-    ``` kotlin
-        Schema.of(compositeField("key", arrayOf(field("key", Supplier { "value" }))))
+    ```kotlin
+    Schema.of(compositeField("key", arrayOf(field("key", Supplier { "value" }))))
     ```
 
 ## CSV transformation
@@ -67,15 +67,15 @@ CSV transformer could be build with help of `CsvTransformer.CsvTransformerBuilde
 
 === "Java"
 
-    ``` java
-         CsvTransformer<String> transformer =
-            CsvTransformer.<String>builder().header(true).separator(separator).build();
+    ```java
+    CsvTransformer<String> transformer =
+        CsvTransformer.<String>builder().header(true).separator(separator).build();
     ```
 
 === "Kotlin"
 
-    ``` kotlin
-        val transformer = CsvTransformer.builder<String>().header(true).separator(separator).build()
+    ```kotlin
+    val transformer = CsvTransformer.builder<String>().header(true).separator(separator).build()
     ```
 
 The following can be configured:
@@ -87,14 +87,14 @@ To generate data based on a schema just call `generate` against `schema`:
 
 === "Java"
 
-    ``` java
-         String csv = transformer.generate(schema, limit);
+    ```java
+     String csv = transformer.generate(schema, limit);
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val csv = transformer.generate(schema, limit)
+    val csv = transformer.generate(schema, limit)
     ```
 
 Also it's possible to use schemas to transform existing data. E.g. there is a collection of `Name` objects 
@@ -102,29 +102,29 @@ and we are going to build csv of first and last names based on this collection:
 
 === "Java"
 
-    ``` java
-         Schema<Name, String> schema =
-            Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName));
+    ```java
+     Schema<Name, String> schema =
+        Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName));
 
-        CsvTransformer<Name> transformer =
-            CsvTransformer.<Name>builder().header(false).separator(" : ").build();
-        String csv =
-            transformer.generate(
-                faker.<Name>collection().suppliers(faker::name).maxLen(limit).build(),
-                schema);
+    CsvTransformer<Name> transformer =
+        CsvTransformer.<Name>builder().header(false).separator(" : ").build();
+    String csv =
+        transformer.generate(
+            faker.<Name>collection().suppliers(faker::name).maxLen(limit).build(),
+            schema);
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val faker = BaseFaker()
+    val faker = BaseFaker()
 
-        val schema = Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName))
+    val schema = Schema.of(field("firstName", Name::firstName), field("lastname", Name::lastName))
 
-        val transformer = CsvTransformer.builder<Name>().header(false).separator(" : ").build()
-        val csv = transformer.generate(
-            faker.collection<Name>().suppliers(Supplier { faker.name() }).maxLen(limit).build(), schema
-        )
+    val transformer = CsvTransformer.builder<Name>().header(false).separator(" : ").build()
+    val csv = transformer.generate(
+        faker.collection<Name>().suppliers(Supplier { faker.name() }).maxLen(limit).build(), schema
+    )
     ```
 
 ## JSON transformation
@@ -135,55 +135,55 @@ Example of JSON generation:
 
 === "Java"
 
-    ``` java
-        Schema<Object, ?> schema = Schema.of(
-            field("Text", () -> faker.name().firstName()),
-            field("Bool", () -> faker.bool().bool())
-        );
+    ```java
+    Schema<Object, ?> schema = Schema.of(
+        field("Text", () -> faker.name().firstName()),
+        field("Bool", () -> faker.bool().bool())
+    );
 
-        JsonTransformer<Object> transformer = JsonTransformer.builder().build();
-        String json = transformer.generate(schema, 2);
+    JsonTransformer<Object> transformer = JsonTransformer.builder().build();
+    String json = transformer.generate(schema, 2);
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val faker = BaseFaker()
-    
-        val schema: Schema<String, *> = Schema.of(
-            field("Text", Supplier { faker.name().firstName() }),
-            field("Bool", Supplier { faker.bool().bool() })
-        )
+    val faker = BaseFaker()
 
-        val transformer = JsonTransformer.builder<String>().build();
-        val json = transformer.generate(schema, 2)
+    val schema: Schema<String, *> = Schema.of(
+        field("Text", Supplier { faker.name().firstName() }),
+        field("Bool", Supplier { faker.bool().bool() })
+    )
+
+    val transformer = JsonTransformer.builder<String>().build()
+    val json = transformer.generate(schema, 2)
     ```
 
 To use composite fields it should be defined on `Schema` level and nothing more.
 
 ## SQL transformation
 
-Note: right now only `INSERT` is supported. 
+> **Note**: right now only `INSERT` is supported. 
 
 It generates a number of `INSERT` statements. There are 2 modes: batch and non batch generation.
 
 Batch generation means that one `INSERT` statement contains several rows to insert.
 Since different databases could have different syntax there is initial support for different dialects. 
-Dialect could be specified during `SQLTransformaer` build e.g:
+Dialect could be specified during `SQLTransformer` build e.g:
 
 === "Java"
 
-    ``` java
-        SqlTransformer<String> transformer =
-            new SqlTransformer.SqlTransformerBuilder<String>()
-                .schemaName(tableSchemaName).dialect(SqlDialect.ORACLE).build();
+    ```java
+    SqlTransformer<String> transformer =
+        new SqlTransformer.SqlTransformerBuilder<String>()
+            .schemaName(tableSchemaName).dialect(SqlDialect.ORACLE).build();
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val transformer = SqlTransformer.SqlTransformerBuilder<String>()
-            .schemaName(tableSchemaName).dialect(SqlDialect.ORACLE).build()
+    val transformer = SqlTransformer.SqlTransformerBuilder<String>()
+        .schemaName(tableSchemaName).dialect(SqlDialect.ORACLE).build()
     ```
 
 Dialect also handles SQL quote identifiers, quotes and other SQL dialect specifics.
@@ -192,22 +192,23 @@ An example of batch mode:
 
 === "Java"
 
-    ``` java
-        Faker faker = new Faker();
-        Schema<String, String> schema =
-            Schema.of(field("firstName", () -> faker.name().firstName()),
-                field("lastName", () -> faker.name().lastName()));
-        SqlTransformer<String> transformer =
-            new SqlTransformer.SqlTransformerBuilder<String>()
-                .batch(5)
-                .tableName("MY_TABLE")
-                .dialect(SqlDialect.POSTGRES)
-                .build();
-        String output = transformer.generate(schema, 10);
+    ```java
+    Faker faker = new Faker();
+    Schema<String, String> schema =
+        Schema.of(field("firstName", () -> faker.name().firstName()),
+            field("lastName", () -> faker.name().lastName()));
+    SqlTransformer<String> transformer =
+        new SqlTransformer.SqlTransformerBuilder<String>()
+            .batch(5)
+            .tableName("MY_TABLE")
+            .dialect(SqlDialect.POSTGRES)
+            .build();
+    String output = transformer.generate(schema, 10);
     ```
+
 === "Kotlin"
 
-    ``` kotlin
+    ```kotlin
         val faker = Faker()
         val schema: Schema<String, String> = Schema.of(
             field("firstName", Supplier { faker.name().firstName() }),
@@ -222,6 +223,7 @@ An example of batch mode:
     ```
 
 will generate 2 `INSERT` each containing 5 rows e.g.
+
 ```
 INSERT INTO MY_TABLE ("firstName", "lastName")
 VALUES ('Billy', 'Wintheiser'),
@@ -240,7 +242,7 @@ VALUES ('Marcell', 'Walsh'),
 ### Advanced SQL types
 
 It also supports generation of `ARRAY`, `MULTISET` and `ROW` types.
-Please be aware that not every database engine supports it and datafaker could do it for every dialect. 
+Please be aware that not every database engine supports it and Datafaker couldn't do it for every dialect. 
 
 To generate `ARRAY` schema field supply an array.  
 To generate `MULTISET` schema field supply a list (SQL `MULTISET` could contain duplicates).  
@@ -250,14 +252,14 @@ e.g.
 
 === "Java"
 
-    ``` java
-        Schema.of(field("ints", () -> new int[]{1, 2, 3}));
+    ```java
+    Schema.of(field("ints", () -> new int[]{1, 2, 3}));
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val schema: Schema<String, IntArray> = Schema.of(field("ints", Supplier { intArrayOf(1, 2, 3) }))
+    val schema: Schema<String, IntArray> = Schema.of(field("ints", Supplier { intArrayOf(1, 2, 3) }))
     ```
 
 will lead to
@@ -265,16 +267,17 @@ will lead to
 ```
 INSERT INTO "MyTable" ("ints") VALUES (ARRAY[1, 2, 3]);
 ```
+
 === "Java"
 
-    ``` java
-        Schema.of(field("names_multiset", () -> Collections.singleton("hello"));
+    ```java
+    Schema.of(field("names_multiset", () -> Collections.singleton("hello")));
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val schema: Schema<String, Set<String>> = Schema.of(field("names_multiset", Supplier { Collections.singleton("hello") } ))
+    val schema: Schema<String, Set<String>> = Schema.of(field("names_multiset", Supplier { Collections.singleton("hello") } ))
     ```
 
 will lead to
@@ -282,16 +285,17 @@ will lead to
 ```
 INSERT INTO "MyTable" ("names_multiset") VALUES (MULTISET['hello']);
 ```
+
 === "Java"
 
-    ``` java
-        schema.of(compositeField("row", new Field[]{field("name", () -> "2")});
+    ```java
+    Schema.of(compositeField("row", new Field[]{field("name", () -> "2")}));
     ```
 
 === "Kotlin"
 
     ```kotlin
-        Schema.of(compositeField("row", arrayOf(field("name", Supplier { "2" }))))
+    Schema.of(compositeField("row", arrayOf(field("name", Supplier { "2" }))))
     ```
 
 will lead to
@@ -309,24 +313,26 @@ The following schema:
 
 === "Java"
     
-    ``` java
-        Schema.of(
-            field("string", () -> "string"),
-            field("array", () -> new int[]{1, 2, 3}),
-            field("map", () -> Map.of("key", "value")),
-            compositeField("struct", new Field[]{field("name", () -> "2")})
-        );
+    ```java
+    Schema.of(
+        field("string", () -> "string"),
+        field("array", () -> new int[]{1, 2, 3}),
+        field("map", () -> Map.of("key", "value")),
+        compositeField("struct", new Field[]{field("name", () -> "2")})
+    );
     ```
+
 === "Kotlin"
 
     ```kotlin
-        Schema.of(
-            field("string", Supplier { "string" }),
-            field("array", Supplier { intArrayOf(1, 2, 3) }),
-            field("map", Supplier { mapOf("key" to "value") }),
-            compositeField("struct", arrayOf(field("name", Supplier { "2" })))
-        )
+    Schema.of(
+        field("string", Supplier { "string" }),
+        field("array", Supplier { intArrayOf(1, 2, 3) }),
+        field("map", Supplier { mapOf("key" to "value") }),
+        compositeField("struct", arrayOf(field("name", Supplier { "2" })))
+    )
     ```
+
 will lead to:
 
 ```
@@ -341,30 +347,30 @@ The following is an example on how to use it:
 
 === "Java"
 
-    ``` java
-        final BaseFaker faker = new BaseFaker();
+    ```java
+    final BaseFaker faker = new BaseFaker();
 
-        YamlTransformer<Object> transformer = new YamlTransformer<>();
-        Schema<Object, ?> schema = Schema.of(
-            field("name", () -> faker.name().firstName()),
-            field("lastname", () -> faker.name().lastName()),
-            field("phones", () -> Schema.of(
-                field("worknumbers", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get())
-                    .collect(Collectors.toList())),
-                field("cellphones", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get())
-                    .collect(Collectors.toList()))
-            )),
-            field("address", () -> Schema.of(
-                field("city", () -> faker.address().city()),
-                field("country", () -> faker.address().country()),
-                field("streetAddress", () -> faker.address().streetAddress())
-            ))
-        );
+    YamlTransformer<Object> transformer = new YamlTransformer<>();
+    Schema<Object, ?> schema = Schema.of(
+        field("name", () -> faker.name().firstName()),
+        field("lastname", () -> faker.name().lastName()),
+        field("phones", () -> Schema.of(
+            field("worknumbers", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get())
+                .collect(Collectors.toList())),
+            field("cellphones", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get())
+                .collect(Collectors.toList()))
+        )),
+        field("address", () -> Schema.of(
+            field("city", () -> faker.address().city()),
+            field("country", () -> faker.address().country()),
+            field("streetAddress", () -> faker.address().streetAddress())
+        ))
+    );
 
-        System.out.println(transformer.generate(schema, 1));
+    System.out.println(transformer.generate(schema, 1));
     ```
 
-will generate yaml with nested fields:
+will generate YAML with nested fields:
 
 ```
 name: Mason
@@ -388,57 +394,55 @@ address:
 Java Object transformer could be built with help of JavaObjectTransformer. 
 
 When building JavaObjectTransformer you should provide a class to be used as a template for generated objects.
+
 === "Java"
 
-    ``` java
-
-        public static class Person {
-           private String firstName;
-           private String lastName;
-           private Date birthDate;
-           private int id;
-        }
+    ```java
+    public static class Person {
+       private String firstName;
+       private String lastName;
+       private Date birthDate;
+       private int id;
+    }
     ```
+
 === "Kotlin"
 
-    ``` kotlin
-
-        data class Person(
-            var firstName: String,
-            var lastName: String,
-            var birthDate: Date,
-            var id: Int
-        )
+    ```kotlin
+    data class Person(
+        var firstName: String,
+        var lastName: String,
+        var birthDate: Date,
+        var id: Int
+    )
     ```
 
 Then you should provide a schema for the class.
 
 === "Java"
 
-    ``` java
+    ```java
+    JavaObjectTransformer jTransformer = new JavaObjectTransformer();
+    Schema<Object, ?> schema = Schema.of(
+        field("firstName", () -> faker.name().firstName()),
+        field("lastName", () -> faker.name().lastName()),
+        field("birthDate", () -> faker.date().birthday()),
+        field("id", () -> faker.number().positive()));
 
-        JavaObjectTransformer jTransformer = new JavaObjectTransformer();
-        Schema<Object, ?> schema = Schema.of(
-            field("firstName", () -> faker.name().firstName()),
-            field("lastName", () -> faker.name().lastName()),
-            field("birthDate", () -> faker.date().birthday()),
-            field("id", () -> faker.number().positive()));
-
-        System.out.println(jTransformer.apply(Person.class, schema));
+    System.out.println(jTransformer.apply(Person.class, schema));
     ```
 
 === "Kotlin"
 
-    ``` kotlin
+    ```kotlin
+    val jTransformer = JavaObjectTransformer()
+    val schema: Schema<Any, Any> = Schema.of(
+        field("firstName", Supplier { faker.name().firstName() }),
+        field("lastName", Supplier { faker.name().lastName() }),
+        field("birthDate", Supplier { faker.date().birthday() }),
+        field("id", Supplier { faker.number().positive() }))
 
-        val jTransformer = JavaObjectTransformer()
-        val schema: Schema<Any, Any> = Schema.of(
-            field("firstName", Supplier { faker.name().firstName() }),
-            field("lastName", Supplier { faker.name().lastName() }),
-            field("birthDate", Supplier { faker.date().birthday() }),
-            field("id", Supplier { faker.number().positive() }))
-
-        println(jTransformer.apply(Person::class.java, schema))
+    println(jTransformer.apply(Person::class.java, schema))
     ```
 
 will generate object with fields populated with random values based on specified suppliers.
@@ -451,49 +455,49 @@ Schema should be declared as a static method with return type `Schema<Object, ?>
 === "Java"
 
     ```java
-          public static Schema<Object, ?> defaultSchema() {
-            var faker = new Faker(Locale.forLanguageTag("fr-en"), new RandomService(new Random(1)));
-            return Schema.of(field("name", () -> faker.name().fullName()));
-          }
+      public static Schema<Object, ?> defaultSchema() {
+        var faker = new Faker(Locale.forLanguageTag("fr-en"), new RandomService(new Random(1)));
+        return Schema.of(field("name", () -> faker.name().fullName()));
+      }
     ```
 
 === "Kotlin"
 
     ```kotlin
-        fun defaultSchema(): Schema<Any, Any> {
-            val faker = Faker(Locale.forLanguageTag("fr-en"), RandomService(Random(1)))
-            return Schema.of(field("name", Supplier { faker.name().fullName() }))
-        }
+    fun defaultSchema(): Schema<Any, Any> {
+        val faker = Faker(Locale.forLanguageTag("fr-en"), RandomService(Random(1)))
+        return Schema.of(field("name", Supplier { faker.name().fullName() }))
+    }
     ```
 
 Then you should provide a class to be used as a template for generated objects. Class should be annotated with `@FakeForSchema` annotation with path to the schema method as a value.
 
-> Note: If default schema and class template are in the same class, you can omit full path to the method and use only method name.
+> **Note**: If default schema and class template are in the same class, you can omit full path to the method and use only method name.
  
 === "Java"
 
     ```java
-        @FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
-        public class Person {
-            private String fullName;
-        
-            public String getFullName() {
-                return fullName;
-            }
-        
-            public void setFullName(String fullName) {
-                this.fullName = fullName;
-            }
+    @FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
+    public class Person {
+        private String fullName;
+    
+        public String getFullName() {
+            return fullName;
         }
+    
+        public void setFullName(String fullName) {
+            this.fullName = fullName;
+        }
+    }
     ```
 
 === "Kotlin"
 
     ```kotlin
-        @FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
-        data class Person(
-            var fullName: String
-        )
+    @FakeForSchema("net.datafaker.annotations.FakeAnnotationTest#defaultSchema")
+    data class Person(
+        var fullName: String
+    )
     ```
 
 Then you can use `net.datafaker.providers.base.BaseFaker.populate(java.lang.Class<T>)` to populate object with default predefined schema.
@@ -501,15 +505,15 @@ Then you can use `net.datafaker.providers.base.BaseFaker.populate(java.lang.Clas
 === "Java"
 
     ```java
-        BaseFaker faker = new BaseFaker();
-        Person person = faker.populate(Person.class);
+    BaseFaker faker = new BaseFaker();
+    Person person = faker.populate(Person.class);
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val faker = BaseFaker()
-        val person = faker.populate(Person::class.java)
+    val faker = BaseFaker()
+    val person = faker.populate(Person::class.java)
     ```
 
 Or you can use `net.datafaker.providers.base.BaseFaker.populate(java.lang.Class<T>, net.datafaker.schema.Schema<java.lang.Object, ?>)` to populate object with custom schema.
@@ -517,51 +521,51 @@ Or you can use `net.datafaker.providers.base.BaseFaker.populate(java.lang.Class<
 === "Java"
 
     ```java
-        BaseFaker faker = new BaseFaker();
-        Person person = faker.populate(Person.class, Schema.of(field("name", () -> faker.superhero().name())));
+    BaseFaker faker = new BaseFaker();
+    Person person = faker.populate(Person.class, Schema.of(field("name", () -> faker.superhero().name())));
     ```
 
 === "Kotlin"
 
     ```kotlin
-        val faker = BaseFaker()
-        val person = faker.populate(Person::class.java, Schema.of(field("name", Supplier { faker.superhero().name() })))
+    val faker = BaseFaker()
+    val person = faker.populate(Person::class.java, Schema.of(field("name", Supplier { faker.superhero().name() })))
     ```
 
-
 ## TOML transformation
+
 TOML transformation is similar to YAML and CSV.
 
 The following is an example on how to use it:
 
 === "Java"
 
-    ``` java
-        final BaseFaker faker = new BaseFaker();
+    ```java
+    final BaseFaker faker = new BaseFaker();
 
-        TomlTransformer<Object> transformer = new TomlTransformer<>();
-        Schema<Object, ?> schema = Schema.of(
-            field("name", () -> faker.name().firstName()),
-            field("lastname", () -> faker.name().lastName()),
-            field("phones", () -> Schema.of(
-                field("worknumbers", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get())
-                    .collect(Collectors.toList())),
-                field("cellphones", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get())
-                    .collect(Collectors.toList()))
-            )),
-            field("address", () -> Schema.of(
-                field("city", () -> faker.address().city()),
-                field("country", () -> faker.address().country()),
-                field("streetAddress", () -> faker.address().streetAddress())
-            ))
-        );
+    TomlTransformer<Object> transformer = new TomlTransformer<>();
+    Schema<Object, ?> schema = Schema.of(
+        field("name", () -> faker.name().firstName()),
+        field("lastname", () -> faker.name().lastName()),
+        field("phones", () -> Schema.of(
+            field("worknumbers", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get())
+                .collect(Collectors.toList())),
+            field("cellphones", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get())
+                .collect(Collectors.toList()))
+        )),
+        field("address", () -> Schema.of(
+            field("city", () -> faker.address().city()),
+            field("country", () -> faker.address().country()),
+            field("streetAddress", () -> faker.address().streetAddress())
+        ))
+    );
 
-        System.out.println(transformer.generate(schema, 1));
+    System.out.println(transformer.generate(schema, 1));
     ```
 
-will generate toml with nested fields:
+will generate TOML with nested fields:
 
-```
+```toml
 name = "Elaine"
 lastname = "King"
 [phones]

--- a/docs/documentation/sequences.md
+++ b/docs/documentation/sequences.md
@@ -14,7 +14,7 @@ For example, the following code will generate a list/stream of first and last na
 
 === "List"
 
-    ``` java 
+    ```java 
     List<String> names = 
         faker.collection(
                 () -> faker.name().firstName(), 
@@ -25,7 +25,7 @@ For example, the following code will generate a list/stream of first and last na
 
 === "Stream"
 
-    ``` java 
+    ```java 
     Stream<String> names = 
         faker.stream(
                 () -> faker.name().firstName(), 
@@ -38,7 +38,7 @@ A list/stream can also contain different types:
 
 === "List"
 
-    ``` java 
+    ```java 
     List<Object> objects =
         faker.<Object>collection(
                 () -> faker.name().firstName(),
@@ -49,7 +49,7 @@ A list/stream can also contain different types:
 
 === "Stream"
 
-    ``` java 
+    ```java 
     Stream<Object> objects =
         faker.<Object>stream(
                 () -> faker.name().firstName(),
@@ -63,7 +63,7 @@ By default, it's value is 0, i.e. no null values will be generated.
 
 === "List"
 
-    ``` java 
+    ```java 
     List<Object> objects =
         faker.<Object>collection(
                 () -> faker.name().firstName(),
@@ -75,7 +75,7 @@ By default, it's value is 0, i.e. no null values will be generated.
 
 === "Stream"
 
-    ``` java 
+    ```java 
     Stream<Object> objects =
         faker.<Object>stream(
                 () -> faker.name().firstName(),
@@ -90,7 +90,7 @@ To generate a collection/stream with only about 30% values of null, `nullRate(0.
 
 === "List"
 
-    ``` java 
+    ```java 
     List<Object> objects =
         faker.<Object>collection(
                 () -> faker.name().firstName(),
@@ -102,7 +102,7 @@ To generate a collection/stream with only about 30% values of null, `nullRate(0.
 
 === "Stream"
 
-    ``` java 
+    ```java 
     Stream<Object> objects =
         faker.<Object>stream(
                 () -> faker.name().firstName(),
@@ -116,7 +116,7 @@ FakeSequence also supports generation of an infinite stream:
 
 === "Java"
 
-    ``` java 
+    ```java 
     Stream<Object> objects =
         faker.<Object>stream(
                 () -> faker.name().firstName(),
@@ -129,7 +129,7 @@ FakeStreams based on FakeSequence API:
 
 === "Java"
 
-    ``` java 
+    ```java 
     FakeSequence<Object> fakeSequence = faker.<Object>stream(
                 () -> faker.name().firstName(),
                 () -> faker.random().nextInt(100))
@@ -142,7 +142,7 @@ For FakeCollection this function will always return false:
 
 === "Java"
 
-    ``` java 
+    ```java 
     FakeSequence<Object> fakeSequence = faker.<Object>collection(
                 () -> faker.name().firstName(),
                 () -> faker.random().nextInt(100))

--- a/docs/documentation/unique-values.md
+++ b/docs/documentation/unique-values.md
@@ -6,7 +6,7 @@ Unique values can be retrieved from the YAML files by key, if the key references
 
 === "Java"
 
-    ``` java 
+    ```java 
     Faker faker = new Faker();
 
     // The values returned in the following lines will never be the same.
@@ -14,15 +14,15 @@ Unique values can be retrieved from the YAML files by key, if the key references
     String secondUniqueInstrument = faker.unique().fetchFromYaml("music.instruments"); // "Clarinet"
     ```
 
-Note: Unique values are based on key and locale, so it's possible to get the same value if the locale is manually changed or if two different keys contain the same value.
+> **Note**: Unique values are based on key and locale, so it's possible to get the same value if the locale is manually changed or if two different keys contain the same value.
 
 If all possible values have been returned, an exception will be thrown.
 
 === "Java"
 
-    ``` java 
+    ```java 
     Faker faker = new Faker();
-    String firstUniqueInstrument = faker.unique().fetchFromYaml("music.instruments"); // "Ukelele"
+    String firstUniqueInstrument = faker.unique().fetchFromYaml("music.instruments"); // "Ukulele"
     ...
     String nthUniqueInstrument = faker.unique().fetchFromYaml("music.instruments"); // throws NoSuchElementException
     ```
@@ -31,7 +31,7 @@ Any non-string values will be converted.
 
 === "Java"
 
-    ``` java 
+    ```java 
     Faker faker = new Faker();
-    String successCode = faker.unique().fetchFromYaml("sip.response.codes.success")); // "200"
+    String successCode = faker.unique().fetchFromYaml("sip.response.codes.success"); // "200"
     ```

--- a/docs/documentation/usage.md
+++ b/docs/documentation/usage.md
@@ -7,7 +7,7 @@ constructor.
 
 === "Java"
 
-    ``` java
+    ```java
     import net.datafaker.Faker;
     
     Faker faker = new Faker();
@@ -17,7 +17,7 @@ constructor.
 
 === "Kotlin"
 
-    ```
+    ```kotlin
     import net.datafaker.Faker
     
     val faker = Faker()
@@ -29,11 +29,11 @@ This will instantiate a Faker using the English locale.
 
 ## Different locale
 
-To use Datafaker with a different locale, you can supply on in the constructor as such:
+To use Datafaker with a different locale, you can supply one in the constructor as such:
 
 === "Java"
 
-    ``` java
+    ```java
     Faker faker = new Faker(new Locale("nl"));
 
     String name = faker.name().fullName(); // Chelan Klijnsma
@@ -41,7 +41,7 @@ To use Datafaker with a different locale, you can supply on in the constructor a
 
 === "Kotlin"
 
-    ``` kotlin
+    ```kotlin
     val faker = Faker(Locale("nl"))
 
     val name = faker.name().fullName() // Chelan Klijnsma
@@ -59,10 +59,9 @@ Schlangenlaan 461a, Oost Jessamyingen, WV 8234 ZX
 1 hoog Gritlaan 52, Margiesmeer, OK 1083 VE
 ```
 
-
 === "Java"
 
-    ``` java 
+    ```java 
     Faker faker1 = new Faker(new Locale("nl"));
     Faker faker2 = new Faker(new Locale("ar"));
 
@@ -76,7 +75,7 @@ Schlangenlaan 461a, Oost Jessamyingen, WV 8234 ZX
 
 === "Kotlin"
 
-    ``` kotlin
+    ```kotlin
     val faker1 = Faker(Locale("nl"))
     val faker2 = Faker(Locale("ar"))
 
@@ -97,13 +96,13 @@ which can be handy for generating results multiple times.
 
 === "Java"
 
-    ``` java
+    ```java
     Faker faker = new Faker(new Random(0));
     ```
 
 === "Kotlin"
 
-    ``` kotlin
+    ```kotlin
     val faker = Faker(Random(0))
     ```
 

--- a/docs/releases/1.3.0.md
+++ b/docs/releases/1.3.0.md
@@ -27,5 +27,5 @@ For this release, we'd like thank the following people:
 * Super Mario
 * Volleyball
 
-Note: The Crypto provider has been renamed to Hashing, since they only contained one way Hashing functions. 
-It can still be accessed using the `crypto` method, but this will be removed in one of the upcoming releases.  
+> **Note*: The Crypto provider has been renamed to Hashing, since they only contained one way Hashing functions. 
+> It can still be accessed using the `crypto` method, but this will be removed in one of the upcoming releases.  

--- a/material/partials/languages/el.html
+++ b/material/partials/languages/el.html
@@ -15,7 +15,7 @@
   "meta.source": "Πηγή",
   "nav.title": "Πλοήγηση",
   "search.config.pipeline": "stopWordFilter",
-  "search.config.separator": "[\s\-]+",
+  "search.config.separator": "[\\s\\-]+",
   "search.placeholder": "Αναζήτηση",
   "search.share": "Διαμοίραση",
   "search.reset": "Καθαρισμός",

--- a/material/partials/languages/en.html
+++ b/material/partials/languages/en.html
@@ -16,7 +16,7 @@
   "nav.title": "Navigation",
   "search.config.lang": "en",
   "search.config.pipeline": "trimmer, stopWordFilter",
-  "search.config.separator": "[\s\-]+",
+  "search.config.separator": "[\\s\\-]+",
   "search.placeholder": "Search",
   "search.share": "Share",
   "search.reset": "Clear",

--- a/material/partials/languages/ja.html
+++ b/material/partials/languages/ja.html
@@ -15,7 +15,7 @@
   "nav.title": "ナビゲーション",
   "search.config.lang": "ja",
   "search.config.pipeline": "trimmer, stemmer",
-  "search.config.separator": "[\s\-　、。，．]+",
+  "search.config.separator": "[\\s\\-　、。，．]+",
   "search.placeholder": "検索",
   "search.reset": "クリア",
   "search.result.initializer": "検索を初期化",

--- a/material/partials/languages/zh-TW.html
+++ b/material/partials/languages/zh-TW.html
@@ -12,7 +12,7 @@
   "meta.source": "來源",
   "search.config.lang": "ja",
   "search.config.pipeline": "trimmer, stemmer",
-  "search.config.separator": "[\s\-　、。，．？；]+",
+  "search.config.separator": "[\\s\\-　、。，．？；]+",
   "search.placeholder": "搜尋",
   "search.result.initializer": "正在初始化搜尋引擎",
   "search.result.placeholder": "打字進行搜尋",

--- a/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
+++ b/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
@@ -74,7 +74,7 @@ public class ProvidersDocsGenerator {
         System.out.println("Providers without '@since' tag: " + fakersWithoutSinceTag);
     }
 
-    private String extractGroupName(Class<?> clazz) {
+    private static String extractGroupName(Class<?> clazz) {
         // `packageName` should be such format: net.datafaker.providers.<groupName> (e.g. base, sport, movie)
         String packageName = clazz.getPackage().getName();
         // And just splitting by '.' we're getting groupName (e.g. base, sport, movie)
@@ -143,7 +143,7 @@ public class ProvidersDocsGenerator {
         Map<String, Integer> providersPerVersion = extractProvidersPerVersion();
 
         StringBuilder sb = new StringBuilder()
-            .append("\nNumber of providers per Datafaker version\n")
+            .append("\nNumber of providers per Datafaker version:\n")
             .append("\n| Version | Number of new providers | Total number of providers |")
             .append("\n|---------|-------------------------|---------------------------|\n");
 
@@ -180,7 +180,7 @@ public class ProvidersDocsGenerator {
         return providersPerVersion;
     }
 
-    private String formatGroupName(String groupName) {
+    private static String formatGroupName(String groupName) {
         return Character.toUpperCase(groupName.charAt(0)) + groupName.substring(1);
     }
 


### PR DESCRIPTION
All tested locally with mkdocs server.

**Note** for the four language files that were modified that was to address:

```
INFO    -  DeprecationWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future.
             File ".....datafaker/.venv/lib/python3.14/site-packages/jinja2/lexer.py", line 391, in __next__
               self.current = next(self._iter)
             File ".....datafaker/.venv/lib/python3.14/site-packages/jinja2/lexer.py", line 654, in wrap
               .decode("unicode-escape")
```

```
Patched 4 language files — \s → \\s, \- → \\-:

material/partials/languages/en.html
material/partials/languages/el.html
material/partials/languages/ja.html
material/partials/languages/zh-TW.html
mkdocs build clean now — no \s DeprecationWarning. Browser still get [\s\-]+ for search regex.
```