### PR TITLE
Fix lowercase country code in Finance.bic()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <commons-validator.version>1.10.1</commons-validator.version>
         <rgxgen.version>3.1</rgxgen.version>
         <google.javaformat.version>1.17.0</google.javaformat.version>
-        <iban-commons.version>1.8.7</iban-commons.version>
+        <iban-commons.version>1.8.8</iban-commons.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <junit.version>6.1.0</junit.version>
         <libphonenumber.version>9.0.33</libphonenumber.version>

--- a/src/main/java/net/datafaker/providers/base/Country.java
+++ b/src/main/java/net/datafaker/providers/base/Country.java
@@ -1,6 +1,10 @@
 package net.datafaker.providers.base;
 
 /**
+ * Provides methods for generating country-related data such as names, codes, capitals, and flags.
+ * <p>
+ * This provider is backed by the data defined in {@code country.yml}.
+ *
  * @since 0.8.0
  */
 public class Country extends AbstractProvider<BaseProviders> {
@@ -11,18 +15,38 @@ public class Country extends AbstractProvider<BaseProviders> {
         this.flagUrl = "https://flags.fmcdn.net/data/flags/w580/";
     }
 
+    /**
+     * Generates a URL pointing to the flag image of a random country.
+     *
+     * @return a flag image URL string
+     */
     public String flag() {
         return flagUrl + resolve("country.code2") + ".png";
     }
 
+    /**
+     * Returns a random two-letter ISO 3166-1 alpha-2 country code in <strong>lowercase</strong>.
+     *
+     * @return a 2-letter lowercase country code
+     */
     public String countryCode2() {
         return resolve("country.code2");
     }
 
+    /**
+     * Returns a random three-letter ISO 3166-1 alpha-3 country code in <strong>lowercase</strong>.
+     *
+     * @return a 3-letter lowercase country code
+     */
     public String countryCode3() {
         return resolve("country.code3");
     }
 
+    /**
+     * Returns a random capital city.
+     *
+     * @return a capital city name
+     */
     public String capital() {
         return resolve("country.capital");
     }
@@ -43,6 +67,11 @@ public class Country extends AbstractProvider<BaseProviders> {
         return faker.money().currencyCode();
     }
 
+    /**
+     * Returns a random country name.
+     *
+     * @return a country name
+     */
     public String name() {
         return resolve("country.name");
     }

--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -120,16 +120,24 @@ public class Finance extends AbstractProvider<BaseProviders> {
     }
 
     /**
-     * Generates a random Business Identifier Code (BIC).
-     * The country code is retrieved from the {@link Country} provider to ensure consistency.
+     * Generates a random Business Identifier Code (BIC) compliant with ISO 9362.
      * <p>
-     * A BIC consists of 8 or 11 characters: 4 letters (bank), 2 letters (ISO country code),
-     * 2 characters (location), and an optional 3-character branch code (whereas {@code XXX} refers to Head Office).
+     * The BIC is guaranteed to consist of <strong>uppercase letters</strong> and digits only.
+     * The embedded two-letter country code is retrieved from the {@link Country} provider
+     * and converted to uppercase to ensure structural validity.
+     * <p>
+     * A BIC consists of either 8 or 11 characters structured as follows:
+     * <ul>
+     *   <li>4 letters: Institution code (bank)</li>
+     *   <li>2 letters: ISO 3166-1 alpha-2 country code</li>
+     *   <li>2 characters: Location code (letters or digits)</li>
+     *   <li>Optional 3 characters: Branch code (letters or digits, where {@code XXX} refers to the head office)</li>
+     * </ul>
      *
      * @return a valid-formatted BIC
      */
     public String bic() {
-        String countryCode = faker.country().countryCode2();
+        String countryCode = faker.country().countryCode2().toUpperCase(Locale.ROOT);
         String regex = String.format("[A-Z]{4}%s[0-9A-Z]{2}(?:[0-9A-Z]{3})?", countryCode);
         return faker.regexify(regex);
     }

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -1,8 +1,8 @@
 package net.datafaker.providers.base;
 
 import static de.speedbanking.bic.junit.jupiter.api.BicAssertions.assertThatBicIsValid;
+import static de.speedbanking.iban.junit.jupiter.api.IbanAssertions.assertThatIban;
 import static de.speedbanking.iban.junit.jupiter.api.IbanAssertions.assertThatIbanIsValid;
-import static de.speedbanking.iban.junit.jupiter.api.IbanAssertions.assertThatIbanOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.speedbanking.iban.Iban;
@@ -64,8 +64,7 @@ class FinanceTest extends BaseFakerTest {
     @Test
     void ibanWithCountryCode() {
         String ibanDe = finance.iban("DE");
-        assertThatIbanIsValid(ibanDe);
-        assertThatIbanOf(ibanDe)
+        assertThatIban(ibanDe)
             .hasCountryCode("DE")
             .hasLength(IbanRegistry.DE.getIbanLength())
             .matches("DE\\d{20}");
@@ -85,8 +84,7 @@ class FinanceTest extends BaseFakerTest {
         Set<String> ibanCountryCodes = Finance.ibanSupportedCountries();
         for (String givenCountryCode : ibanCountryCodes) {
             final String iban = finance.iban(givenCountryCode).toUpperCase(faker.getContext().getLocale());
-            assertThatIbanIsValid(iban);
-            assertThatIbanOf(iban)
+            assertThatIban(iban)
                 .hasCountryCode(givenCountryCode)
                 .hasLength(IbanRegistry.getByCode(givenCountryCode).getIbanLength());
         }
@@ -105,8 +103,7 @@ class FinanceTest extends BaseFakerTest {
         final String givenCountryCode = "CR";
         final BaseFaker faker = new BaseFaker();
         final String ibanFaker = finance.iban(givenCountryCode).toUpperCase(faker.getContext().getLocale());
-        assertThatIbanIsValid(ibanFaker);
-        assertThatIbanOf(ibanFaker)
+        assertThatIban(ibanFaker)
             .hasCountryCode(givenCountryCode)
             .hasLength(IbanRegistry.CR.getIbanLength());
     }


### PR DESCRIPTION
## Problem
`countryCode2()` returns lowercase ISO 3166-1 alpha-2 codes (e.g. `de`).
The BIC regex `[A-Z]{4}%s[0-9A-Z]{2}` requires uppercase, so generated BICs silently violated ISO 9362.

## Fix
Apply `.toUpperCase(Locale.ROOT)` before interpolating the country code into the regex pattern.

## Also included
- Javadoc for `Finance.bic()` and `Country` provider methods
- `iban-commons` bumped to 1.8.8
- Deprecated `assertThatIbanOf` replaced with `assertThatIban` in `FinanceTest`

Fixes #1853