### PR TITLE
feat(stock): add ISIN generation and consolidate Luhn logic

### DIFF
--- a/src/main/java/net/datafaker/internal/helper/LuhnCheckDigit.java
+++ b/src/main/java/net/datafaker/internal/helper/LuhnCheckDigit.java
@@ -1,0 +1,58 @@
+package net.datafaker.internal.helper;
+
+/**
+ * Calculates the check digit using the Luhn algorithm (Modulus 10).
+ *
+ * @since 2.8.0
+ */
+public final class LuhnCheckDigit {
+
+    private LuhnCheckDigit() {
+        throw new UnsupportedOperationException(
+            String.format("Utility class %s cannot be instantiated", getClass().getSimpleName()));
+    }
+
+    /**
+     * Extracts all digits from a CharSequence and calculates the Luhn check digit.
+     * <p>
+     * Non-digit characters are automatically ignored.
+     *
+     * @param sequence the sequence containing the numeric characters
+     * @return the single check digit (0-9)
+     */
+    public static int calculate(CharSequence sequence) {
+        if (sequence == null) {
+            return 0;
+        }
+        // avoid boxing overhead by using codePoints() or chars() directly to int[]
+        int[] digits = sequence.chars()
+            .filter(Character::isDigit)
+            .map(c -> c - '0')
+            .toArray();
+
+        return calculate(digits);
+    }
+
+    /**
+     * Calculates the Luhn check digit for a given array of numeric values.
+     * <p>
+     * The algorithm processes the array from right to left, doubling every second digit
+     * starting with the rightmost element.
+     *
+     * @param digits an array of numbers representing the base value
+     * @return the single check digit (0-9) that satisfies the Luhn criteria
+     */
+    public static int calculate(int[] digits) {
+        int luhnSum = 0;
+        int multiplier = 2;
+
+        for (int i = digits.length - 1; i >= 0; i--) {
+            int product = digits[i] * multiplier;
+            luhnSum += (product / 10) + (product % 10);
+            multiplier = (multiplier == 2 ? 1 : 2);
+        }
+
+        return (10 - (luhnSum % 10)) % 10;
+    }
+
+}

--- a/src/main/java/net/datafaker/providers/base/Code.java
+++ b/src/main/java/net/datafaker/providers/base/Code.java
@@ -1,5 +1,7 @@
 package net.datafaker.providers.base;
 
+import net.datafaker.internal.helper.LuhnCheckDigit;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -160,30 +162,18 @@ public class Code extends AbstractProvider<BaseProviders> {
         str[0] = arr.charAt(0);
         str[1] = arr.charAt(1);
 
-        // Fill all the remaining numbers except for the last one with random values.
+        int[] baseDigits = new int[len - 1];
+        baseDigits[0] = Character.getNumericValue(str[0]);
+        baseDigits[1] = Character.getNumericValue(str[1]);
+
         for (int i = 2; i < len - 1; i++) {
-            str[i] = Character.forDigit(faker.number().numberBetween(0, 9), 10);
+            int randomDigit = faker.number().numberBetween(0, 9);
+            str[i] = Character.forDigit(randomDigit, 10);
+            baseDigits[i] = randomDigit;
         }
 
-        // Calculate the Luhn checksum of the values thus far
-        int lenOffset = (len + 1) % 2;
-        int sum = 0;
-        for (int i = 0; i < len - 1; i++) {
-            if ((i + lenOffset) % 2 != 0) {
-                int t = Character.getNumericValue(str[i]) << 1;
-
-                if (t > 9) {
-                    t -= 9;
-                }
-
-                sum += t;
-            } else {
-                sum += Character.getNumericValue(str[i]);
-            }
-        }
-
-        // Choose the last digit so that it causes the entire string to pass the checksum.
-        str[len - 1] = Character.forDigit(((10 - (sum % 10)) % 10), 10);
+        int checkDigit = LuhnCheckDigit.calculate(baseDigits);
+        str[len - 1] = Character.forDigit(checkDigit, 10);
 
         return new String(str);
     }

--- a/src/main/java/net/datafaker/providers/base/Finance.java
+++ b/src/main/java/net/datafaker/providers/base/Finance.java
@@ -1,6 +1,7 @@
 package net.datafaker.providers.base;
 
 import net.datafaker.annotations.Deterministic;
