### PR TITLE
fix(ci): skip publish job in forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository == 'datafaker-net/datafaker'
     steps:
       - name: Configure GPG Key
         run: |


### PR DESCRIPTION
## Problem

The `publish` job in `deploy.yml` runs on every push to `main` — including forks, where `GPG_SIGNING_KEY` is unavailable:

> gpg: no valid OpenPGP data found.
> Error: Process completed with exit code 2.

## Fix

Added a repository guard to the `publish` job:

```yaml
if: github.repository == 'datafaker-net/datafaker'
```

The job is skipped (not failed) in forks. No impact on the upstream repo.