### PR TITLE
Tweak release processing

### DIFF
--- a/.github/workflows/version-updates.yml
+++ b/.github/workflows/version-updates.yml
@@ -1,3 +1,5 @@
+name: Release Follow-up Version Updates
+
 on:
   workflow_run:
     workflows:

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -13,19 +13,21 @@ The release process is now driven by GitHub Releases:
 4. Set the release title (can be the same as the tag)
 5. Add a description of the changes (optional - will be enhanced by automated changelog)
 6. Click "Publish release"
-7. Update documentation:
-   - At least files
-     * `docs/releases/current.version.md`
-     * `docs/releases/next.version-SNAPSHOT.md`
-     * `mkdocs.yml`
-   - And probably file `docs/documentation/providers.md` (if new providers have been added)
 
-The automated workflow will:
+The automated workflow will then:
 1. Extract the version from the tag
 2. Update the Maven project version
 3. Build and deploy to Maven Central
 4. Generate a changelog and add it to the release notes
-5. Create a PR to update the pom.xml to the next SNAPSHOT version
+
+Followed by a separate job which will:
+1. Create a PR to update the pom.xml to the next SNAPSHOT version
+2. Update documentation:
+   - At least files
+     * `docs/releases/current.version.md`
+     * `docs/releases/next.version-SNAPSHOT.md`
+     * `mkdocs.yml` (see also [`material/README.md`](material/README.md) for docs site / theme dependency updates)
+     * `docs/documentation/providers.md`
 
 ## Requirements
 

--- a/src/test/java/net/datafaker/script/ReleaseNotesGenerator.java
+++ b/src/test/java/net/datafaker/script/ReleaseNotesGenerator.java
@@ -22,6 +22,10 @@ import java.util.regex.Pattern;
  *   <li>output path {@code docs/releases/{RELEASED_VERSION}.md} (must not already exist)</li>
  * </ul>
  *
+ * <p>Strips a leading {@code ## What's Changed} heading from the GitHub release body when
+ * present, so it is not duplicated under the template's {@code ## What's changed} heading.
+ * Leading and trailing blank lines around the body are trimmed.
+ *
  * <p>Strips {@code #} from bullet lines like {@code * #1234 ...} so issue numbers are not
  * treated as markdown headings.
  *
@@ -31,6 +35,8 @@ public final class ReleaseNotesGenerator {
 
     static final String WHATS_CHANGED = "## What's changed";
     private static final Pattern ISSUE_HASH_BULLET = Pattern.compile("^(\\s*[-*]\\s*)#(\\d+)");
+    private static final Pattern WHATS_CHANGED_HEADING =
+            Pattern.compile("^#{1,2}\\s+What's\\s+changed\\s*$", Pattern.CASE_INSENSITIVE);
 
     private ReleaseNotesGenerator() {
     }
@@ -52,18 +58,48 @@ public final class ReleaseNotesGenerator {
 
     static String generate(List<String> templateLines, String version, String date, List<String> bodyLines) {
         List<String> out = new ArrayList<>(templateLines.size() + bodyLines.size());
+        List<String> preparedBody = prepareBodyLines(bodyLines);
         boolean inserted = false;
         for (String line : templateLines) {
             out.add(line.replace("X.Y.Z", version).replace("dd-mm-yyyy", date));
             if (!inserted && WHATS_CHANGED.equals(out.get(out.size() - 1))) {
-                out.add("");
-                for (String bodyLine : bodyLines) {
-                    out.add(stripIssueHash(bodyLine));
+                if (!preparedBody.isEmpty()) {
+                    out.add("");
+                    for (String bodyLine : preparedBody) {
+                        out.add(stripIssueHash(bodyLine));
+                    }
                 }
                 inserted = true;
             }
         }
         return String.join("\n", out) + "\n";
+    }
+
+    static List<String> prepareBodyLines(List<String> bodyLines) {
+        List<String> lines = new ArrayList<>(bodyLines);
+        trimLeadingBlankLines(lines);
+        if (!lines.isEmpty() && isWhatsChangedHeading(lines.get(0))) {
+            lines.remove(0);
+            trimLeadingBlankLines(lines);
+        }
+        trimTrailingBlankLines(lines);
+        return lines;
+    }
+
+    static boolean isWhatsChangedHeading(String line) {
+        return WHATS_CHANGED_HEADING.matcher(line.trim()).matches();
+    }
+
+    private static void trimLeadingBlankLines(List<String> lines) {
+        while (!lines.isEmpty() && lines.get(0).isBlank()) {
+            lines.remove(0);
+        }
+    }
+
+    private static void trimTrailingBlankLines(List<String> lines) {
+        while (!lines.isEmpty() && lines.get(lines.size() - 1).isBlank()) {
+            lines.remove(lines.size() - 1);
+        }
     }
 
     static String stripIssueHash(String line) {

--- a/src/test/java/net/datafaker/script/ReleaseNotesGeneratorTest.java
+++ b/src/test/java/net/datafaker/script/ReleaseNotesGeneratorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReleaseNotesGeneratorTest {
@@ -63,6 +64,54 @@ class ReleaseNotesGeneratorTest {
 
         assertTrue(result.contains("## Not a bullet"));
         assertTrue(result.contains("* no hash here"));
+    }
+
+    @Test
+    void generateStripsDuplicateWhatsChangedHeading() {
+        String result = ReleaseNotesGenerator.generate(
+            TEMPLATE,
+            "2.7.0",
+            "24-06-2026",
+            List.of(
+                "## What's Changed",
+                "",
+                "* Fix bug",
+                "* Add feature"
+            )
+        );
+
+        assertTrue(result.contains("""
+            ## What's changed
+
+            * Fix bug
+            * Add feature
+            """));
+        assertFalse(result.contains("What's Changed"));
+    }
+
+    @Test
+    void generateStripsLeadingAndTrailingBlankLinesFromBody() {
+        String result = ReleaseNotesGenerator.generate(
+            TEMPLATE,
+            "2.7.0",
+            "24-06-2026",
+            List.of(
+                "",
+                "## What's Changed",
+                "",
+                "",
+                "* Fix bug",
+                ""
+            )
+        );
+
+        assertTrue(result.contains("""
+            ## What's changed
+
+            * Fix bug
+
+            ## New contributors
+            """));
     }
 
     @Test


### PR DESCRIPTION
- Give the version updates workflow a proper name.
- Adjust release documentation to be up-to-date.
- Update release page generator to trim "What's Changed" heading from release description if present (the template already contains the heading in with the capitalization we want).