+import net.datafaker.internal.helper.LuhnCheckDigit;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -79,14 +80,8 @@ public class Finance extends AbstractProvider<BaseProviders> {
         String value = resolve(key);
         final String template = faker.numerify(value);
 
-        int[] digits = template.chars().filter(Character::isDigit).boxed().mapToInt(t -> t - '0').toArray();
-        int luhnSum = 0;
-        int multiplier = 1;
-        for (int i = digits.length - 1; i >= 0; i--) {
-            multiplier = (multiplier == 2 ? 1 : 2);
-            luhnSum += sumOfDigits(digits[i] * multiplier);
-        }
-        int luhnDigit = (10 - (luhnSum % 10)) % 10;
+        int luhnDigit = LuhnCheckDigit.calculate(template);
+
         StringBuilder res = new StringBuilder(template.length());
         for (int i = 0; i < template.length(); i++) {
             final char c = template.charAt(i);
@@ -97,15 +92,6 @@ public class Finance extends AbstractProvider<BaseProviders> {
             }
         }
         return res.toString().trim();
-    }
-
-    private int sumOfDigits(int value) {
-        int res = 0;
-        while (value > 0) {
-            res += value % 10;
-            value /= 10;
-        }
-        return res;
     }
 
     /**

--- a/src/main/java/net/datafaker/providers/base/Stock.java
+++ b/src/main/java/net/datafaker/providers/base/Stock.java
@@ -1,5 +1,9 @@
 package net.datafaker.providers.base;
 
+import net.datafaker.internal.helper.LuhnCheckDigit;
+
+import java.util.Locale;
+
 /**
  * @since 0.8.0
  */
@@ -27,6 +31,34 @@ public class Stock extends AbstractProvider<BaseProviders> {
 
     public String exchanges() {
         return resolve("stock.exchanges");
+    }
+
+    /**
+     * Generates a random International Securities Identification Number (ISIN) compliant with ISO 6166.
+     * <p>
+     * The ISIN consists of a 2-letter country code, a 9-character alphanumeric security identifier,
+     * and a single check digit calculated using the Luhn algorithm via {@link LuhnCheckDigit}.
+     *
+     * @return a valid-formatted ISIN
+     * @since 2.8.0
+     */
+    public String isin() {
+        String countryCode = faker.country().countryCode2().toUpperCase(Locale.ROOT);
+        String nsin = faker.regexify("[0-9A-Z]{9}");
+        String baseIsin = countryCode + nsin;
+
+        int baseIsinLen = baseIsin.length();
+        StringBuilder digits = new StringBuilder(baseIsinLen * 2);
+        for (int i = 0; i < baseIsinLen; i++) {
+            char c = baseIsin.charAt(i);
+            if (Character.isLetter(c)) {
+                digits.append(c - 'A' + 10);
+            } else {
+                digits.append(c - '0');
+            }
+        }
+
+        return baseIsin + LuhnCheckDigit.calculate(digits);
     }
 
 }

