### PR TITLE
Migrate Country.flag() from deprecated flags.fmcdn.net to flagcdn.com; add overload

### DIFF
--- a/src/main/java/net/datafaker/providers/base/Country.java
+++ b/src/main/java/net/datafaker/providers/base/Country.java
@@ -1,27 +1,50 @@
 package net.datafaker.providers.base;
 
+import java.util.Locale;
+
 /**
  * Provides methods for generating country-related data such as names, codes, capitals, and flags.
  * <p>
  * This provider is backed by the data defined in {@code country.yml}.
+ * <p>
+ * Flag images are served by <a href="https://flagcdn.com">flagcdn.com</a>
+ * (see <a href="https://flagpedia.net/download/api">Flagpedia API</a>).
  *
  * @since 0.8.0
  */
 public class Country extends AbstractProvider<BaseProviders> {
-    private final String flagUrl;
+
+    private static final String FLAG_BASE_URL = "https://flagcdn.com/";
 
     protected Country(BaseProviders faker) {
         super(faker);
-        this.flagUrl = "https://flags.fmcdn.net/data/flags/w580/";
     }
 
     /**
-     * Generates a URL pointing to the flag image of a random country.
+     * Generates a <em>PNG</em> flag URL for a random country at size ({@code w580}).
      *
      * @return a flag image URL string
      */
     public String flag() {
-        return flagUrl + resolve("country.code2") + ".png";
+        return flag("w580", ImageFormat.PNG);
+    }
+
+    /**
+     * Generates a flag URL for a random country.
+     * <p>
+     * For {@link ImageFormat#SVG} the {@code size} argument is ignored.<br>
+     * See the <a href="https://flagpedia.net/download/api">Flagpedia API</a> for valid size strings.
+     *
+     * @param size   a {@code flagcdn.com} size string, e.g. {@code "w320"}, {@code "h80"}, {@code "32x24"}
+     * @param format the desired image format
+     * @return a flag image URL string
+     */
+    public String flag(String size, ImageFormat format) {
+        String url = FLAG_BASE_URL;
+        if (ImageFormat.SVG != format) {
+            url += size + '/';
+        }
+        return url + countryCode2() + '.' + format.getExtension();
     }
 
     /**
@@ -74,6 +97,26 @@ public class Country extends AbstractProvider<BaseProviders> {
      */
     public String name() {
         return resolve("country.name");
+    }
+
+    /**
+     * Image format for flag URLs.
+     */
+    public enum ImageFormat {
+        JPG,
+        PNG,
+        SVG,
+        WEBP;
+
+        private final String extension;
+
+        ImageFormat() {
+            this.extension = name().toLowerCase(Locale.ROOT);
+        }
+
+        public String getExtension() {
+            return extension;
+        }
     }
 
 }

--- a/src/test/java/net/datafaker/providers/base/CountryTest.java
+++ b/src/test/java/net/datafaker/providers/base/CountryTest.java
@@ -1,12 +1,17 @@
 package net.datafaker.providers.base;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.net.URL;
 import java.util.Collection;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class CountryTest extends BaseFakerTest {
 
@@ -14,8 +19,19 @@ class CountryTest extends BaseFakerTest {
 
     @RepeatedTest(10)
     void testFlag() {
-        String flag = country.flag();
-        assertThat(flag).matches("^https://flags.fmcdn\\.net/data/flags/w580/[a-zA-Z0-9_]+\\.png$");
+        assertThat(country.flag()).matches("^https://flagcdn\\.com/w580/[a-z]{2}+\\.png$");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"w580", "w320", "h80", "32x24"})
+    void testFlagWithSizeProducesValidUrl(String size) {
+        assertThatNoException().isThrownBy(() -> new URL(country.flag(size, Country.ImageFormat.PNG)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(Country.ImageFormat.class)
+    void testFlagWithFormatProducesValidUrl(Country.ImageFormat format) {
+        assertThatNoException().isThrownBy(() -> new URL(country.flag("w320", format)));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`flags.fmcdn.net` is deprecated. The domain operator explicitly requests migrating to `flagcdn.com`:

> Flags.fmcdn.net was CDN of country flags for Flagpedia.net. If you use this domain for embedding flags to your own website, please make the change from flags.fmcdn.net to flagcdn.com that we created exactly for this purpose.

### Changes

**`Country.java`**
- Replace deprecated `flags.fmcdn.net` base URL with `https://flagcdn.com/`
- Replace instance field `flagUrl` by `static final FLAG_BASE_URL`
- Add `ImageFormat` enum (JPG, PNG, SVG, WEBP)
- Add overload `flag(String size, ImageFormat format)` for full control over image size and format

**`CountryTest.java`**
- Update `testFlag()` regex to match the new URL pattern
- Add `testFlagWithSizeProducesValidUrl` (`@ValueSource`) to verify URL structure for a number of sample sizes
- Add `testFlagWithFormatProducesValidUrl` (`@EnumSource`) - covers all `ImageFormat` values

### Backward Compatibility

`flag()` without arguments keeps the same behavior as before (PNG, width 580px).
Only the CDN domain changes, so existing usages are unaffected.