--- a/src/test/java/net/datafaker/internal/helper/LuhnCheckDigitTest.java
+++ b/src/test/java/net/datafaker/internal/helper/LuhnCheckDigitTest.java
@@ -1,0 +1,109 @@
+package net.datafaker.internal.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.stream.Stream;
+
+final class LuhnCheckDigitTest {
+
+    @DisplayName("Private constructor should throw UnsupportedOperationException")
+    @Test
+    void privateConstructor_shouldThrowException() {
+        assertConstructorIsPrivate(LuhnCheckDigit.class);
+    }
+
+    @DisplayName("Verify Luhn check digit calculation from CharSequence inputs")
+    @ParameterizedTest(name = "[{index}] Sequence: ''{0}'' -> Expected Digit: {1}")
+    @CsvSource({
+        // Standard credit card numbers / IMF examples (Base sequence without the check digit)
+        "4992739871, 6",
+        // test ignoring non-digits (dashes, spaces)
+        "4992-7398-71, 6",
+        "4992 7398 71, 6",
+        // IMEI examples
+        "49015420323751, 8",
+        // single digit edge cases
+        "0, 0",
+        "1, 8",
+        "9, 1"
+    })
+    void shouldCalculateCorrectDigitForCharSequence(CharSequence sequence, int expectedCheckDigit) {
+        int actualDigit = LuhnCheckDigit.calculate(sequence);
+        assertThat(actualDigit)
+            .as("Luhn check digit for sequence '%s' should be %d", sequence, expectedCheckDigit)
+            .isEqualTo(expectedCheckDigit);
+    }
+
+    @DisplayName("Verify Luhn check digit calculation from primitive int array inputs")
+    @ParameterizedTest(name = "[{index}] Array length: {1} -> Expected Digit: {2}")
+    @MethodSource("intArrayProvider")
+    void shouldCalculateCorrectDigitForIntArray(int[] digits, String description, int expectedCheckDigit) {
+        int actualDigit = LuhnCheckDigit.calculate(digits);
+        assertThat(actualDigit)
+            .as("Luhn check digit for %s should be %d", description, expectedCheckDigit)
+            .isEqualTo(expectedCheckDigit);
+    }
+
+    @DisplayName("Verify that null safe guard returns 0 for CharSequence method")
+    @ParameterizedTest
+    @NullSource
+    void shouldReturnZeroOnNullInput(CharSequence nullSequence) {
+        assertThat(LuhnCheckDigit.calculate(nullSequence)).isZero();
+    }
+
+    private static Stream<Arguments> intArrayProvider() {
+        return Stream.of(
+            Arguments.of(new int[]{4, 9, 9, 2, 7, 3, 9, 8, 7, 1}, "Standard CC digits", 6),
+            Arguments.of(new int[]{4, 9, 0, 1, 5, 4, 2, 0, 3, 2, 3, 7, 5, 1}, "IMEI digits", 8),
+            Arguments.of(new int[]{0}, "Single zero digit", 0),
+            Arguments.of(new int[]{1}, "Single one digit", 8),
+            Arguments.of(new int[]{9}, "Single nine digit", 1)
+        );
+    }
+
+    /**
+     * Asserts that a class has a private default constructor and throwing an
+     * {@link UnsupportedOperationException} on instantiation.
+     *
+     * @param <T>   the type of the class
+     * @param clazz the class to be tested
+     * @return the private constructor
+     * @throws AssertionError if any assertion fails
+     */
+    public static <T> Constructor<T> assertConstructorIsPrivate(Class<T> clazz) {
+        assertThat(clazz).isNotNull();
+
+        Constructor<T> constructor = null;
+        try {
+            constructor = clazz.getDeclaredConstructor();
+        } catch (NoSuchMethodException | SecurityException ex) {
+            throw new AssertionError("Private default constructor not found for " + clazz.getSimpleName(), ex);
+        }
+
+        assertThat(Modifier.isPrivate(constructor.getModifiers()))
+            .as("Constructor of utility class must be private")
+            .isTrue();
+
+        constructor.setAccessible(true);
+
+        assertThatThrownBy(constructor::newInstance)
+            .isInstanceOf(InvocationTargetException.class)
+            .hasCauseInstanceOf(UnsupportedOperationException.class)
+            .hasStackTraceContaining("cannot be instantiated");
+
+        return constructor;
+    }
+
+}

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -8,27 +8,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.speedbanking.iban.Iban;
 import de.speedbanking.iban.IbanRegistry;
 import net.datafaker.providers.base.Finance.CreditCardType;
-import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
+import org.apache.commons.validator.routines.CreditCardValidator;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 class FinanceTest extends BaseFakerTest {
+
+    private static final CreditCardValidator CREDIT_CARD_VALIDATOR = CreditCardValidator.genericCreditCardValidator();
 
     private final Finance finance = faker.finance();
 
     @RepeatedTest(100)
     void creditCard() {
-        final String creditCard = finance.creditCard();
-        assertCardLuhnDigit(creditCard);
-    }
-
-    private void assertCardLuhnDigit(String creditCard) {
-        final String creditCardStripped = creditCard.replace("-", "");
-        assertThat(LuhnCheckDigit.LUHN_CHECK_DIGIT.isValid(creditCardStripped)).isTrue();
+        assertThatCreditCardIsValid(finance.creditCard().replace("-", ""), null, CREDIT_CARD_VALIDATOR);
     }
 
     @RepeatedTest(10)
@@ -90,12 +89,11 @@ class FinanceTest extends BaseFakerTest {
         }
     }
 
-    @Test
-    void creditCardWithType() {
-        for (CreditCardType type : CreditCardType.values()) {
-            final String creditCard = finance.creditCard(type);
-            assertCardLuhnDigit(creditCard);
-        }
+    @ParameterizedTest(name = "[{index}] {0}")
+    @EnumSource(CreditCardType.class)
+    void creditCardWithType(CreditCardType type) {
+        String cc = finance.creditCard(type).replace("-", "");
+        assertThatCreditCardIsValid(cc, type, CREDIT_CARD_VALIDATOR);
     }
 
     @Test
@@ -112,19 +110,21 @@ class FinanceTest extends BaseFakerTest {
     void visaCard() {
         String creditCard = finance.creditCard(CreditCardType.VISA).replace("-", "");
         assertThat(creditCard).startsWith("4").hasSize(16);
+        assertThatCreditCardIsValid(creditCard, CreditCardType.VISA, CREDIT_CARD_VALIDATOR);
     }
 
     @RepeatedTest(100)
     void discoverCard() {
         String creditCard = finance.creditCard(CreditCardType.DISCOVER).replace("-", "");
         assertThat(creditCard).startsWith("6").hasSize(16);
+        assertThatCreditCardIsValid(creditCard, CreditCardType.DISCOVER, CREDIT_CARD_VALIDATOR);
     }
 
     @RepeatedTest(100)
     void unionpayCard() {
         List<String> startingDigits = List.of("62", "64", "65", "81");
         String creditCard = finance.creditCard(CreditCardType.UNIONPAY).replace("-", "");
-        assertThat(creditCard).hasSize(16);
+        assertThatCreditCardIsValid(creditCard, CreditCardType.UNIONPAY, CreditCardValidator.genericCreditCardValidator(16));
         assertThat(startingDigits)
             .as("UnionPay card '%s' should start with one of %s", creditCard, startingDigits)
             .anyMatch(prefix -> creditCard.startsWith(prefix));
@@ -143,4 +143,22 @@ class FinanceTest extends BaseFakerTest {
         }
         assertThat(check % 10).isZero();
     }
+
+    /**
+     * Asserts that the given credit card number is valid according to the specified validator.
+     *
+     * @param creditCard the card number to validate
+     * @param type the expected card type, or {@code null} if unspecified
+     * @param creditCardValidator the validator instance used for verification
+     */
+    private void assertThatCreditCardIsValid(String creditCard, CreditCardType type, CreditCardValidator creditCardValidator) {
+        assertThat(creditCard)
+            .satisfies(cc -> {
+                assertThat(creditCardValidator.isValid(cc))
+                    .as("Credit card %s (%s) should be valid according to %s",
+                        cc, Objects.requireNonNullElse(type, "unspecified"), creditCardValidator.getClass().getName())
+                    .isTrue();
+            });
+    }
+
 }

--- a/src/test/java/net/datafaker/providers/base/StockTest.java
+++ b/src/test/java/net/datafaker/providers/base/StockTest.java
@@ -1,9 +1,16 @@
 package net.datafaker.providers.base;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.validator.routines.ISINValidator;
+import org.junit.jupiter.api.RepeatedTest;
+
 import java.util.Collection;
+import java.util.List;
 
 class StockTest extends BaseFakerTest {
+
+    private static final ISINValidator ISIN_VALIDATOR = ISINValidator.getInstance(true);
 
     @Override
     protected Collection<TestSpec> providerListTest() {
@@ -13,6 +20,15 @@ class StockTest extends BaseFakerTest {
                 TestSpec.of(stock::nseSymbol, "stock.symbol_nse"),
                 TestSpec.of(stock::lseSymbol, "stock.symbol_lse"),
                 TestSpec.of(stock::exchanges, "stock.exchanges"));
+    }
+
+    @RepeatedTest(100)
+    void isin() {
+        assertThat(faker.stock().isin())
+            .matches("^[A-Z]{2}[0-9A-Z]{9}[0-9]$")
+            .satisfies(isin -> assertThat(ISIN_VALIDATOR.isValid(isin))
+            .as("ISIN %s should be valid according to %s", isin, ISIN_VALIDATOR.getClass().getName())
+            .isTrue());
     }
 
 }


### PR DESCRIPTION
## What

Adds `Stock.isin()` for generating **ISO 6166-compliant ISINs** (country code + NSIN + Luhn check digit).

While implementing this, I noticed duplicated Luhn logic in `Finance` and `Code` and extracted it into a shared `LuhnCheckDigit` utility in `internal.helper`.

Class `Stock` was preferred over class `Finance` since an ISIN is a securities identifier, not a payment instrument.

## Changes

- `Stock.isin()` – new method, validated against `ISINValidator` in repeated test runs
- `LuhnCheckDigit` – new internal helper with `CharSequence` and `int[]` overloads, replaces inline Luhn loops in `Finance.creditCard()` and `Code.imei()`
- `FinanceTest` – uses `CreditCardValidator` instead of manual Luhn check; `creditCardWithType` converted to `@ParameterizedTest`