### PR TITLE
Further Java Modernization

### DIFF
--- a/docs/documentation/formats.md
+++ b/docs/documentation/formats.md
@@ -22,7 +22,7 @@ attributes using randomly generated data in the following way:
         Collection<Xml.XmlNode> address = faker.<Xml.XmlNode>collection()
                 .suppliers(() -> new Xml.XmlNode("address",
                         map(entry("country", faker.address().country()),
-                                entry("city", faker.address().city()), entry("streetAddress", faker.address().streetAddress())), Collections.emptyList()))
+                                entry("city", faker.address().city()), entry("streetAddress", faker.address().streetAddress())), List.of()))
                 .maxLen(3).build().get();
 
         Collection<Xml.XmlNode> persons = faker.<Xml.XmlNode>collection()

--- a/docs/documentation/schemas.md
+++ b/docs/documentation/schemas.md
@@ -356,9 +356,9 @@ The following is an example on how to use it:
         field("lastname", () -> faker.name().lastName()),
         field("phones", () -> Schema.of(
             field("worknumbers", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get())
-                .collect(Collectors.toList())),
+                .toList()),
             field("cellphones", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get())
-                .collect(Collectors.toList()))
+                .toList())
         )),
         field("address", () -> Schema.of(
             field("city", () -> faker.address().city()),
@@ -549,9 +549,9 @@ The following is an example on how to use it:
         field("lastname", () -> faker.name().lastName()),
         field("phones", () -> Schema.of(
             field("worknumbers", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().phoneNumber()).maxLen(2).build().get())
-                .collect(Collectors.toList())),
+                .toList()),
             field("cellphones", () -> ((Stream<?>) faker.<String>stream().suppliers(() -> faker.phoneNumber().cellPhone()).maxLen(3).build().get())
-                .collect(Collectors.toList()))
+                .toList())
         )),
         field("address", () -> Schema.of(
             field("city", () -> faker.address().city()),

--- a/docs/documentation/schemas.md
+++ b/docs/documentation/schemas.md
@@ -271,13 +271,13 @@ INSERT INTO "MyTable" ("ints") VALUES (ARRAY[1, 2, 3]);
 === "Java"
 
     ```java
-    Schema.of(field("names_multiset", () -> Collections.singleton("hello")));
+    Schema.of(field("names_multiset", () -> Set.of("hello")));
     ```
 
 === "Kotlin"
 
     ```kotlin
-    val schema: Schema<String, Set<String>> = Schema.of(field("names_multiset", Supplier { Collections.singleton("hello") } ))
+    val schema: Schema<String, Set<String>> = Schema.of(field("names_multiset", Supplier { Set.of("hello") } ))
     ```
 
 will lead to

--- a/src/main/java/net/datafaker/providers/base/Fingerprint.java
+++ b/src/main/java/net/datafaker/providers/base/Fingerprint.java
@@ -65,7 +65,7 @@ public class Fingerprint extends AbstractProvider<BaseProviders> {
     }
 
     private byte[] encodePng(BufferedImage image) {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try (var baos = new ByteArrayOutputStream()) {
             ImageIO.write(image, "PNG", baos);
             return baos.toByteArray();
         } catch (IOException e) {

--- a/src/main/java/net/datafaker/providers/base/Image.java
+++ b/src/main/java/net/datafaker/providers/base/Image.java
@@ -150,7 +150,7 @@ public class Image extends AbstractProvider<BaseProviders> {
         }
         graphics.dispose();
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try (var baos = new ByteArrayOutputStream()) {
             ImageIO.write(bufferedImage, imageType.name(), baos);
             byte[] imageBytes = baos.toByteArray();
             return "data:" + imageType.mimeType + ";base64," + Base64.getEncoder().encodeToString(imageBytes);

--- a/src/main/java/net/datafaker/providers/base/Internet.java
+++ b/src/main/java/net/datafaker/providers/base/Internet.java
@@ -10,7 +10,6 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.text.Normalizer;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -135,7 +134,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         final List<String> prefixList = (prefixObj instanceof List<?> list
                 && list.stream().allMatch(String.class::isInstance))
                         ? list.stream().map(String.class::cast).toList()
-                        : Collections.emptyList();
+                        : List.of();
         if (prefixList.contains(parts[0])) {
             parts = Arrays.copyOfRange(parts, 1, parts.length);
         }
@@ -144,7 +143,7 @@ public class Internet extends AbstractProvider<BaseProviders> {
         final List<String> suffixList = (suffixObj instanceof List<?> list
                 && list.stream().allMatch(String.class::isInstance))
                         ? list.stream().map(String.class::cast).toList()
-                        : Collections.emptyList();
+                        : List.of();
         if (suffixList.contains(parts[parts.length - 1])) {
             parts = Arrays.copyOfRange(parts, 0, parts.length - 1);
         }

--- a/src/main/java/net/datafaker/providers/base/Options.java
+++ b/src/main/java/net/datafaker/providers/base/Options.java
@@ -1,6 +1,5 @@
 package net.datafaker.providers.base;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -76,7 +75,7 @@ public class Options extends AbstractProvider<BaseProviders> {
             throw new IllegalArgumentException("size should be not negative: " + size);
         }
         if (size == 0) {
-            return Collections.emptySet();
+            return Set.of();
         }
         List<E> opts = Stream.of(options).distinct().collect(Collectors.toList());
         if (size >= opts.size()) {
@@ -119,7 +118,7 @@ public class Options extends AbstractProvider<BaseProviders> {
             throw new IllegalArgumentException("size should be not negative: " + size);
         }
         if (size == 0) {
-            return Collections.emptySet();
+            return Set.of();
         }
         List<String> opts = Stream.of(options).distinct().collect(Collectors.toList());
         if (size >= opts.size()) {

--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -121,27 +121,39 @@ public class Text extends AbstractProvider<BaseProviders> {
         super(faker);
     }
 
-    public static class TextRuleConfig {
-        private final char[][] textKeys;
-        private final int[] required;
-        private final int fixedNumberOfCharacters;
-
-        private final int numberOfRequiredSymbols;
-
+    public record TextRuleConfig(
+        char[][] textKeys,
+        int[] required,
+        int fixedNumberOfCharacters,
+        int numberOfRequiredSymbols
+    ) {
         private TextRuleConfig(int fixedNumberOfCharacters, Map<String, Integer> map, int numberOfRequiredSymbols) {
+            this(
+                buildTextKeys(map),
+                buildRequired(map),
+                fixedNumberOfCharacters,
+                numberOfRequiredSymbols
+            );
             assert numberOfRequiredSymbols >= 0;
             assert fixedNumberOfCharacters >= numberOfRequiredSymbols;
+        }
 
-            this.fixedNumberOfCharacters = fixedNumberOfCharacters;
-            this.numberOfRequiredSymbols = numberOfRequiredSymbols;
-            this.textKeys = new char[map.size()][];
-            this.required = new int[map.size()];
+        private static char[][] buildTextKeys(Map<String, Integer> map) {
+            char[][] textKeys = new char[map.size()][];
             int i = 0;
-            for (Map.Entry<String, Integer> entry: map.entrySet()) {
-                textKeys[i] = entry.getKey().toCharArray();
-                required[i] = entry.getValue();
-                i++;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                textKeys[i++] = entry.getKey().toCharArray();
             }
+            return textKeys;
+        }
+
+        private static int[] buildRequired(Map<String, Integer> map) {
+            int[] required = new int[map.size()];
+            int i = 0;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                required[i++] = entry.getValue();
+            }
+            return required;
         }
 
         public int getFixedNumberOfCharacters() {
@@ -151,7 +163,6 @@ public class Text extends AbstractProvider<BaseProviders> {
         public int getNumberOfRequiredSymbols() {
             return numberOfRequiredSymbols;
         }
-
     }
 
     public static class TextSymbolsBuilder {
@@ -238,8 +249,8 @@ public class Text extends AbstractProvider<BaseProviders> {
         char[] buffer = new char[fixedNumberOfCharacters];
         int idx = 0;
         int maxDiffSymbols = 0;
-        for (int i = 0; i < textRuleConfig.textKeys.length; i++) {
-            maxDiffSymbols += textRuleConfig.textKeys[i].length;
+        for (int i = 0; i < textRuleConfig.textKeys().length; i++) {
+            maxDiffSymbols += textRuleConfig.textKeys()[i].length;
         }
         // 256 is a length of byte value range
         if (maxDiffSymbols <= 256) {
@@ -248,13 +259,13 @@ public class Text extends AbstractProvider<BaseProviders> {
                 fixedNumberOfCharacters, numberOfRequiredSymbols);
         }
         int numberOfRequired = 0;
-        int[] required = Arrays.copyOf(textRuleConfig.required, textRuleConfig.required.length);
+        int[] required = Arrays.copyOf(textRuleConfig.required(), textRuleConfig.required().length);
         while (idx < buffer.length) {
             if (numberOfRequiredSymbols > numberOfRequired
                 && numberOfRequiredSymbols - numberOfRequired == buffer.length - idx) {
-                for (int j = 0; j < textRuleConfig.textKeys.length; j++) {
+                for (int j = 0; j < textRuleConfig.textKeys().length; j++) {
                     while (required[j] > 0) {
-                        buffer[idx++] = textRuleConfig.textKeys[j][faker.random().nextInt(textRuleConfig.textKeys[j].length)];
+                        buffer[idx++] = textRuleConfig.textKeys()[j][faker.random().nextInt(textRuleConfig.textKeys()[j].length)];
                         numberOfRequired++;
                         required[j]--;
                     }
@@ -266,7 +277,7 @@ public class Text extends AbstractProvider<BaseProviders> {
                     numberOfRequired++;
                     required[index]--;
                 }
-                buffer[idx++] = textRuleConfig.textKeys[index][faker.random().nextInt(textRuleConfig.textKeys[index].length)];
+                buffer[idx++] = textRuleConfig.textKeys()[index][faker.random().nextInt(textRuleConfig.textKeys()[index].length)];
             }
         }
         return String.valueOf(buffer);
@@ -278,25 +289,25 @@ public class Text extends AbstractProvider<BaseProviders> {
         int idx = 0;
         int bytesCounter = 0;
         int numberOfRequired = 0;
-        int[] required = Arrays.copyOf(textRuleConfig.required, textRuleConfig.required.length);
+        int[] required = Arrays.copyOf(textRuleConfig.required(), textRuleConfig.required().length);
         while (idx < buffer.length) {
             if (numberOfRequiredSymbols > numberOfRequired
                 && numberOfRequiredSymbols - numberOfRequired == buffer.length - idx) {
-                for (int j = 0; j < textRuleConfig.textKeys.length; j++) {
+                for (int j = 0; j < textRuleConfig.textKeys().length; j++) {
                     while (required[j] > 0) {
-                        buffer[idx++] = textRuleConfig.textKeys[j][((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys[j].length];
+                        buffer[idx++] = textRuleConfig.textKeys()[j][((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys()[j].length];
                         numberOfRequired++;
                         required[j]--;
                     }
                     if (idx == buffer.length) break;
                 }
             } else {
-                int index = ((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys.length;
+                int index = ((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys().length;
                 if (required[index] > 0) {
                     numberOfRequired++;
                     required[index]--;
                 }
-                buffer[idx++] = textRuleConfig.textKeys[index][((char) bytes[bytesCounter++]) % textRuleConfig.textKeys[index].length];
+                buffer[idx++] = textRuleConfig.textKeys()[index][((char) bytes[bytesCounter++]) % textRuleConfig.textKeys()[index].length];
             }
         }
         return String.valueOf(buffer);

--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -121,39 +121,27 @@ public class Text extends AbstractProvider<BaseProviders> {
         super(faker);
     }
 
-    public record TextRuleConfig(
-        char[][] textKeys,
-        int[] required,
-        int fixedNumberOfCharacters,
-        int numberOfRequiredSymbols
-    ) {
+    public static class TextRuleConfig {
+        private final char[][] textKeys;
+        private final int[] required;
+        private final int fixedNumberOfCharacters;
+
+        private final int numberOfRequiredSymbols;
+
         private TextRuleConfig(int fixedNumberOfCharacters, Map<String, Integer> map, int numberOfRequiredSymbols) {
-            this(
-                buildTextKeys(map),
-                buildRequired(map),
-                fixedNumberOfCharacters,
-                numberOfRequiredSymbols
-            );
             assert numberOfRequiredSymbols >= 0;
             assert fixedNumberOfCharacters >= numberOfRequiredSymbols;
-        }
 
-        private static char[][] buildTextKeys(Map<String, Integer> map) {
-            char[][] textKeys = new char[map.size()][];
+            this.fixedNumberOfCharacters = fixedNumberOfCharacters;
+            this.numberOfRequiredSymbols = numberOfRequiredSymbols;
+            this.textKeys = new char[map.size()][];
+            this.required = new int[map.size()];
             int i = 0;
-            for (var entry : map.entrySet()) {
-                textKeys[i++] = entry.getKey().toCharArray();
+            for (Map.Entry<String, Integer> entry: map.entrySet()) {
+                textKeys[i] = entry.getKey().toCharArray();
+                required[i] = entry.getValue();
+                i++;
             }
-            return textKeys;
-        }
-
-        private static int[] buildRequired(Map<String, Integer> map) {
-            int[] required = new int[map.size()];
-            int i = 0;
-            for (var entry : map.entrySet()) {
-                required[i++] = entry.getValue();
-            }
-            return required;
         }
 
         public int getFixedNumberOfCharacters() {
@@ -163,6 +151,7 @@ public class Text extends AbstractProvider<BaseProviders> {
         public int getNumberOfRequiredSymbols() {
             return numberOfRequiredSymbols;
         }
+
     }
 
     public static class TextSymbolsBuilder {
@@ -249,8 +238,8 @@ public class Text extends AbstractProvider<BaseProviders> {
         char[] buffer = new char[fixedNumberOfCharacters];
         int idx = 0;
         int maxDiffSymbols = 0;
-        for (int i = 0; i < textRuleConfig.textKeys().length; i++) {
-            maxDiffSymbols += textRuleConfig.textKeys()[i].length;
+        for (int i = 0; i < textRuleConfig.textKeys.length; i++) {
+            maxDiffSymbols += textRuleConfig.textKeys[i].length;
         }
         // 256 is a length of byte value range
         if (maxDiffSymbols <= 256) {
@@ -259,13 +248,13 @@ public class Text extends AbstractProvider<BaseProviders> {
                 fixedNumberOfCharacters, numberOfRequiredSymbols);
         }
         int numberOfRequired = 0;
-        int[] required = Arrays.copyOf(textRuleConfig.required(), textRuleConfig.required().length);
+        int[] required = Arrays.copyOf(textRuleConfig.required, textRuleConfig.required.length);
         while (idx < buffer.length) {
             if (numberOfRequiredSymbols > numberOfRequired
                 && numberOfRequiredSymbols - numberOfRequired == buffer.length - idx) {
-                for (int j = 0; j < textRuleConfig.textKeys().length; j++) {
+                for (int j = 0; j < textRuleConfig.textKeys.length; j++) {
                     while (required[j] > 0) {
-                        buffer[idx++] = textRuleConfig.textKeys()[j][faker.random().nextInt(textRuleConfig.textKeys()[j].length)];
+                        buffer[idx++] = textRuleConfig.textKeys[j][faker.random().nextInt(textRuleConfig.textKeys[j].length)];
                         numberOfRequired++;
                         required[j]--;
                     }
@@ -277,7 +266,7 @@ public class Text extends AbstractProvider<BaseProviders> {
                     numberOfRequired++;
                     required[index]--;
                 }
-                buffer[idx++] = textRuleConfig.textKeys()[index][faker.random().nextInt(textRuleConfig.textKeys()[index].length)];
+                buffer[idx++] = textRuleConfig.textKeys[index][faker.random().nextInt(textRuleConfig.textKeys[index].length)];
             }
         }
         return String.valueOf(buffer);
@@ -289,25 +278,25 @@ public class Text extends AbstractProvider<BaseProviders> {
         int idx = 0;
         int bytesCounter = 0;
         int numberOfRequired = 0;
-        int[] required = Arrays.copyOf(textRuleConfig.required(), textRuleConfig.required().length);
+        int[] required = Arrays.copyOf(textRuleConfig.required, textRuleConfig.required.length);
         while (idx < buffer.length) {
             if (numberOfRequiredSymbols > numberOfRequired
                 && numberOfRequiredSymbols - numberOfRequired == buffer.length - idx) {
-                for (int j = 0; j < textRuleConfig.textKeys().length; j++) {
+                for (int j = 0; j < textRuleConfig.textKeys.length; j++) {
                     while (required[j] > 0) {
-                        buffer[idx++] = textRuleConfig.textKeys()[j][((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys()[j].length];
+                        buffer[idx++] = textRuleConfig.textKeys[j][((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys[j].length];
                         numberOfRequired++;
                         required[j]--;
                     }
                     if (idx == buffer.length) break;
                 }
             } else {
-                int index = ((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys().length;
+                int index = ((char) (bytes[bytesCounter++])) % textRuleConfig.textKeys.length;
                 if (required[index] > 0) {
                     numberOfRequired++;
                     required[index]--;
                 }
-                buffer[idx++] = textRuleConfig.textKeys()[index][((char) bytes[bytesCounter++]) % textRuleConfig.textKeys()[index].length];
+                buffer[idx++] = textRuleConfig.textKeys[index][((char) bytes[bytesCounter++]) % textRuleConfig.textKeys[index].length];
             }
         }
         return String.valueOf(buffer);

--- a/src/main/java/net/datafaker/providers/base/Text.java
+++ b/src/main/java/net/datafaker/providers/base/Text.java
@@ -141,7 +141,7 @@ public class Text extends AbstractProvider<BaseProviders> {
         private static char[][] buildTextKeys(Map<String, Integer> map) {
             char[][] textKeys = new char[map.size()][];
             int i = 0;
-            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            for (var entry : map.entrySet()) {
                 textKeys[i++] = entry.getKey().toCharArray();
             }
             return textKeys;
@@ -150,7 +150,7 @@ public class Text extends AbstractProvider<BaseProviders> {
         private static int[] buildRequired(Map<String, Integer> map) {
             int[] required = new int[map.size()];
             int i = 0;
-            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            for (var entry : map.entrySet()) {
                 required[i++] = entry.getValue();
             }
             return required;

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Collections.emptyMap;
 import static net.datafaker.internal.helper.JavaNames.toJavaNames;
 
 public class FakeValues implements FakeValuesInterface {
@@ -82,7 +81,7 @@ public class FakeValues implements FakeValuesInterface {
                 return result;
             }
         }
-        return emptyMap();
+        return Map.of();
     }
 
     private void enrichMapWithJavaNames(Map<String, Object> result) {

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -90,9 +90,9 @@ public class FakeValues implements FakeValuesInterface {
             for (Map.Entry<String, Object> entry : result.entrySet()) {
                 final String key = entry.getKey();
                 Object value = entry.getValue();
-                if (entry.getValue() instanceof Map) {
+                if (value instanceof Map<?, ?> rawMap) {
                     @SuppressWarnings("unchecked")
-                    Map<String, Object> entryMap = (Map<String, Object>) entry.getValue();
+                    Map<String, Object> entryMap = (Map<String, Object>) rawMap;
                     prefixUnqualifiedExpressions(entryMap, key);
                     Map<String, Object> nestedMap = new HashMap<>(entryMap.size());
                     for (Map.Entry<String, Object> e: entryMap.entrySet()) {

--- a/src/main/java/net/datafaker/service/FakeValues.java
+++ b/src/main/java/net/datafaker/service/FakeValues.java
@@ -40,7 +40,7 @@ public class FakeValues implements FakeValuesInterface {
         if (url == null) {
             return null;
         }
-        try (InputStream stream = url.openStream()) {
+        try (var stream = url.openStream()) {
             Map<String, Object> result = readFromStream(stream);
             enrichMapWithJavaNames(result);
             return result;
@@ -63,12 +63,12 @@ public class FakeValues implements FakeValuesInterface {
                 "/" + locale.getLanguage() + ".yml"};
 
         for (String path : paths) {
-            try (InputStream stream = getClass().getResourceAsStream(path)) {
+            try (var stream = getClass().getResourceAsStream(path)) {
                 if (stream != null) {
                     result = readFromStream(stream);
                     enrichMapWithJavaNames(result);
                 } else {
-                    try (InputStream stream2 = getClass().getClassLoader().getResourceAsStream(path)) {
+                    try (var stream2 = getClass().getClassLoader().getResourceAsStream(path)) {
                         result = readFromStream(stream2);
                         enrichMapWithJavaNames(result);
                     }
@@ -87,7 +87,7 @@ public class FakeValues implements FakeValuesInterface {
     private void enrichMapWithJavaNames(Map<String, Object> result) {
         if (result != null) {
             Map<String, Object> map = null;
-            for (Map.Entry<String, Object> entry : result.entrySet()) {
+            for (var entry : result.entrySet()) {
                 final String key = entry.getKey();
                 Object value = entry.getValue();
                 if (value instanceof Map<?, ?> rawMap) {
@@ -95,7 +95,7 @@ public class FakeValues implements FakeValuesInterface {
                     Map<String, Object> entryMap = (Map<String, Object>) rawMap;
                     prefixUnqualifiedExpressions(entryMap, key);
                     Map<String, Object> nestedMap = new HashMap<>(entryMap.size());
-                    for (Map.Entry<String, Object> e: entryMap.entrySet()) {
+                    for (var e : entryMap.entrySet()) {
                         nestedMap.put(toJavaNames(e.getKey(), true), e.getValue());
                     }
                     entryMap.putAll(nestedMap);

--- a/src/main/java/net/datafaker/service/FakeValuesContext.java
+++ b/src/main/java/net/datafaker/service/FakeValuesContext.java
@@ -7,18 +7,37 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
 
-record FakeValuesContext(SingletonLocale singletonLocale, String filename, String path, URL url) {
+class FakeValuesContext {
+    private final SingletonLocale singletonLocale;
+    private final String filename;
+    private final int filenameHashCode;
+    private final String path;
+    private final URL url;
+    private final int urlHashCode;
 
     private FakeValuesContext(Locale locale) {
-        this(SingletonLocale.get(locale), getFilename(locale), getFilename(locale), null);
+        this(locale, getFilename(locale), getFilename(locale), null);
     }
 
     private FakeValuesContext(Locale locale, URL url) {
-        this(SingletonLocale.get(locale), getFilename(locale), null, url);
+        this(locale, getFilename(locale), null, url);
     }
 
     private FakeValuesContext(Locale locale, String filename, String path) {
-        this(SingletonLocale.get(locale), filename, path, null);
+        this(locale, filename, path, null);
+    }
+
+    private FakeValuesContext(Locale locale, String filename, String path, URL url) {
+        this.singletonLocale = SingletonLocale.get(locale);
+        this.filename = filename;
+        this.path = path;
+        this.url = url;
+        this.filenameHashCode = filename == null ? 0 : filename.hashCode();
+        try {
+            this.urlHashCode = url == null ? 0 : url.toURI().hashCode();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Invalid url: \"%s\"".formatted(url), e);
+        }
     }
 
     public static FakeValuesContext of(Locale locale) {
@@ -34,7 +53,7 @@ record FakeValuesContext(SingletonLocale singletonLocale, String filename, Strin
     }
 
     public static FakeValuesContext of(Locale locale, String filename, String path, URL url) {
-        return new FakeValuesContext(SingletonLocale.get(locale), filename, path, url);
+        return new FakeValuesContext(locale, filename, path, url);
     }
 
     private static String getFilename(Locale locale) {
@@ -61,11 +80,11 @@ record FakeValuesContext(SingletonLocale singletonLocale, String filename, Strin
         };
     }
 
-    Locale getLocale() {
+    public Locale getLocale() {
         return singletonLocale.getLocale();
     }
 
-    String getFilename() {
+    public String getFilename() {
         return filename;
     }
 
@@ -73,42 +92,30 @@ record FakeValuesContext(SingletonLocale singletonLocale, String filename, Strin
         return path;
     }
 
-    URL getUrl() {
+    public URL getUrl() {
         return url;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof FakeValuesContext that)) {
-            return false;
-        }
-        return Objects.equals(singletonLocale, that.singletonLocale)
-            && Objects.equals(filename, that.filename)
-            && Objects.equals(path, that.path)
-            && Objects.equals(url, that.url);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FakeValuesContext that = (FakeValuesContext) o;
+
+        if (!Objects.equals(singletonLocale, that.singletonLocale)) return false;
+        if (!Objects.equals(filename, that.filename)) return false;
+        if (!Objects.equals(path, that.path)) return false;
+        return Objects.equals(url, that.url);
     }
 
     @Override
     public int hashCode() {
         int result = singletonLocale == null ? 0 : singletonLocale.hashCode();
-        result = 31 * result + (filename == null ? 0 : filename.hashCode());
+        result = 31 * result + filenameHashCode;
         result = 31 * result + (path == null ? 0 : path.hashCode());
-        result = 31 * result + urlHashCode(url);
+        result = 31 * result + urlHashCode;
         return result;
-    }
-
-    private static int urlHashCode(URL url) {
-        if (url == null) {
-            return 0;
-        }
-        try {
-            return url.toURI().hashCode();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException("Invalid url: \"%s\"".formatted(url), e);
-        }
     }
 
     @Override

--- a/src/main/java/net/datafaker/service/FakeValuesContext.java
+++ b/src/main/java/net/datafaker/service/FakeValuesContext.java
@@ -7,37 +7,18 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
 
-class FakeValuesContext {
-    private final SingletonLocale singletonLocale;
-    private final String filename;
-    private final int filenameHashCode;
-    private final String path;
-    private final URL url;
-    private final int urlHashCode;
+record FakeValuesContext(SingletonLocale singletonLocale, String filename, String path, URL url) {
 
     private FakeValuesContext(Locale locale) {
-        this(locale, getFilename(locale), getFilename(locale), null);
+        this(SingletonLocale.get(locale), getFilename(locale), getFilename(locale), null);
     }
 
     private FakeValuesContext(Locale locale, URL url) {
-        this(locale, getFilename(locale), null, url);
+        this(SingletonLocale.get(locale), getFilename(locale), null, url);
     }
 
     private FakeValuesContext(Locale locale, String filename, String path) {
-        this(locale, filename, path, null);
-    }
-
-    private FakeValuesContext(Locale locale, String filename, String path, URL url) {
-        this.singletonLocale = SingletonLocale.get(locale);
-        this.filename = filename;
-        this.path = path;
-        this.url = url;
-        this.filenameHashCode = filename == null ? 0 : filename.hashCode();
-        try {
-            this.urlHashCode = url == null ? 0 : url.toURI().hashCode();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException("Invalid url: \"%s\"".formatted(url), e);
-        }
+        this(SingletonLocale.get(locale), filename, path, null);
     }
 
     public static FakeValuesContext of(Locale locale) {
@@ -53,7 +34,7 @@ class FakeValuesContext {
     }
 
     public static FakeValuesContext of(Locale locale, String filename, String path, URL url) {
-        return new FakeValuesContext(locale, filename, path, url);
+        return new FakeValuesContext(SingletonLocale.get(locale), filename, path, url);
     }
 
     private static String getFilename(Locale locale) {
@@ -80,11 +61,11 @@ class FakeValuesContext {
         };
     }
 
-    public Locale getLocale() {
+    Locale getLocale() {
         return singletonLocale.getLocale();
     }
 
-    public String getFilename() {
+    String getFilename() {
         return filename;
     }
 
@@ -92,30 +73,42 @@ class FakeValuesContext {
         return path;
     }
 
-    public URL getUrl() {
+    URL getUrl() {
         return url;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        FakeValuesContext that = (FakeValuesContext) o;
-
-        if (!Objects.equals(singletonLocale, that.singletonLocale)) return false;
-        if (!Objects.equals(filename, that.filename)) return false;
-        if (!Objects.equals(path, that.path)) return false;
-        return Objects.equals(url, that.url);
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FakeValuesContext that)) {
+            return false;
+        }
+        return Objects.equals(singletonLocale, that.singletonLocale)
+            && Objects.equals(filename, that.filename)
+            && Objects.equals(path, that.path)
+            && Objects.equals(url, that.url);
     }
 
     @Override
     public int hashCode() {
         int result = singletonLocale == null ? 0 : singletonLocale.hashCode();
-        result = 31 * result + filenameHashCode;
+        result = 31 * result + (filename == null ? 0 : filename.hashCode());
         result = 31 * result + (path == null ? 0 : path.hashCode());
-        result = 31 * result + urlHashCode;
+        result = 31 * result + urlHashCode(url);
         return result;
+    }
+
+    private static int urlHashCode(URL url) {
+        if (url == null) {
+            return 0;
+        }
+        try {
+            return url.toURI().hashCode();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Invalid url: \"%s\"".formatted(url), e);
+        }
     }
 
     @Override

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -3,9 +3,9 @@ package net.datafaker.service;
 import net.datafaker.service.files.EnFile;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -42,7 +42,7 @@ public final class FakeValuesGrouping implements FakeValuesInterface {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Map get(String key) {
         Map result = null;
-        for (FakeValuesInterface fakeValues : fakeValues.getOrDefault(key, Collections.emptyList())) {
+        for (FakeValuesInterface fakeValues : fakeValues.getOrDefault(key, List.of())) {
             if (result == null) {
                 result = fakeValues.get(key);
             } else {

--- a/src/main/java/net/datafaker/service/FakeValuesGrouping.java
+++ b/src/main/java/net/datafaker/service/FakeValuesGrouping.java
@@ -27,12 +27,12 @@ public final class FakeValuesGrouping implements FakeValuesInterface {
     }
 
     public void add(FakeValuesInterface fakeValue) {
-        if (fakeValue instanceof FakeValues) {
-            ((FakeValues) fakeValue).getPaths().forEach(p ->
+        if (fakeValue instanceof FakeValues values) {
+            values.getPaths().forEach(p ->
             fakeValues.computeIfAbsent(p, key -> new HashSet<>())
                 .add(fakeValue));
-        } else if (fakeValue instanceof FakeValuesGrouping) {
-            fakeValues.putAll(((FakeValuesGrouping) fakeValue).fakeValues);
+        } else if (fakeValue instanceof FakeValuesGrouping grouping) {
+            fakeValues.putAll(grouping.fakeValues);
         } else {
             throw new RuntimeException(fakeValues.getClass().getName() + " not supported (please raise an issue)");
         }

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -163,23 +163,12 @@ public class FakeValuesService {
         return (String) fetch(key, context);
     }
 
-    private class SafeFetchResolver implements ValueResolver {
-        private final String simpleDirective;
-        private final FakerContext context;
-
-        private SafeFetchResolver(String simpleDirective, FakerContext context) {
-            this.simpleDirective = simpleDirective;
-            this.context = context;
-        }
+    private record SafeFetchResolver(FakeValuesService service, String simpleDirective, FakerContext context)
+        implements ValueResolver {
 
         @Override
         public Object resolve() {
-            return safeFetch(simpleDirective, context, null);
-        }
-
-        @Override
-        public String toString() {
-            return "%s[simpleDirective=%s, context=%s]".formatted(getClass().getSimpleName(), simpleDirective, context);
+            return service.safeFetch(simpleDirective, context, null);
         }
     }
 
@@ -755,7 +744,7 @@ public class FakeValuesService {
         // car.wheel will be looked up in the YAML file.
         // It's only "simple" if there aren't args
         if (args.length == 0) {
-            res.add(new SafeFetchResolver(simpleDirective, context));
+            res.add(new SafeFetchResolver(this, simpleDirective, context));
         }
 
         // resolve method references on faker object like #{regexify '[a-z]'}
@@ -775,7 +764,7 @@ public class FakeValuesService {
         // class.method_name (lowercase)
         if (dotIndex >= 0) {
             final String key = javaNameToYamlName(simpleDirective);
-            res.add(new SafeFetchResolver(key, context));
+            res.add(new SafeFetchResolver(this, key, context));
         }
 
         return res;

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -677,7 +676,7 @@ public class FakeValuesService {
             return res;
         }
         if (res instanceof List<?> list) {
-            Iterator<ValueResolver> it = ((List<ValueResolver>) list).iterator();
+            var it = ((List<ValueResolver>) list).iterator();
             while (it.hasNext()) {
                 Object valueResolver = it.next();
                 Object value;
@@ -909,7 +908,7 @@ public class FakeValuesService {
         LOG.fine(() -> "Find accessor named %s on %s with args %s".formatted(accessorName, clazz.getSimpleName(), Arrays.toString(args)));
         String name = removeUnderscoreChars(accessorName);
 
-        Map<String, Collection<Method>> classMethodsMap = CLASS_2_METHODS_CACHE.computeIfAbsent(clazz, (__) -> {
+        var classMethodsMap = CLASS_2_METHODS_CACHE.computeIfAbsent(clazz, (__) -> {
             Method[] classMethods = clazz.getMethods();
             Map<String, Collection<Method>> methodMap =
                 classMethods.length == 0 ? Map.of() : new HashMap<>(classMethods.length);

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -142,8 +142,8 @@ public class FakeValuesService {
     public Object fetch(String key, FakerContext context) {
         List<?> valuesArray = null;
         final Object o = fetchObject(key, context);
-        if (o instanceof List) {
-            valuesArray = (List<?>) o;
+        if (o instanceof List<?> list) {
+            valuesArray = list;
             final int size = valuesArray.size();
             if (size == 0) {
                 return null;
@@ -193,8 +193,8 @@ public class FakeValuesService {
         Object o = fetchObject(key, context);
         String str;
         if (o == null) return defaultIfNull;
-        if (o instanceof List) {
-            final List<String> values = (List<String>) o;
+        if (o instanceof List<?> list) {
+            final List<String> values = (List<String>) list;
             final int size = values.size();
             return switch (size) {
                 case 0 -> defaultIfNull;
@@ -237,8 +237,8 @@ public class FakeValuesService {
             Object currentValue = fakeValuesInterfaceMap.get(sLocale);
             for (int p = 0; currentValue != null && p < path.length; p++) {
                 String currentPath = path[p];
-                if (currentValue instanceof Map) {
-                    currentValue = ((Map<?, ?>) currentValue).get(currentPath);
+                if (currentValue instanceof Map<?, ?> map) {
+                    currentValue = map.get(currentPath);
                 } else {
                     currentValue = ((FakeValuesInterface) currentValue).get(currentPath);
                 }
@@ -670,14 +670,14 @@ public class FakeValuesService {
     private Object resExp(String directive, String[] args, Object current, ProviderRegistration root, FakerContext context, String expr) {
         Object res = resolveExpression(directive, args, current, root, context);
         LOG.fine(() -> "resExp(%s [%s]) current: %s, root: %s, context: %s, expr: %s -> res: %s".formatted(directive, Arrays.toString(args), current, root, context, expr, res));
-        if (res instanceof CharSequence) {
-            if (((CharSequence) res).isEmpty()) {
+        if (res instanceof CharSequence charSequence) {
+            if (charSequence.isEmpty()) {
                 regexp2SupplierMap.put(expr, new RegExpContext(root, context, EMPTY_STRING));
             }
             return res;
         }
-        if (res instanceof List) {
-            Iterator<ValueResolver> it = ((List<ValueResolver>) res).iterator();
+        if (res instanceof List<?> list) {
+            Iterator<ValueResolver> it = ((List<ValueResolver>) list).iterator();
             while (it.hasNext()) {
                 Object valueResolver = it.next();
                 Object value;
@@ -716,8 +716,8 @@ public class FakeValuesService {
             // resolve method references on CURRENT object like #{number_between '1','10'} on Number or
             // #{ssn_valid} on IdNumber
             if (dotIndex == -1) {
-                if (current instanceof AbstractProvider) {
-                    final Method method = BaseFaker.getMethod((AbstractProvider<?>) current, directive);
+                if (current instanceof AbstractProvider<?> provider) {
+                    final Method method = BaseFaker.getMethod(provider, directive);
                     if (method != null) {
                         res.add(new MethodResolver(method, current, args));
                         return res;

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -42,8 +42,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
@@ -264,7 +262,7 @@ public class FakeValuesService {
         }
         if (local2Add != null) {
             Object valueToCache = result;
-            Object curResult = key2fetchedObject.getOrDefault(local2Add, emptyMap()).get(key);
+            Object curResult = key2fetchedObject.getOrDefault(local2Add, Map.of()).get(key);
             if (curResult != null) {
                 return (T) result; // Strange... Why return result, not curResult?
             }
@@ -925,7 +923,7 @@ public class FakeValuesService {
         Map<String, Collection<Method>> classMethodsMap = CLASS_2_METHODS_CACHE.computeIfAbsent(clazz, (__) -> {
             Method[] classMethods = clazz.getMethods();
             Map<String, Collection<Method>> methodMap =
-                classMethods.length == 0 ? emptyMap() : new HashMap<>(classMethods.length);
+                classMethods.length == 0 ? Map.of() : new HashMap<>(classMethods.length);
             for (Method m : classMethods) {
                 String key = m.getName().toLowerCase(ROOT);
                 methodMap.computeIfAbsent(key, k -> new ArrayList<>()).add(m);
@@ -934,7 +932,7 @@ public class FakeValuesService {
             return methodMap;
         });
 
-        Collection<Method> methods = classMethodsMap.getOrDefault(name, emptyList());
+        Collection<Method> methods = classMethodsMap.getOrDefault(name, List.of());
         if (methods.isEmpty()) {
             LOG.fine(() -> "Didn't find accessor named %s on %s with args %s".formatted(accessorName, clazz.getSimpleName(), Arrays.toString(args)));
             return null;

--- a/src/main/java/net/datafaker/service/files/EnFile.java
+++ b/src/main/java/net/datafaker/service/files/EnFile.java
@@ -3,11 +3,18 @@ package net.datafaker.service.files;
 import java.util.List;
 import java.util.stream.Stream;
 
-public record EnFile(String file, String path) {
+public class EnFile {
     private static final String YML = ".yml";
+    private final String file;
+    private final String path;
 
     private EnFile(String file) {
         this(file, file.endsWith(YML) ? file.substring(0, file.length() - YML.length()) : file);
+    }
+
+    private EnFile(String file, String path) {
+        this.file = file;
+        this.path = path;
     }
 
     public String getFile() {

--- a/src/main/java/net/datafaker/service/files/EnFile.java
+++ b/src/main/java/net/datafaker/service/files/EnFile.java
@@ -3,18 +3,11 @@ package net.datafaker.service.files;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class EnFile {
+public record EnFile(String file, String path) {
     private static final String YML = ".yml";
-    private final String file;
-    private final String path;
 
     private EnFile(String file) {
         this(file, file.endsWith(YML) ? file.substring(0, file.length() - YML.length()) : file);
-    }
-
-    private EnFile(String file, String path) {
-        this.file = file;
-        this.path = path;
     }
 
     public String getFile() {

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -2,8 +2,6 @@ package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
 
-import java.util.Iterator;
-
 public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     public static final String DEFAULT_SEPARATOR = ";";
     public static final char DEFAULT_QUOTE = '"';
@@ -46,7 +44,7 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
         StringBuilder sb = new StringBuilder();
         generateHeader(schema, sb, true);
 
-        Iterator<IN> iterator = input.iterator();
+        var iterator = input.iterator();
         boolean hasNext = iterator.hasNext();
         while (hasNext) {
             IN in = iterator.next();

--- a/src/main/java/net/datafaker/transformations/CsvTransformer.java
+++ b/src/main/java/net/datafaker/transformations/CsvTransformer.java
@@ -61,8 +61,8 @@ public class CsvTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     private void addLine(StringBuilder sb, Object transform) {
-        if (transform instanceof CharSequence) {
-            addCharSequence(sb, (CharSequence) transform);
+        if (transform instanceof CharSequence charSequence) {
+            addCharSequence(sb, charSequence);
         } else {
             sb.append(transform);
         }

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -28,10 +28,10 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
     @Override
     public Object apply(Object input, Schema<Object, ?> schema) {
-        Class clazz;
+        Class<?> clazz;
         Object result = null;
-        if (input instanceof Class) {
-            clazz = (Class) input;
+        if (input instanceof Class<?> inputClass) {
+            clazz = inputClass;
         } else {
             clazz = input.getClass();
             result = input;

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -150,7 +150,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
     @Override
     public Collection<Object> generate(Schema<Object, ?> schema, int limit) {
-        return this.generateStream(schema, limit).collect(Collectors.toList());
+        return this.generateStream(schema, limit).toList();
     }
 
     @Override

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -78,7 +78,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
             Consumer<Object> consumer = SCHEMA2CONSUMER.get(schema);
             if (consumer == null) {
                 final Field<Object, ?>[] fields = schema.getFields();
-                final Map<String, java.lang.reflect.Field> name2ClassField = Stream.of(clazz.getDeclaredFields()).collect(
+                var name2ClassField = Stream.of(clazz.getDeclaredFields()).collect(
                     Collectors.toMap(java.lang.reflect.Field::getName, Function.identity()));
                 final java.lang.reflect.Field[] rFields = new java.lang.reflect.Field[fields.length];
                 for (int i = 0; i < fields.length; i++) {

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -4,6 +4,7 @@ import net.datafaker.sequence.FakeSequence;
 
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.RecordComponent;
@@ -77,10 +78,10 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
             Consumer<Object> consumer = SCHEMA2CONSUMER.get(schema);
             if (consumer == null) {
-                final Field<Object, ?>[] fields = schema.getFields();
-                var name2ClassField = Stream.of(clazz.getDeclaredFields()).collect(
-                    Collectors.toMap(java.lang.reflect.Field::getName, Function.identity()));
-                final java.lang.reflect.Field[] rFields = new java.lang.reflect.Field[fields.length];
+                final net.datafaker.transformations.Field<Object, ?>[] fields = schema.getFields();
+                final Map<String, Field> name2ClassField = Stream.of(clazz.getDeclaredFields()).collect(
+                    Collectors.toMap(Field::getName, Function.identity()));
+                final Field[] rFields = new Field[fields.length];
                 for (int i = 0; i < fields.length; i++) {
                     rFields[i] = name2ClassField.get(fields[i].getName());
                     rFields[i].setAccessible(true);
@@ -164,7 +165,7 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
     }
 
     private Object getObject(Schema<Object, ?> schema, Object result, Constructor<?> recordConstructor) {
-        final Field<Object, ?>[] fields = schema.getFields();
+        final net.datafaker.transformations.Field<Object, ?>[] fields = schema.getFields();
         final Object[] values = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             values[i] = fields[i].transform(result);

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -32,8 +32,10 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         for (int i = 0; i < fields.length; i++) {
             value2String((fields[i].getName()), sb);
             sb.append(": ");
-            if (fields[i] instanceof CompositeField) {
-                sb.append(apply(input, (CompositeField) fields[i], i));
+            if (fields[i] instanceof CompositeField compositeField) {
+                sb.append(apply(input, compositeField, i));
+            } else if (fields[i] instanceof SimpleField simpleField) {
+                applyValue(input, sb, simpleField.transform(input));
             } else {
                 applyValue(input, sb, ((SimpleField) fields[i]).transform(input));
             }
@@ -89,8 +91,8 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
     }
 
     private void applyValue(IN input, StringBuilder sb, Object value) {
-        if (value instanceof Collection<?>) {
-            sb.append(generate(input, (Collection) value));
+        if (value instanceof Collection<?> collection) {
+            sb.append(generate(input, (Collection<Object>) collection));
         } else if (value != null && value.getClass().isArray()) {
             sb.append(generate(input, Arrays.asList((Object[]) value)));
         } else {
@@ -107,8 +109,8 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
                 sb.append(", ");
             }
             i++;
-            if (value instanceof CompositeField<?, ?>) {
-                sb.append(apply(input, ((CompositeField) value)));
+            if (value instanceof CompositeField compositeField) {
+                sb.append(apply(input, compositeField));
             } else {
                 applyValue(input, sb, value);
             }

--- a/src/main/java/net/datafaker/transformations/JsonTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JsonTransformer.java
@@ -6,7 +6,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.StringJoiner;
 
@@ -54,7 +53,7 @@ public class JsonTransformer<IN> implements Transformer<IN, CharSequence> {
         }
 
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
-        Iterator<IN> iterator = input.iterator();
+        var iterator = input.iterator();
         while (iterator.hasNext()) {
             data.add(apply(iterator.next(), schema) + (commaBetweenObjects && iterator.hasNext() ? "," : ""));
         }

--- a/src/main/java/net/datafaker/transformations/TomlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/TomlTransformer.java
@@ -2,6 +2,7 @@ package net.datafaker.transformations;
 
 import net.datafaker.sequence.FakeSequence;
 
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -105,14 +106,14 @@ public class TomlTransformer<IN> implements Transformer<IN, String> {
     }
 
     private void handleArray(StringBuilder sb, String key, Object array) {
-        int length = java.lang.reflect.Array.getLength(array);
+        int length = Array.getLength(array);
         if (length == 0) {
             sb.append(key).append(" = []").append(LINE_SEPARATOR);
             return;
         }
         List<Object> list = new ArrayList<>(length);
         for (int i = 0; i < length; i++) {
-            list.add(java.lang.reflect.Array.get(array, i));
+            list.add(Array.get(array, i));
         }
         String joined = list.stream().map(this::value2String).collect(Collectors.joining(", "));
         sb.append(key).append(" = [ ").append(joined).append(" ]").append(LINE_SEPARATOR);

--- a/src/main/java/net/datafaker/transformations/TomlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/TomlTransformer.java
@@ -27,7 +27,7 @@ public class TomlTransformer<IN> implements Transformer<IN, String> {
             throw new IllegalArgumentException("The sequence should be finite of size: " + fs);
         }
         StringJoiner joiner = new StringJoiner(LINE_SEPARATOR);
-        for (IN in : input) {
+        for (var in : input) {
             joiner.add(apply(in, schema));
         }
         return joiner.toString();

--- a/src/main/java/net/datafaker/transformations/XmlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/XmlTransformer.java
@@ -85,8 +85,8 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
 
         final String tag = xmlNode.getName().trim();
         sb.append("<").append(tag);
-        if (xmlNode instanceof CompositeField) {
-            Field<IN, ?>[] attrs = ((CompositeField) xmlNode).getFields();
+        if (xmlNode instanceof CompositeField compositeField) {
+            Field<IN, ?>[] attrs = compositeField.getFields();
             applyAttributes(input, sb, attrs);
 
             xmlNode = Arrays.stream(attrs)
@@ -120,8 +120,8 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
                 sb.append("</").append(tag).append(">");
             }
 
-        } else if (xmlNodeValue instanceof String) {
-            applyValue(sb, tag, (String) xmlNodeValue);
+        } else if (xmlNodeValue instanceof String stringValue) {
+            applyValue(sb, tag, stringValue);
         } else if (xmlNodeValue == null) {
             applyValue(sb, tag, null);
         }

--- a/src/main/java/net/datafaker/transformations/XmlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/XmlTransformer.java
@@ -34,7 +34,7 @@ public class XmlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
 
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
-        for (IN in : input) {
+        for (var in : input) {
             data.add(apply(in, schema));
         }
 

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -30,7 +30,7 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
 
         StringJoiner data = new StringJoiner(LINE_SEPARATOR);
-        for (IN in : input) {
+        for (var in : input) {
             data.add(apply(in, schema));
         }
 

--- a/src/main/java/net/datafaker/transformations/YamlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/YamlTransformer.java
@@ -89,13 +89,13 @@ public class YamlTransformer<IN> implements Transformer<IN, CharSequence> {
         }
     }
     private void value2String(Object value, StringBuilder sb, String offset) {
-        if (value instanceof Schema) {
-            Field<IN, ?>[] fields = ((Schema<IN, ?>) value).getFields();
+        if (value instanceof Schema schemaValue) {
+            Field<IN, ?>[] fields = schemaValue.getFields();
             apply(sb, null, fields, offset);
-        } else if (value instanceof Collection) {
+        } else if (value instanceof Collection<?> collection) {
             sb.append(System.lineSeparator());
             offset += INDENTATION;
-            addCollection(sb, (Collection) value, offset);
+            addCollection(sb, (Collection<Object>) collection, offset);
         } else if (value != null && value.getClass().isArray()) {
             sb.append(System.lineSeparator());
             offset += INDENTATION;

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -118,9 +118,9 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
                 }
             }
 
-            if (fields[i] instanceof SimpleField) {
+            if (fields[i] instanceof SimpleField<?, ?> simpleField) {
                 //noinspection unchecked
-                Object value = ((SimpleField<Object, ?>) fields[i]).transform(input);
+                Object value = ((SimpleField<Object, ?>) simpleField).transform(input);
                 Class<?> clazz = value == null ? null : value.getClass();
                 if (value == null
                     || value instanceof Number

--- a/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
+++ b/src/main/java/net/datafaker/transformations/sql/SqlTransformer.java
@@ -181,7 +181,7 @@ public class SqlTransformer<IN> implements Transformer<IN, CharSequence> {
     private String handleObjectInMap(Map<?, ?> map) {
         StringBuilder result = new StringBuilder();
         int i = 0;
-        for (Map.Entry<?, ?> entry : map.entrySet()) {
+        for (var entry : map.entrySet()) {
             result.append(handleObject(entry.getKey()));
             result.append(", ");
             result.append(handleObject(entry.getValue()));

--- a/src/test/java/net/datafaker/FakerTest.java
+++ b/src/test/java/net/datafaker/FakerTest.java
@@ -372,7 +372,7 @@ class FakerTest {
                      IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
-            for (Method m : methods) {
+            for (var m : methods) {
                 final var set = new HashSet<>();
                 try {
                     int currentSize = 0;

--- a/src/test/java/net/datafaker/NoDuplicatesInYmlTest.java
+++ b/src/test/java/net/datafaker/NoDuplicatesInYmlTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -24,7 +23,7 @@ public class NoDuplicatesInYmlTest {
     @ParameterizedTest
     @MethodSource("ymlFiles")
     void noDuplicatesInArrays(Path file) {
-        try (InputStream in = newInputStream(file)) {
+        try (var in = newInputStream(file)) {
             Object ymlContent = new Yaml().load(in);
             var errors = findDuplicates(ymlContent);
             assertThat(errors)
@@ -64,7 +63,7 @@ public class NoDuplicatesInYmlTest {
             }
         } else if (node instanceof List<?> list) {
             Set<Object> seen = new HashSet<>();
-            for (Object value : list) {
+            for (var value : list) {
                 if (!seen.add(value) && !areDuplicatesAllowed(path)) {
                     errors.computeIfAbsent(path, k -> new HashSet<>()).add(value);
                 }

--- a/src/test/java/net/datafaker/TestStrings.java
+++ b/src/test/java/net/datafaker/TestStrings.java
@@ -9,11 +9,4 @@ public final class TestStrings {
     public static String lines(String textBlock) {
         return textBlock.replace("\n", System.lineSeparator());
     }
-
-    /** Like {@link #lines(String)}, but strips one trailing platform line separator. */
-    public static String linesTrimTrailing(String textBlock) {
-        String result = lines(textBlock);
-        String sep = System.lineSeparator();
-        return result.endsWith(sep) ? result.substring(0, result.length() - sep.length()) : result;
-    }
 }

--- a/src/test/java/net/datafaker/TestStrings.java
+++ b/src/test/java/net/datafaker/TestStrings.java
@@ -1,0 +1,19 @@
+package net.datafaker;
+
+public final class TestStrings {
+
+    private TestStrings() {
+    }
+
+    /** Maps text-block newlines to the platform line separator used by transformers. */
+    public static String lines(String textBlock) {
+        return textBlock.replace("\n", System.lineSeparator());
+    }
+
+    /** Like {@link #lines(String)}, but strips one trailing platform line separator. */
+    public static String linesTrimTrailing(String textBlock) {
+        String result = lines(textBlock);
+        String sep = System.lineSeparator();
+        return result.endsWith(sep) ? result.substring(0, result.length() - sep.length()) : result;
+    }
+}

--- a/src/test/java/net/datafaker/ThreadLocalLogHandler.java
+++ b/src/test/java/net/datafaker/ThreadLocalLogHandler.java
@@ -42,7 +42,7 @@ public class ThreadLocalLogHandler extends Handler {
             List<LogRecord> threadLogs = logs.get();
             if (!threadLogs.isEmpty()) {
                 consoleHandler.publish(summaryLog(threadLogs));
-                for (LogRecord log : threadLogs) {
+                for (var log : threadLogs) {
                     consoleHandler.publish(log);
                 }
             }

--- a/src/test/java/net/datafaker/assertions/ImageAssert.java
+++ b/src/test/java/net/datafaker/assertions/ImageAssert.java
@@ -13,7 +13,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Base64;
 import java.util.regex.Pattern;
 
@@ -54,7 +53,7 @@ public class ImageAssert extends AbstractAssert<ImageAssert, ImageData> {
     private ImageAssert verifyImage(ImageData image, int width, int height) {
         String content = RE.matcher(image.url()).replaceFirst("$1");
         byte[] bytes = Base64.getDecoder().decode(content);
-        try (InputStream in = new ByteArrayInputStream(bytes)) {
+        try (var in = new ByteArrayInputStream(bytes)) {
             BufferedImage i = ImageIO.read(in);
             assertThat(i.getWidth()).isEqualTo(width);
             assertThat(i.getHeight()).isEqualTo(height);

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Random;
 
-import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.field;
 import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,10 +84,9 @@ class CsvTest {
 
         String csv = transformer.generate(schema, 1);
 
-        String expected = linesTrimTrailing("""
-            "values","title"
-            "1,2,3","The ""fabulous"" artist"
-            """);
+        String expected =
+            "\"values\",\"title\"" + LINE_SEPARATOR
+                + "\"1,2,3\",\"The \"\"fabulous\"\" artist\"";
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -107,13 +105,12 @@ class CsvTest {
 
         String csv = transformer.generate(schema, 4);
 
-        String expected = linesTrimTrailing("""
-            "Number","Bool","String","Text"
-            3,false,"Flor","The, ""fabulous"" artist'"
-            6,true,"Stephnie","The, ""fabulous"" artist'"
-            1,false,"Edythe","The, ""fabulous"" artist'"
-            1,true,"Dwight","The, ""fabulous"" artist'"
-            """);
+        String expected =
+            "\"Number\",\"Bool\",\"String\",\"Text\"" + LINE_SEPARATOR
+                + "3,false,\"Flor\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
+                + "6,true,\"Stephnie\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
+                + "1,false,\"Edythe\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
+                + "1,true,\"Dwight\",\"The, \"\"fabulous\"\" artist'\"";
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -135,14 +132,13 @@ class CsvTest {
             .build();
         String csv = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
-            "Number","Password"
-            3,"nf3"
-            6,"4b0v69"
-            7,"00827v2"
-            1,"5"
-            3,"p6x"
-            """);
+        String expected =
+            "\"Number\",\"Password\"" + LINE_SEPARATOR
+                + "3,\"nf3\"" + LINE_SEPARATOR
+                + "6,\"4b0v69\"" + LINE_SEPARATOR
+                + "7,\"00827v2\"" + LINE_SEPARATOR
+                + "1,\"5\"" + LINE_SEPARATOR
+                + "3,\"p6x\"";
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -165,12 +161,11 @@ class CsvTest {
 
         String csv = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
-            "Number","Password"
-            3,"0p4"
-            8,"714487nf"
-            5,"0v691"
-            """);
+        String expected =
+            "\"Number\",\"Password\"" + LINE_SEPARATOR
+                + "3,\"0p4\"" + LINE_SEPARATOR
+                + "8,\"714487nf\"" + LINE_SEPARATOR
+                + "5,\"0v691\"";
 
         assertThat(csv).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Random;
 
+import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.field;
 import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,9 +85,10 @@ class CsvTest {
 
         String csv = transformer.generate(schema, 1);
 
-        String expected =
-            "\"values\",\"title\"" + LINE_SEPARATOR
-                + "\"1,2,3\",\"The \"\"fabulous\"\" artist\"";
+        String expected = linesTrimTrailing("""
+            "values","title"
+            "1,2,3","The ""fabulous"" artist"
+            """);
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -105,12 +107,13 @@ class CsvTest {
 
         String csv = transformer.generate(schema, 4);
 
-        String expected =
-            "\"Number\",\"Bool\",\"String\",\"Text\"" + LINE_SEPARATOR
-                + "3,false,\"Flor\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
-                + "6,true,\"Stephnie\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
-                + "1,false,\"Edythe\",\"The, \"\"fabulous\"\" artist'\"" + LINE_SEPARATOR
-                + "1,true,\"Dwight\",\"The, \"\"fabulous\"\" artist'\"";
+        String expected = linesTrimTrailing("""
+            "Number","Bool","String","Text"
+            3,false,"Flor","The, ""fabulous"" artist'"
+            6,true,"Stephnie","The, ""fabulous"" artist'"
+            1,false,"Edythe","The, ""fabulous"" artist'"
+            1,true,"Dwight","The, ""fabulous"" artist'"
+            """);
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -132,13 +135,14 @@ class CsvTest {
             .build();
         String csv = transformer.generate(fakeSequence, schema);
 
-        String expected =
-            "\"Number\",\"Password\"" + LINE_SEPARATOR
-                + "3,\"nf3\"" + LINE_SEPARATOR
-                + "6,\"4b0v69\"" + LINE_SEPARATOR
-                + "7,\"00827v2\"" + LINE_SEPARATOR
-                + "1,\"5\"" + LINE_SEPARATOR
-                + "3,\"p6x\"";
+        String expected = linesTrimTrailing("""
+            "Number","Password"
+            3,"nf3"
+            6,"4b0v69"
+            7,"00827v2"
+            1,"5"
+            3,"p6x"
+            """);
 
         assertThat(csv).isEqualTo(expected);
     }
@@ -161,11 +165,12 @@ class CsvTest {
 
         String csv = transformer.generate(fakeSequence, schema);
 
-        String expected =
-            "\"Number\",\"Password\"" + LINE_SEPARATOR
-                + "3,\"0p4\"" + LINE_SEPARATOR
-                + "8,\"714487nf\"" + LINE_SEPARATOR
-                + "5,\"0v691\"";
+        String expected = linesTrimTrailing("""
+            "Number","Password"
+            3,"0p4"
+            8,"714487nf"
+            5,"0v691"
+            """);
 
         assertThat(csv).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/formats/CsvTest.java
+++ b/src/test/java/net/datafaker/formats/CsvTest.java
@@ -116,12 +116,11 @@ class CsvTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     void testCsvWithDifferentObjectsFunction() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
             field("Number", integer -> integer),
-            field("Password", integer -> faker.internet().password(integer, integer))
+            field("Password", integer -> faker.credentials().password(integer, integer))
         );
         CsvTransformer<Integer> transformer =
             CsvTransformer.<Integer>builder().header(true).separator(",").build();
@@ -144,12 +143,11 @@ class CsvTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     void testCsvWithDifferentObjectsFunctionStream() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
             field("Number", integer -> integer),
-            field("Password", integer -> faker.internet().password(integer, integer))
+            field("Password", integer -> faker.credentials().password(integer, integer))
         );
         CsvTransformer<Integer> transformer =
             CsvTransformer.<Integer>builder().header(true).separator(",").build();

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -324,7 +324,7 @@ class JsonTest {
     private static Map<Supplier<String>, Supplier<Object>> map(
         Map.Entry<Supplier<String>, Supplier<Object>>... entries) {
         Map<Supplier<String>, Supplier<Object>> map = new LinkedHashMap<>();
-        for (Map.Entry<Supplier<String>, Supplier<Object>> entry : entries) {
+        for (var entry : entries) {
             map.put(entry.getKey(), entry.getValue());
         }
         return map;

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -76,12 +76,11 @@ class JsonTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     void testGenerateFromFakeSequenceCollectionWithoutComma() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
             field("Number", integer -> integer),
-            field("Password", integer -> faker.internet().password(integer, integer))
+            field("Password", integer -> faker.credentials().password(integer, integer))
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().withCommaBetweenObjects(false).build();
@@ -105,12 +104,11 @@ class JsonTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     void testGenerateFromFakeSequenceCollection() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
             field("Number", integer -> integer),
-            field("Password", integer -> faker.internet().password(integer, integer))
+            field("Password", integer -> faker.credentials().password(integer, integer))
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();
@@ -134,12 +132,11 @@ class JsonTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     void testGenerateFromFakeSequenceStream() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
             field("Number", integer -> integer),
-            field("Password", integer -> faker.internet().password(integer, integer))
+            field("Password", integer -> faker.credentials().password(integer, integer))
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().withCommaBetweenObjects(false).build();
@@ -160,12 +157,11 @@ class JsonTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     void testGenerateFromInfiniteFakeSequence() {
         BaseFaker faker = new BaseFaker(new Random(10L));
         Schema<Integer, ?> schema = Schema.of(
             field("Number", integer -> integer),
-            field("Password", integer -> faker.internet().password(integer, integer))
+            field("Password", integer -> faker.credentials().password(integer, integer))
         );
 
         JsonTransformer<Integer> transformer = JsonTransformer.<Integer>builder().build();

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static net.datafaker.TestStrings.linesTrimTrailing;
+import static net.datafaker.TestStrings.lines;
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
 import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
@@ -41,7 +41,7 @@ class JsonTest {
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         Stream<CharSequence> json = transformer.generateStream(schema, 10);
         String output = json.collect(Collectors.joining(LINE_SEPARATOR));
-        assertThat(output).isEqualTo(linesTrimTrailing("""
+        assertThat(output).isEqualTo(lines("""
             [
             {"Text": "Willis", "Bool": false},
             {"Text": "Carlena", "Bool": true},
@@ -53,8 +53,7 @@ class JsonTest {
             {"Text": "Alphonse", "Bool": false},
             {"Text": "Louisa", "Bool": true},
             {"Text": "Caryn", "Bool": false}
-            ]
-            """));
+            ]"""));
     }
 
     @Test
@@ -67,12 +66,11 @@ class JsonTest {
 
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         String json = transformer.generate(schema, 2);
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             [
             {"Text": "Willis", "Bool": false},
             {"Text": "Carlena", "Bool": true}
-            ]
-            """);
+            ]""");
 
         assertThat(json).isEqualTo(expected);
     }
@@ -94,15 +92,14 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             [
             {"Number": 3, "Password": "nf3"}
             {"Number": 6, "Password": "4b0v69"}
             {"Number": 7, "Password": "00827v2"}
             {"Number": 1, "Password": "5"}
             {"Number": 3, "Password": "p6x"}
-            ]
-            """);
+            ]""");
 
         assertThat(json).isEqualTo(expected);
     }
@@ -124,15 +121,14 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             [
             {"Number": 3, "Password": "nf3"},
             {"Number": 6, "Password": "4b0v69"},
             {"Number": 7, "Password": "00827v2"},
             {"Number": 1, "Password": "5"},
             {"Number": 3, "Password": "p6x"}
-            ]
-            """);
+            ]""");
 
         assertThat(json).isEqualTo(expected);
     }
@@ -154,12 +150,11 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             [
             {"Number": 3, "Password": "0p4"}
             {"Number": 8, "Password": "714487nf"}
-            ]
-            """);
+            ]""");
 
         assertThat(json).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/formats/JsonTest.java
+++ b/src/test/java/net/datafaker/formats/JsonTest.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
 import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
@@ -40,18 +41,20 @@ class JsonTest {
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         Stream<CharSequence> json = transformer.generateStream(schema, 10);
         String output = json.collect(Collectors.joining(LINE_SEPARATOR));
-        assertThat(output).isEqualTo("[" + LINE_SEPARATOR +
-            "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
-            "{\"Text\": \"Carlena\", \"Bool\": true}," + LINE_SEPARATOR +
-            "{\"Text\": \"Stephnie\", \"Bool\": true}," + LINE_SEPARATOR +
-            "{\"Text\": \"Rutha\", \"Bool\": true}," + LINE_SEPARATOR +
-            "{\"Text\": \"Armand\", \"Bool\": true}," + LINE_SEPARATOR +
-            "{\"Text\": \"Margot\", \"Bool\": false}," + LINE_SEPARATOR +
-            "{\"Text\": \"Patrick\", \"Bool\": false}," + LINE_SEPARATOR +
-            "{\"Text\": \"Alphonse\", \"Bool\": false}," + LINE_SEPARATOR +
-            "{\"Text\": \"Louisa\", \"Bool\": true}," + LINE_SEPARATOR +
-            "{\"Text\": \"Caryn\", \"Bool\": false}" + LINE_SEPARATOR +
-            "]");
+        assertThat(output).isEqualTo(linesTrimTrailing("""
+            [
+            {"Text": "Willis", "Bool": false},
+            {"Text": "Carlena", "Bool": true},
+            {"Text": "Stephnie", "Bool": true},
+            {"Text": "Rutha", "Bool": true},
+            {"Text": "Armand", "Bool": true},
+            {"Text": "Margot", "Bool": false},
+            {"Text": "Patrick", "Bool": false},
+            {"Text": "Alphonse", "Bool": false},
+            {"Text": "Louisa", "Bool": true},
+            {"Text": "Caryn", "Bool": false}
+            ]
+            """));
     }
 
     @Test
@@ -64,10 +67,12 @@ class JsonTest {
 
         JsonTransformer<Object> transformer = JsonTransformer.builder().build();
         String json = transformer.generate(schema, 2);
-        String expected = "[" + LINE_SEPARATOR +
-            "{\"Text\": \"Willis\", \"Bool\": false}," + LINE_SEPARATOR +
-            "{\"Text\": \"Carlena\", \"Bool\": true}" + LINE_SEPARATOR +
-            "]";
+        String expected = linesTrimTrailing("""
+            [
+            {"Text": "Willis", "Bool": false},
+            {"Text": "Carlena", "Bool": true}
+            ]
+            """);
 
         assertThat(json).isEqualTo(expected);
     }
@@ -89,13 +94,15 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "[" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"nf3\"}" + LINE_SEPARATOR +
-            "{\"Number\": 6, \"Password\": \"4b0v69\"}" + LINE_SEPARATOR +
-            "{\"Number\": 7, \"Password\": \"00827v2\"}" + LINE_SEPARATOR +
-            "{\"Number\": 1, \"Password\": \"5\"}" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"p6x\"}" + LINE_SEPARATOR +
-            "]";
+        String expected = linesTrimTrailing("""
+            [
+            {"Number": 3, "Password": "nf3"}
+            {"Number": 6, "Password": "4b0v69"}
+            {"Number": 7, "Password": "00827v2"}
+            {"Number": 1, "Password": "5"}
+            {"Number": 3, "Password": "p6x"}
+            ]
+            """);
 
         assertThat(json).isEqualTo(expected);
     }
@@ -117,13 +124,15 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "[" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"nf3\"}," + LINE_SEPARATOR +
-            "{\"Number\": 6, \"Password\": \"4b0v69\"}," + LINE_SEPARATOR +
-            "{\"Number\": 7, \"Password\": \"00827v2\"}," + LINE_SEPARATOR +
-            "{\"Number\": 1, \"Password\": \"5\"}," + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"p6x\"}" + LINE_SEPARATOR +
-            "]";
+        String expected = linesTrimTrailing("""
+            [
+            {"Number": 3, "Password": "nf3"},
+            {"Number": 6, "Password": "4b0v69"},
+            {"Number": 7, "Password": "00827v2"},
+            {"Number": 1, "Password": "5"},
+            {"Number": 3, "Password": "p6x"}
+            ]
+            """);
 
         assertThat(json).isEqualTo(expected);
     }
@@ -145,10 +154,12 @@ class JsonTest {
 
         String json = transformer.generate(fakeSequence, schema);
 
-        String expected = "[" + LINE_SEPARATOR +
-            "{\"Number\": 3, \"Password\": \"0p4\"}" + LINE_SEPARATOR +
-            "{\"Number\": 8, \"Password\": \"714487nf\"}" + LINE_SEPARATOR +
-            "]";
+        String expected = linesTrimTrailing("""
+            [
+            {"Number": 3, "Password": "0p4"}
+            {"Number": 8, "Password": "714487nf"}
+            ]
+            """);
 
         assertThat(json).isEqualTo(expected);
     }
@@ -282,8 +293,8 @@ class JsonTest {
                     )
                 )
             ), 1);
-        assertThat(json).isEqualTo("{\"text\": \"Mrs. Brian Braun\", " +
-            "\"objectCollection\": [{\"country\": \"Denmark\", \"city\": \"Port Angel\"}, {\"two\": \"Denmark\", \"one\": \"Port Angel\"}]}");
+        assertThat(json).isEqualTo("""
+            {"text": "Mrs. Brian Braun", "objectCollection": [{"country": "Denmark", "city": "Port Angel"}, {"two": "Denmark", "one": "Port Angel"}]}""");
     }
 
     @Test
@@ -311,8 +322,8 @@ class JsonTest {
                     )
                 )
             ), 1);
-        assertThat(json).isEqualTo("{\"text\": \"Mrs. Brian Braun\", " +
-            "\"objectCollection\": [[[{\"country\": \"Denmark\", \"city\": \"Port Angel\"}, {\"two\": \"Denmark\", \"one\": \"Port Angel\"}]]]}");
+        assertThat(json).isEqualTo("""
+            {"text": "Mrs. Brian Braun", "objectCollection": [[[{"country": "Denmark", "city": "Port Angel"}, {"two": "Denmark", "one": "Port Angel"}]]]}""");
     }
 
     private static Map.Entry<Supplier<String>, Supplier<Object>> entry(

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static net.datafaker.TestStrings.linesTrimTrailing;
+import static net.datafaker.TestStrings.lines;
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
 import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
@@ -48,13 +48,12 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MyTable" ("Number", "Password") VALUES (3, 'nf3');
             INSERT INTO "MyTable" ("Number", "Password") VALUES (6, '4b0v69');
             INSERT INTO "MyTable" ("Number", "Password") VALUES (7, '00827v2');
             INSERT INTO "MyTable" ("Number", "Password") VALUES (1, '5');
-            INSERT INTO "MyTable" ("Number", "Password") VALUES (3, 'p6x');
-            """);
+            INSERT INTO "MyTable" ("Number", "Password") VALUES (3, 'p6x');""");
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -77,14 +76,13 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MyTable" ("Number", "Password")
             VALUES (3, 'nf3'),
                    (6, '4b0v69'),
                    (7, '00827v2'),
                    (1, '5'),
-                   (3, 'p6x');
-            """);
+                   (3, 'p6x');""");
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -135,10 +133,9 @@ class SqlTest {
         SqlTransformer<Object> transformer = SqlTransformer.builder().build();
         String sql = transformer.generate(schema, 2);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Willis', false);
-            INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Carlena', true);
-            """);
+            INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Carlena', true);""");
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -156,11 +153,10 @@ class SqlTest {
             .build();
         String sql = transformer.generate(schema, 2);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MyTable" ("Text", "Bool")
             VALUES ('Willis', false),
-                   ('Carlena', true);
-            """);
+                   ('Carlena', true);""");
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -179,11 +175,10 @@ class SqlTest {
             .build();
         String sql = forceQuotedTransformer.generate(schema, 2);
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MY_TABLE" ("TEXT", "BOOL")
             VALUES ('Willis', false),
-                   ('Carlena', true);
-            """);
+                   ('Carlena', true);""");
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -568,14 +563,13 @@ class SqlTest {
                 .generateStream(schema, 4)
                 .collect(Collectors.joining(LINE_SEPARATOR));
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MyTable" ("Number", "Password")
             VALUES ('6', '09fd4007-40ba-39df-8cb1-65926bf7b8a9'),
                    ('8', '96c19757-1f18-3051-9acb-f56f0b5555ae'),
                    ('2', '8a4a0365-cd39-33c1-a52a-279b1076cf2d');
             INSERT INTO "MyTable" ("Number", "Password")
-            VALUES ('6', 'e807efdd-b6db-319d-8342-a044274d3417');
-            """);
+            VALUES ('6', 'e807efdd-b6db-319d-8342-a044274d3417');""");
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -596,12 +590,11 @@ class SqlTest {
 
         String sql = transformer.generateStream(schema,3).collect(Collectors.joining(LINE_SEPARATOR));
 
-        String expected = linesTrimTrailing("""
+        String expected = lines("""
             INSERT INTO "MyTable" ("Address", "Book")
             VALUES ('Cote d\\'Ivoire', 'All the King\\'s Men'),
                    ('Cote d\\'Ivoire', 'Blood\\'s a Rover'),
-                   ('Cote d\\'Ivoire', 'Blood\\'s a Rover');
-            """);
+                   ('Cote d\\'Ivoire', 'Blood\\'s a Rover');""");
 
         assertThat(sql).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/formats/SqlTest.java
+++ b/src/test/java/net/datafaker/formats/SqlTest.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
 import static net.datafaker.transformations.Transformer.LINE_SEPARATOR;
@@ -47,11 +48,13 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected = "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'nf3');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (6, '4b0v69');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (7, '00827v2');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (1, '5');" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\") VALUES (3, 'p6x');";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MyTable" ("Number", "Password") VALUES (3, 'nf3');
+            INSERT INTO "MyTable" ("Number", "Password") VALUES (6, '4b0v69');
+            INSERT INTO "MyTable" ("Number", "Password") VALUES (7, '00827v2');
+            INSERT INTO "MyTable" ("Number", "Password") VALUES (1, '5');
+            INSERT INTO "MyTable" ("Number", "Password") VALUES (3, 'p6x');
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -74,13 +77,14 @@ class SqlTest {
 
         String sql = transformer.generate(fakeSequence, schema);
 
-        String expected =
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
-                "VALUES (3, 'nf3')," + LINE_SEPARATOR +
-                "       (6, '4b0v69')," + LINE_SEPARATOR +
-                "       (7, '00827v2')," + LINE_SEPARATOR +
-                "       (1, '5')," + LINE_SEPARATOR +
-                "       (3, 'p6x');";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MyTable" ("Number", "Password")
+            VALUES (3, 'nf3'),
+                   (6, '4b0v69'),
+                   (7, '00827v2'),
+                   (1, '5'),
+                   (3, 'p6x');
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -131,9 +135,10 @@ class SqlTest {
         SqlTransformer<Object> transformer = SqlTransformer.builder().build();
         String sql = transformer.generate(schema, 2);
 
-        String expected =
-            "INSERT INTO \"MyTable\" (\"Text\", \"Bool\") VALUES ('Willis', false);" + LINE_SEPARATOR +
-            "INSERT INTO \"MyTable\" (\"Text\", \"Bool\") VALUES ('Carlena', true);";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Willis', false);
+            INSERT INTO "MyTable" ("Text", "Bool") VALUES ('Carlena', true);
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -151,10 +156,11 @@ class SqlTest {
             .build();
         String sql = transformer.generate(schema, 2);
 
-        String expected =
-            "INSERT INTO \"MyTable\" (\"Text\", \"Bool\")" + LINE_SEPARATOR +
-            "VALUES ('Willis', false)," + LINE_SEPARATOR +
-            "       ('Carlena', true);";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MyTable" ("Text", "Bool")
+            VALUES ('Willis', false),
+                   ('Carlena', true);
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -173,9 +179,11 @@ class SqlTest {
             .build();
         String sql = forceQuotedTransformer.generate(schema, 2);
 
-        String expected = "INSERT INTO \"MY_TABLE\" (\"TEXT\", \"BOOL\")" + LINE_SEPARATOR +
-            "VALUES ('Willis', false)," + LINE_SEPARATOR +
-            "       ('Carlena', true);";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MY_TABLE" ("TEXT", "BOOL")
+            VALUES ('Willis', false),
+                   ('Carlena', true);
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -560,13 +568,14 @@ class SqlTest {
                 .generateStream(schema, 4)
                 .collect(Collectors.joining(LINE_SEPARATOR));
 
-        String expected =
-            "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
-                "VALUES ('6', '09fd4007-40ba-39df-8cb1-65926bf7b8a9')," + LINE_SEPARATOR +
-                "       ('8', '96c19757-1f18-3051-9acb-f56f0b5555ae')," + LINE_SEPARATOR +
-                "       ('2', '8a4a0365-cd39-33c1-a52a-279b1076cf2d');" + LINE_SEPARATOR +
-                "INSERT INTO \"MyTable\" (\"Number\", \"Password\")" + LINE_SEPARATOR +
-                "VALUES ('6', 'e807efdd-b6db-319d-8342-a044274d3417');";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MyTable" ("Number", "Password")
+            VALUES ('6', '09fd4007-40ba-39df-8cb1-65926bf7b8a9'),
+                   ('8', '96c19757-1f18-3051-9acb-f56f0b5555ae'),
+                   ('2', '8a4a0365-cd39-33c1-a52a-279b1076cf2d');
+            INSERT INTO "MyTable" ("Number", "Password")
+            VALUES ('6', 'e807efdd-b6db-319d-8342-a044274d3417');
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }
@@ -587,10 +596,12 @@ class SqlTest {
 
         String sql = transformer.generateStream(schema,3).collect(Collectors.joining(LINE_SEPARATOR));
 
-        String expected = "INSERT INTO \"MyTable\" (\"Address\", \"Book\")" + LINE_SEPARATOR +
-            "VALUES ('Cote d\\'Ivoire', 'All the King\\'s Men')," + LINE_SEPARATOR +
-            "       ('Cote d\\'Ivoire', 'Blood\\'s a Rover')," + LINE_SEPARATOR +
-            "       ('Cote d\\'Ivoire', 'Blood\\'s a Rover');";
+        String expected = linesTrimTrailing("""
+            INSERT INTO "MyTable" ("Address", "Book")
+            VALUES ('Cote d\\'Ivoire', 'All the King\\'s Men'),
+                   ('Cote d\\'Ivoire', 'Blood\\'s a Rover'),
+                   ('Cote d\\'Ivoire', 'Blood\\'s a Rover');
+            """);
 
         assertThat(sql).isEqualTo(expected);
     }

--- a/src/test/java/net/datafaker/formats/TomlTest.java
+++ b/src/test/java/net/datafaker/formats/TomlTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -30,6 +29,7 @@ class TomlTest {
     }
 
     private static Stream<Arguments> generateTestSchema() {
+        String sep = System.lineSeparator();
         return Stream.of(
             of(Schema.of(), ""),
             of(Schema.of(field("key", () -> "value")), "key = \"value\""),
@@ -49,11 +49,9 @@ class TomlTest {
             of(Schema.of(
                 field("key", () -> "value"),
                 field("nested", () -> Schema.of(field("nestedkey", () -> "nestedvalue")))
-            ), linesTrimTrailing("""
-                key = "value"
-                [nested]
-                nestedkey = "nestedvalue"
-                """)),
+            ), "key = \"value\"" + sep +
+                "[nested]" + sep +
+                "nestedkey = \"nestedvalue\""),
             of(Schema.of(
                 field("key", () -> "value"),
                 field("nested", () -> Schema.of(
@@ -62,32 +60,26 @@ class TomlTest {
                         field("nestedkey2", () -> "nestedvalue2")
                     ))
                 ))
-            ), linesTrimTrailing("""
-                key = "value"
-                [nested]
-                nestedkey = "nestedvalue"
-                [nested.nested2]
-                nestedkey2 = "nestedvalue2"
-                """)),
+            ), "key = \"value\"" + sep +
+                "[nested]" + sep +
+                "nestedkey = \"nestedvalue\"" + sep +
+                "[nested.nested2]" + sep +
+                "nestedkey2 = \"nestedvalue2\""),
             of(Schema.of(
                 field("parent", () -> Schema.of(
                     field("numbers", () -> new Integer[]{1, 2})
                 ))
-            ), linesTrimTrailing("""
-                [parent]
-                numbers = [ 1, 2 ]
-                """)),
+            ), "[parent]" + sep +
+                "numbers = [ 1, 2 ]"),
             of(Schema.of(
                 field("items", () -> List.of(
                     Schema.of(field("id", () -> 1)),
                     Schema.of(field("id", () -> 2))
                 ))
-            ), linesTrimTrailing("""
-                [[items]]
-                id = 1
-                [[items]]
-                id = 2
-                """))
+            ), "[[items]]" + sep +
+                "id = 1" + sep +
+                "[[items]]" + sep +
+                "id = 2")
         );
     }
 

--- a/src/test/java/net/datafaker/formats/TomlTest.java
+++ b/src/test/java/net/datafaker/formats/TomlTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -112,7 +111,7 @@ class TomlTest {
         final BaseFaker faker = new BaseFaker();
         Schema<Name, List<String>> schema = Schema.of(field("firstNames", name -> IntStream.rangeClosed(1, limit)
             .mapToObj(it -> name.firstName())
-            .collect(Collectors.toList())));
+            .toList()));
 
         TomlTransformer<Name> transformer = new TomlTransformer<>();
 

--- a/src/test/java/net/datafaker/formats/TomlTest.java
+++ b/src/test/java/net/datafaker/formats/TomlTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -29,7 +30,6 @@ class TomlTest {
     }
 
     private static Stream<Arguments> generateTestSchema() {
-        String sep = System.lineSeparator();
         return Stream.of(
             of(Schema.of(), ""),
             of(Schema.of(field("key", () -> "value")), "key = \"value\""),
@@ -49,9 +49,11 @@ class TomlTest {
             of(Schema.of(
                 field("key", () -> "value"),
                 field("nested", () -> Schema.of(field("nestedkey", () -> "nestedvalue")))
-            ), "key = \"value\"" + sep +
-                "[nested]" + sep +
-                "nestedkey = \"nestedvalue\""),
+            ), linesTrimTrailing("""
+                key = "value"
+                [nested]
+                nestedkey = "nestedvalue"
+                """)),
             of(Schema.of(
                 field("key", () -> "value"),
                 field("nested", () -> Schema.of(
@@ -60,26 +62,32 @@ class TomlTest {
                         field("nestedkey2", () -> "nestedvalue2")
                     ))
                 ))
-            ), "key = \"value\"" + sep +
-                "[nested]" + sep +
-                "nestedkey = \"nestedvalue\"" + sep +
-                "[nested.nested2]" + sep +
-                "nestedkey2 = \"nestedvalue2\""),
+            ), linesTrimTrailing("""
+                key = "value"
+                [nested]
+                nestedkey = "nestedvalue"
+                [nested.nested2]
+                nestedkey2 = "nestedvalue2"
+                """)),
             of(Schema.of(
                 field("parent", () -> Schema.of(
                     field("numbers", () -> new Integer[]{1, 2})
                 ))
-            ), "[parent]" + sep +
-                "numbers = [ 1, 2 ]"),
+            ), linesTrimTrailing("""
+                [parent]
+                numbers = [ 1, 2 ]
+                """)),
             of(Schema.of(
                 field("items", () -> List.of(
                     Schema.of(field("id", () -> 1)),
                     Schema.of(field("id", () -> 2))
                 ))
-            ), "[[items]]" + sep +
-                "id = 1" + sep +
-                "[[items]]" + sep +
-                "id = 2")
+            ), linesTrimTrailing("""
+                [[items]]
+                id = 1
+                [[items]]
+                id = 2
+                """))
         );
     }
 

--- a/src/test/java/net/datafaker/formats/XmlTest.java
+++ b/src/test/java/net/datafaker/formats/XmlTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
@@ -120,12 +119,12 @@ class XmlTest {
                         () -> List.of(
                             field("firstname", () -> faker.name().firstName()),
                             field("lastname", () -> faker.name().lastName()),
-                            field("addresses", () -> address.get().collect(Collectors.toList())))))
+                            field("addresses", () -> address.get().toList()))))
                 .maxLen(3).build();
 
 
         XmlTransformer<Object> xmlTransformer = new XmlTransformer.XmlTransformerBuilder<>().pretty(true).build();
-        String xml = xmlTransformer.generate(Schema.of(field("persons", () -> persons.get().collect(Collectors.toList()))), 1).toString();
+        String xml = xmlTransformer.generate(Schema.of(field("persons", () -> persons.get().toList())), 1).toString();
         assertThat(xml).isNotEmpty();
         int numberOfLines = getNumberOfLines(xml);
         assertThat(numberOfLines).isEqualTo(65);
@@ -151,11 +150,11 @@ class XmlTest {
                         new Field[]{
                             field("firstname", () -> faker.name().firstName()),
                             field("lastname", () -> faker.name().lastName()),
-                            field(null, () -> List.of(field("addresses", () -> address.get().collect(Collectors.toList()))))}))
+                            field(null, () -> List.of(field("addresses", () -> address.get().toList())))}))
                 .maxLen(3).build();
 
         XmlTransformer<Object> xmlTransformer = new XmlTransformer.XmlTransformerBuilder<>().pretty(true).build();
-        String xml = xmlTransformer.generate(Schema.of(field("persons", () -> persons.get().collect(Collectors.toList()))), 1).toString();
+        String xml = xmlTransformer.generate(Schema.of(field("persons", () -> persons.get().toList())), 1).toString();
         assertThat(xml).isNotEmpty();
         int numberOfLines = getNumberOfLines(xml);
         assertThat(numberOfLines).isEqualTo(23);

--- a/src/test/java/net/datafaker/formats/XmlTest.java
+++ b/src/test/java/net/datafaker/formats/XmlTest.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static net.datafaker.TestStrings.linesTrimTrailing;
+import static net.datafaker.TestStrings.lines;
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,11 +75,10 @@ class XmlTest {
                     compositeField("root",
                         new Field[]{field("attribute1", () -> "value1"), field("attribute2", () -> "value2"),
                             field(null, () -> List.of(field("child", () -> "value")))})),
-                linesTrimTrailing("""
+                lines("""
                     <root attribute1="value1" attribute2="value2">
                         <child>value</child>
-                    </root>
-                    """)),
+                    </root>""")),
             of(Schema.of(field("root", () -> "<> value\"")), "<root>&lt;&gt; value&quot;</root>")
         );
     }

--- a/src/test/java/net/datafaker/formats/XmlTest.java
+++ b/src/test/java/net/datafaker/formats/XmlTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static net.datafaker.TestStrings.linesTrimTrailing;
 import static net.datafaker.transformations.Field.compositeField;
 import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,7 +75,11 @@ class XmlTest {
                     compositeField("root",
                         new Field[]{field("attribute1", () -> "value1"), field("attribute2", () -> "value2"),
                             field(null, () -> List.of(field("child", () -> "value")))})),
-                "<root attribute1=\"value1\" attribute2=\"value2\">" + System.lineSeparator() + "    <child>value</child>" + System.lineSeparator() + "</root>"),
+                linesTrimTrailing("""
+                    <root attribute1="value1" attribute2="value2">
+                        <child>value</child>
+                    </root>
+                    """)),
             of(Schema.of(field("root", () -> "<> value\"")), "<root>&lt;&gt; value&quot;</root>")
         );
     }

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -99,7 +98,7 @@ class YamlTest {
     void generateFromFakeSequenceWithCollection(int limit) {
         final BaseFaker faker = new BaseFaker();
         Schema<Name, List<String>> schema = Schema.of(field("firstNames", name -> IntStream.rangeClosed(1, limit)
-            .mapToObj(it -> name.firstName()).collect(Collectors.toList())));
+            .mapToObj(it -> name.firstName()).toList()));
 
         YamlTransformer<Name> transformer = new YamlTransformer<>();
         String yaml =

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -18,6 +18,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static net.datafaker.TestStrings.lines;
 import static net.datafaker.transformations.Field.field;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -34,40 +35,66 @@ class YamlTest {
     private static Stream<Arguments> generateTestSchema() {
         return Stream.of(
             of(Schema.of(), ""),
-            of(Schema.of(field("key", () -> "value")), "key: value" + System.lineSeparator()),
-            of(Schema.of(field("number", () -> 123)), "number: 123" + System.lineSeparator()),
-            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.0))), "number: 123.0" + System.lineSeparator()),
-            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), "number: 123.123" + System.lineSeparator()),
-            of(Schema.of(field("boolean", () -> true)), "boolean: true" + System.lineSeparator()),
-            of(Schema.of(field("nullValue", () -> null)), "nullValue: null" + System.lineSeparator()),
-            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})),
-                "array:" + System.lineSeparator()
-                    + "  - null" + System.lineSeparator()
-                    + "  - test" + System.lineSeparator()
-                    + "  - 123" + System.lineSeparator()),
-            of(Schema.of(field("array", () -> new Integer[]{123, 456, 789})),
-                "array:" + System.lineSeparator()
-                    + "  - 123" + System.lineSeparator()
-                    + "  - 456" + System.lineSeparator()
-                    + "  - 789" + System.lineSeparator()),
-            of(Schema.of(field("array", () -> new Object[]{"test", 456, true})),
-                "array:" + System.lineSeparator()
-                    + "  - test" + System.lineSeparator()
-                    + "  - 456" + System.lineSeparator()
-                    + "  - true" + System.lineSeparator()),
-            of(Schema.of(field("emptyarray", () -> new Long[]{})), "emptyarray:" + System.lineSeparator()),
-            of(Schema.of(field("emptyarray", Collections::emptyList)), "emptyarray:" + System.lineSeparator()),
+            of(Schema.of(field("key", () -> "value")), lines("""
+                key: value
+                """)),
+            of(Schema.of(field("number", () -> 123)), lines("""
+                number: 123
+                """)),
+            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.0))), lines("""
+                number: 123.0
+                """)),
+            of(Schema.of(field("number", () -> BigDecimal.valueOf(123.123))), lines("""
+                number: 123.123
+                """)),
+            of(Schema.of(field("boolean", () -> true)), lines("""
+                boolean: true
+                """)),
+            of(Schema.of(field("nullValue", () -> null)), lines("""
+                nullValue: null
+                """)),
+            of(Schema.of(field("array", () -> new String[]{null, "test", "123"})), lines("""
+                array:
+                  - null
+                  - test
+                  - 123
+                """)),
+            of(Schema.of(field("array", () -> new Integer[]{123, 456, 789})), lines("""
+                array:
+                  - 123
+                  - 456
+                  - 789
+                """)),
+            of(Schema.of(field("array", () -> new Object[]{"test", 456, true})), lines("""
+                array:
+                  - test
+                  - 456
+                  - true
+                """)),
+            of(Schema.of(field("emptyarray", () -> new Long[]{})), lines("""
+                emptyarray:
+                """)),
+            of(Schema.of(field("emptyarray", Collections::emptyList)), lines("""
+                emptyarray:
+                """)),
             of(Schema.of(field("key", () -> "value"),
                     field("nested", () -> Schema.of(field("nestedkey", () -> "nestedvalue")))),
-                "key: value" + System.lineSeparator() + "nested:" + System.lineSeparator() + "  nestedkey: nestedvalue" + System.lineSeparator()),
+                lines("""
+                    key: value
+                    nested:
+                      nestedkey: nestedvalue
+                    """)),
             of(Schema.of(field("key", () -> "value"),
                     field("nested",
                         () -> Schema.of(field("nestedkey", () -> "nestedvalue"),
                             field("nested2", () -> Schema.of(field("nestedkey2", () -> "nestedvalue2")))))),
-                "key: value" + System.lineSeparator()
-                    + "nested:" + System.lineSeparator() + "  nestedkey: nestedvalue" + System.lineSeparator()
-                    + "  nested2:" + System.lineSeparator()
-                    + "    nestedkey2: nestedvalue2" + System.lineSeparator())
+                lines("""
+                    key: value
+                    nested:
+                      nestedkey: nestedvalue
+                      nested2:
+                        nestedkey2: nestedvalue2
+                    """))
         );
     }
 

--- a/src/test/java/net/datafaker/formats/YamlTest.java
+++ b/src/test/java/net/datafaker/formats/YamlTest.java
@@ -119,7 +119,7 @@ class YamlTest {
     @SafeVarargs
     private static Map<Supplier<String>, Supplier<Object>> map(Map.Entry<Supplier<String>, Supplier<Object>>... entries) {
         Map<Supplier<String>, Supplier<Object>> map = new LinkedHashMap<>();
-        for (Map.Entry<Supplier<String>, Supplier<Object>> entry : entries) {
+        for (var entry : entries) {
             map.put(entry.getKey(), entry.getValue());
         }
         return map;

--- a/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
+++ b/src/test/java/net/datafaker/integration/FakerIntegrationTest.java
@@ -93,7 +93,7 @@ class FakerIntegrationTest {
         final Faker faker = init(locale, random);
 
         Method[] methods = faker.getClass().getMethods();
-        for (Method provider : methods) {
+        for (var provider : methods) {
             if (AbstractProvider.class.isAssignableFrom(provider.getReturnType()) && provider.getParameterCount() == 0) {
                 log.fine(() -> "    (%s), method: %s.%s()".formatted(locale, provider.getDeclaringClass().getSimpleName(), provider.getName()));
 
@@ -111,7 +111,7 @@ class FakerIntegrationTest {
             withReturnType(String.class),
             withParametersCount(0));
 
-        for (Method method : methodsThatReturnStrings) {
+        for (var method : methodsThatReturnStrings) {
             if (isExcepted(provider, method, locale)) {
                 continue;
             }
@@ -169,7 +169,7 @@ class FakerIntegrationTest {
         arguments.add(Arguments.of(null, null));
 
         String[] ymlFiles = requireNonNull(new File("./src/main/resources").list());
-        for (String ymlFileName : ymlFiles) {
+        for (var ymlFileName : ymlFiles) {
             if (ymlFileName.endsWith(".yml") && !ymlFileName.startsWith("_")) {
                 String locale = substringBefore(ymlFileName, ".").replace("-", "_");
                 arguments.add(Arguments.of(new Locale(locale), null));

--- a/src/test/java/net/datafaker/integration/FakerRepeatabilityIntegrationTest.java
+++ b/src/test/java/net/datafaker/integration/FakerRepeatabilityIntegrationTest.java
@@ -63,7 +63,7 @@ public class FakerRepeatabilityIntegrationTest {
         List<Method> providerList = Arrays.asList(methods);
         providerList.sort(Comparator.comparing(Method::getName));
 
-        for (Method provider : providerList) {
+        for (var provider : providerList) {
 
             if (AbstractProvider.class.isAssignableFrom(provider.getReturnType()) && provider.getParameterCount() == 0) {
                 AbstractProvider providerImpl = (AbstractProvider) provider.invoke(faker);
@@ -73,7 +73,7 @@ public class FakerRepeatabilityIntegrationTest {
                 List<Method> generatorMethodList = Arrays.asList(generatorMethods);
                 generatorMethodList.sort(Comparator.comparing(Method::getName));
 
-                for (Method generatorMethod : generatorMethodList) {
+                for (var generatorMethod : generatorMethodList) {
 
                     if (!Instant.class.isAssignableFrom(generatorMethod.getReturnType()) &&
                         !byte[].class.isAssignableFrom(generatorMethod.getReturnType())

--- a/src/test/java/net/datafaker/integration/UkLocalDirectivesTest.java
+++ b/src/test/java/net/datafaker/integration/UkLocalDirectivesTest.java
@@ -33,10 +33,10 @@ class UkLocalDirectivesTest {
         boolean startsWithMascPrefix = false;
         boolean startsWithFemPrefix = false;
 
-        for (String mascPrefix : masc) {
+        for (var mascPrefix : masc) {
             startsWithMascPrefix |= streetName.startsWith(mascPrefix);
         }
-        for (String femPrefix : fem) {
+        for (var femPrefix : fem) {
             startsWithFemPrefix |= streetName.startsWith(femPrefix);
         }
 

--- a/src/test/java/net/datafaker/providers/base/AbstractProviderListTest.java
+++ b/src/test/java/net/datafaker/providers/base/AbstractProviderListTest.java
@@ -37,14 +37,14 @@ public abstract class AbstractProviderListTest<T extends BaseFaker> {
         return faker.fakeValuesService().fetchObject(key, faker.getContext());
     }
 
-    protected void testProviderList(ProviderListTest.TestSpec testSpec, T faker) {
+    protected void testProviderList(TestSpec testSpec, T faker) {
         // Given
-        Set<String> expected = new HashSet<>(getBaseList(faker, testSpec.key));
+        Set<String> expected = new HashSet<>(getBaseList(faker, testSpec.key()));
         // When
-        String actual = (String) testSpec.supplier.get();
+        String actual = (String) testSpec.supplier().get();
         // Then
         assertThat(actual).isNotEmpty();
-        String collection = "\"" + testSpec.key + "\"";
+        String collection = "\"" + testSpec.key() + "\"";
         assertThat(expected)
             .as(() -> "Check expected list isn't empty and contains the actual for the key " + collection)
             .isNotEmpty()
@@ -52,22 +52,12 @@ public abstract class AbstractProviderListTest<T extends BaseFaker> {
         assertThat(expected)
             .as(() -> "Actual should not have empty entries. " + collection)
             .noneMatch(String::isBlank);
-        if (!testSpec.regex.isEmpty()) {
-            assertThat(actual).matches(Pattern.compile(testSpec.regex));
+        if (!testSpec.regex().isEmpty()) {
+            assertThat(actual).matches(Pattern.compile(testSpec.regex()));
         }
     }
 
-    protected static class TestSpec {
-        private final Supplier<?> supplier;
-        private final String key;
-        private final String regex;
-
-        private TestSpec(Supplier<?> supplier, String key, String regex) {
-            this.supplier = supplier;
-            this.key = key;
-            this.regex = regex;
-        }
-
+    protected record TestSpec(Supplier<?> supplier, String key, String regex) {
         public static TestSpec of(Supplier<?> supplier, String key) {
             return new TestSpec(supplier, key, "");
         }

--- a/src/test/java/net/datafaker/providers/base/BarcodeTest.java
+++ b/src/test/java/net/datafaker/providers/base/BarcodeTest.java
@@ -10,9 +10,10 @@ class BarcodeTest {
 
     @Test
     void type() {
-        assertThat(faker.barcode().type()).matches("(Code(128|39|93))|([EJ])AN(-\\d{1,2})*|Codabar|UCC|UPC(-([AE]))*|IS([BS])N|ITF|" +
-            "Ames\\sCode|NW-7|Monarch|Code\\s2\\sof\\s7|Rationalized|ANSI/AIM BC3-1995|USD-4|" +
-            "GS1 Databar|MSI Plessey");
+        assertThat(faker.barcode().type()).matches("""
+            (Code(128|39|93))|([EJ])AN(-\\d{1,2})*|Codabar|UCC|UPC(-([AE]))*|IS([BS])N|ITF|\
+            Ames\\sCode|NW-7|Monarch|Code\\s2\\sof\\s7|Rationalized|ANSI/AIM BC3-1995|USD-4|\
+            GS1 Databar|MSI Plessey""");
     }
 
     private static boolean isBarcodeValid(long barcode) {

--- a/src/test/java/net/datafaker/providers/base/CredentialsTest.java
+++ b/src/test/java/net/datafaker/providers/base/CredentialsTest.java
@@ -1,6 +1,5 @@
 package net.datafaker.providers.base;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -132,7 +131,7 @@ class CredentialsTest {
         final List<String> list = (obj instanceof List<?> l
                 && l.stream().allMatch(String.class::isInstance))
                         ? l.stream().map(String.class::cast).toList()
-                        : Collections.emptyList();
+                        : List.of();
 
         assertThat(faker.credentials().weakPassword()).isIn(list);
     }

--- a/src/test/java/net/datafaker/providers/base/CredentialsTest.java
+++ b/src/test/java/net/datafaker/providers/base/CredentialsTest.java
@@ -26,7 +26,6 @@ class CredentialsTest {
 
     @ParameterizedTest
     @MethodSource("userNameWithSpacesProvider")
-    @SuppressWarnings("removal")
     void testUsernameWithSpaces(String firstName, String lastName, String expected) {
         Locale locale = new Locale("TR");
         Name name = mock();
@@ -40,7 +39,7 @@ class CredentialsTest {
             }
         };
 
-        assertThat(mockedFaker.internet().username())
+        assertThat(mockedFaker.credentials().username())
             .isEqualTo(expected);
     }
 

--- a/src/test/java/net/datafaker/providers/base/DomainTest.java
+++ b/src/test/java/net/datafaker/providers/base/DomainTest.java
@@ -16,7 +16,7 @@ class DomainTest {
     @Test
     void testFirstLevelDomain() {
         String[] components = faker.domain().firstLevelDomain("example").split("\\.");
-        for (String str : components) {
+        for (var str : components) {
             assert (!str.isEmpty());
         }
     }
@@ -30,7 +30,7 @@ class DomainTest {
     @Test
     void testSecondLevelDomain() {
         String[] components = faker.domain().secondLevelDomain("example").split("\\.");
-        for (String str : components) {
+        for (var str : components) {
             assert (!str.isEmpty());
         }
     }
@@ -45,7 +45,7 @@ class DomainTest {
     @Test
     void testFullDomain() {
         String[] components = faker.domain().fullDomain("example").split("\\.");
-        for (String str : components) {
+        for (var str : components) {
             assert (!str.isEmpty());
         }
     }
@@ -59,7 +59,7 @@ class DomainTest {
     @Test
     void testValidDomain() {
         String[] components = faker.domain().validDomain("example").split("\\.");
-        for (String str : components) {
+        for (var str : components) {
             assert (!str.isEmpty());
         }
     }

--- a/src/test/java/net/datafaker/providers/base/FinanceTest.java
+++ b/src/test/java/net/datafaker/providers/base/FinanceTest.java
@@ -81,7 +81,7 @@ class FinanceTest extends BaseFakerTest {
     @Test
     void ibanWithAllCountryCodes() {
         Set<String> ibanCountryCodes = Finance.ibanSupportedCountries();
-        for (String givenCountryCode : ibanCountryCodes) {
+        for (var givenCountryCode : ibanCountryCodes) {
             final String iban = finance.iban(givenCountryCode).toUpperCase(faker.getContext().getLocale());
             assertThatIban(iban)
                 .hasCountryCode(givenCountryCode)

--- a/src/test/java/net/datafaker/providers/base/HttpTest.java
+++ b/src/test/java/net/datafaker/providers/base/HttpTest.java
@@ -115,7 +115,7 @@ class HttpTest extends BaseFakerTest {
 
     @Test
     void userAgentForAllBrowsers() {
-        for (Http.Browser browser : Http.Browser.values()) {
+        for (var browser : Http.Browser.values()) {
             assertThat(http.userAgent(browser))
                 .as("User agent for browser %s", browser)
                 .isNotBlank()

--- a/src/test/java/net/datafaker/providers/base/InternetTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.Locale;
 import java.util.Random;
 import java.util.regex.Pattern;
@@ -129,9 +129,9 @@ class InternetTest {
 
         when(spyedFaker.fakeValuesService()).thenReturn(mockedFakeValuesService);
         when(mockedFakeValuesService.fetchObject("name.prefix", spyedFaker.getContext()))
-            .thenReturn(Collections.emptySet());
+            .thenReturn(Set.of());
         when(mockedFakeValuesService.fetchObject("name.suffix", spyedFaker.getContext()))
-            .thenReturn(Collections.emptySet());
+            .thenReturn(Set.of());
 
         String emailAddress = spyedFaker.internet().emailAddress("John McClane");
         assertThat(emailAddress).startsWith("john.mcclane@");

--- a/src/test/java/net/datafaker/providers/base/InternetTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.Integer.parseInt;
@@ -161,7 +160,7 @@ class InternetTest {
         }
         final String safeDomain = faker.internet().resolve("internet.safe_email");
 
-        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).collect(Collectors.toList()))
+        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).toList())
             .isNotEmpty();
     }
 
@@ -176,7 +175,7 @@ class InternetTest {
         }
         final String safeDomain = faker.internet().resolve("internet.safe_email");
 
-        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).collect(Collectors.toList()))
+        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).toList())
             .isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/providers/base/InternetTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetTest.java
@@ -521,7 +521,7 @@ class InternetTest {
     @Test
     void testUserAgent() {
         Internet.UserAgent[] agents = Internet.UserAgent.values();
-        for (Internet.UserAgent agent : agents) {
+        for (var agent : agents) {
             assertThat(faker.internet().userAgent(agent)).isNotEmpty();
         }
 
@@ -532,7 +532,7 @@ class InternetTest {
     @Test
     void testBotUserAgent() {
         Internet.BotUserAgent[] agents = Internet.BotUserAgent.values();
-        for (Internet.BotUserAgent agent : agents) {
+        for (var agent : agents) {
             assertThat(faker.internet().botUserAgent(agent)).isNotEmpty();
         }
 

--- a/src/test/java/net/datafaker/providers/base/InternetTest.java
+++ b/src/test/java/net/datafaker/providers/base/InternetTest.java
@@ -14,10 +14,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.Locale;
 import java.util.Random;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.Integer.parseInt;
@@ -160,7 +161,7 @@ class InternetTest {
         }
         final String safeDomain = faker.internet().resolve("internet.safe_email");
 
-        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).toList())
+        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).collect(Collectors.toList()))
             .isNotEmpty();
     }
 
@@ -175,7 +176,7 @@ class InternetTest {
         }
         final String safeDomain = faker.internet().resolve("internet.safe_email");
 
-        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).toList())
+        assertThat(emails.stream().filter(t -> t.endsWith("@" + safeDomain)).collect(Collectors.toList()))
             .isNotEmpty();
     }
 

--- a/src/test/java/net/datafaker/providers/base/NumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/NumberTest.java
@@ -391,7 +391,7 @@ class NumberTest {
             map.merge(r, 1, Integer::sum);
         }
 
-        for (Map.Entry<Integer, Integer> entry : map.entrySet()) {
+        for (var entry : map.entrySet()) {
             int count = entry.getValue();
             assertThat((mean - count) / mean).isLessThan(0.2);
         }
@@ -417,7 +417,7 @@ class NumberTest {
             map.merge(r, 1, Integer::sum);
         }
 
-        for (Map.Entry<Long, Integer> entry : map.entrySet()) {
+        for (var entry : map.entrySet()) {
             int count = entry.getValue();
             assertThat(Math.abs(mean - count) / mean)
                 .as(() -> "Entry: %s, all numbers: %s".formatted(entry, map))

--- a/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
+++ b/src/test/java/net/datafaker/providers/base/PhoneNumberTest.java
@@ -48,9 +48,10 @@ class PhoneNumberTest {
     @ParameterizedTest
     @MethodSource("canadianLocales")
     void testPhone_CA(Locale locale) {
-        String areaCode = "263|354|382|403|587|780|825|236|250|368|428|604|672|778|204|431|506|"
-            + "709|782|902|226|249|289|343|365|416|437|519|548|613|647|705|807|905|367|"
-            + "418|438|450|468|474|514|579|581|584|683|742|753|819|873|306|639|867|879|942|257";
+        String areaCode = """
+            263|354|382|403|587|780|825|236|250|368|428|604|672|778|204|431|506|\
+            709|782|902|226|249|289|343|365|416|437|519|548|613|647|705|807|905|367|\
+            418|438|450|468|474|514|579|581|584|683|742|753|819|873|306|639|867|879|942|257""";
         Pattern canadianPhone = Pattern.compile("((\\+1)?(\\(?(%s)\\)?)|(%s))[- .]\\d{3}[- .]\\d{4}".formatted(areaCode, areaCode));
         PhoneNumber phoneNumber = new BaseFaker(locale).phoneNumber();
         for (int i = 0; i < COUNT; i++) {

--- a/src/test/java/net/datafaker/providers/base/TwitterTest.java
+++ b/src/test/java/net/datafaker/providers/base/TwitterTest.java
@@ -79,9 +79,9 @@ class TwitterTest {
         String text = twitter.text(keywords, sentenceMaxLength, wordMaxLength);
         String[] textwords = text.split(" ");
         boolean flag = true;
-        for (String keyword : keywords) {
+        for (var keyword : keywords) {
             boolean tmpFlag = false;
-            for (String textword : textwords) {
+            for (var textword : textwords) {
                 if (keyword.equals(textword)) {
                     tmpFlag = true;
                     break;

--- a/src/test/java/net/datafaker/script/MkdocsReleaseNavUpdater.java
+++ b/src/test/java/net/datafaker/script/MkdocsReleaseNavUpdater.java
@@ -56,7 +56,7 @@ public final class MkdocsReleaseNavUpdater {
 
         List<String> out = new ArrayList<>(lines.size() + 2);
         boolean inReleases = false;
-        for (String line : lines) {
+        for (var line : lines) {
             if (RELEASES_HEADER.matcher(line).matches()) {
                 out.add(line);
                 inReleases = true;
@@ -89,7 +89,7 @@ public final class MkdocsReleaseNavUpdater {
 
     private static String findPreviousStable(List<String> lines, String releasedVersion) {
         boolean inReleases = false;
-        for (String line : lines) {
+        for (var line : lines) {
             if (RELEASES_HEADER.matcher(line).matches()) {
                 inReleases = true;
                 continue;

--- a/src/test/java/net/datafaker/script/ProviderGenerator.java
+++ b/src/test/java/net/datafaker/script/ProviderGenerator.java
@@ -44,7 +44,7 @@ class ProviderGenerator {
 
         System.out.println(files.length + " files");
 
-        for (File file : filesToProcess) {
+        for (var file : filesToProcess) {
             final Map<String, Object> valuesMap = new Yaml().loadAs(new FileReader(file), Map.class);
 
             Map<String, Object> en = (Map<String, Object>) valuesMap.get("en");
@@ -101,7 +101,7 @@ class ProviderGenerator {
         System.out.println("    }");
         System.out.println();
 
-        for (String string : strings) {
+        for (var string : strings) {
             String methodName = StringUtils.uncapitalize(toJavaConvention(string));
 
             System.out.println("    public String " + methodName + "() {\n" +
@@ -127,7 +127,7 @@ class ProviderGenerator {
         System.out.println("class " + className + "Test extends " + providerType.getTestSuperclassSimpleName() + " {");
         System.out.println();
 
-        for (String string : strings) {
+        for (var string : strings) {
             String testMethodName = StringUtils.uncapitalize(toJavaConvention(string));
 
             System.out.println("    @" + Test.class.getSimpleName());

--- a/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
+++ b/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
@@ -48,7 +48,7 @@ public class ProvidersDocsGenerator {
     public static void main(String[] args) {
         ProvidersDocsGenerator providersDocsGenerator = new ProvidersDocsGenerator();
         providersDocsGenerator.initSubtypes();
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(DESTINATION_PLACE_OF_PROVIDERS_FILE))) {
+        try (var writer = new BufferedWriter(new FileWriter(DESTINATION_PLACE_OF_PROVIDERS_FILE))) {
             providersDocsGenerator.constructHeaderInProvidersFile(writer);
             providersDocsGenerator.generateProvidersDocs(writer);
             writer.flush();
@@ -67,7 +67,7 @@ public class ProvidersDocsGenerator {
     }
 
     void generateProvidersDocs(BufferedWriter writer) throws IOException {
-        for (Class<?> clazz : subTypes) {
+        for (var clazz : subTypes) {
             String groupName = extractGroupName(clazz);
             String comment = extractCommentFromJavadoc("src/main/java/net/datafaker/providers/" + groupName + "/" + clazz.getSimpleName() + ".java");
             writer.write(Column.generateRow(' ', clazz.getSimpleName(), comment, formatGroupName(groupName)));
@@ -149,7 +149,7 @@ public class ProvidersDocsGenerator {
             .append("\n|---------|-------------------------|---------------------------|\n");
 
         int cumulativeCountOfProvidersPerVersion = 0;
-        for (Map.Entry<String, Integer> entry : providersPerVersion.entrySet()) {
+        for (var entry : providersPerVersion.entrySet()) {
             cumulativeCountOfProvidersPerVersion += entry.getValue();
             sb.append("| ").append(entry.getKey()).append(" | ")
                 .append(entry.getValue().toString()).append(" | ")
@@ -167,7 +167,7 @@ public class ProvidersDocsGenerator {
     private Map<String, Integer> extractProvidersPerVersion() {
         Map<String, Integer> providersPerVersion = new TreeMap<>(Comparator.naturalOrder());
 
-        for (Class<?> clazz : subTypes) {
+        for (var clazz : subTypes) {
             String groupName = extractGroupName(clazz);
             String comment = extractCommentFromJavadoc("src/main/java/net/datafaker/providers/" + groupName + "/" + clazz.getSimpleName() + ".java");
             String sinceTag = Column.SINCE.getValue(comment);

--- a/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
+++ b/src/test/java/net/datafaker/script/ProvidersDocsGenerator.java
@@ -143,10 +143,13 @@ public class ProvidersDocsGenerator {
     private String providersPerVersionTable() {
         Map<String, Integer> providersPerVersion = extractProvidersPerVersion();
 
-        StringBuilder sb = new StringBuilder()
-            .append("\nNumber of providers per Datafaker version:\n")
-            .append("\n| Version | Number of new providers | Total number of providers |")
-            .append("\n|---------|-------------------------|---------------------------|\n");
+        StringBuilder sb = new StringBuilder("""
+            
+            Number of providers per Datafaker version:
+            
+            | Version | Number of new providers | Total number of providers |
+            |---------|-------------------------|---------------------------|
+            """);
 
         int cumulativeCountOfProvidersPerVersion = 0;
         for (var entry : providersPerVersion.entrySet()) {

--- a/src/test/java/net/datafaker/script/ReleaseNotesGenerator.java
+++ b/src/test/java/net/datafaker/script/ReleaseNotesGenerator.java
@@ -60,12 +60,12 @@ public final class ReleaseNotesGenerator {
         List<String> out = new ArrayList<>(templateLines.size() + bodyLines.size());
         List<String> preparedBody = prepareBodyLines(bodyLines);
         boolean inserted = false;
-        for (String line : templateLines) {
+        for (var line : templateLines) {
             out.add(line.replace("X.Y.Z", version).replace("dd-mm-yyyy", date));
             if (!inserted && WHATS_CHANGED.equals(out.get(out.size() - 1))) {
                 if (!preparedBody.isEmpty()) {
                     out.add("");
-                    for (String bodyLine : preparedBody) {
+                    for (var bodyLine : preparedBody) {
                         out.add(stripIssueHash(bodyLine));
                     }
                 }

--- a/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeCollectionTest.java
@@ -34,7 +34,7 @@ class FakeCollectionTest {
             .minLen(3)
             .maxLen(5).build().get();
         assertThat(names).hasSizeBetween(3, 5);
-        for (String name : names) {
+        for (var name : names) {
             assertThat(name).matches("[a-zA-Z']+");
         }
     }
@@ -45,7 +45,7 @@ class FakeCollectionTest {
             .collection(() -> faker.number().digit())
             .len(3, 10).generate();
         assertThat(digits).hasSizeBetween(3, 10);
-        for (String digit : digits) {
+        for (var digit : digits) {
             assertThat(digit).matches("\\d");
         }
     }
@@ -94,7 +94,7 @@ class FakeCollectionTest {
             .collection(() -> faker.number().digit())
             .len(5).generate();
         assertThat(digits).hasSize(5);
-        for (String digit : digits) {
+        for (var digit : digits) {
             assertThat(digit).matches("\\d");
         }
     }
@@ -107,7 +107,7 @@ class FakeCollectionTest {
             .minLen(3)
             .maxLen(5).build().get();
         assertThat(names).hasSizeBetween(3, 5);
-        for (String name : names) {
+        for (var name : names) {
             assertThat(name).isNull();
         }
     }
@@ -155,7 +155,7 @@ class FakeCollectionTest {
             .suppliers(() -> faker.name().firstName(), () -> faker.random().nextInt(100))
             .maxLen(5).build().get();
         assertThat(objects).hasSize(5);
-        for (Object object : objects) {
+        for (var object : objects) {
             assertThat(object).isInstanceOfAny(Integer.class, String.class);
         }
     }
@@ -284,7 +284,7 @@ class FakeCollectionTest {
             .build();
 
         int count = 0;
-        for (String digit : digits) {
+        for (var digit : digits) {
             assertThat(digit).matches("\\d");
             count++;
         }

--- a/src/test/java/net/datafaker/sequence/FakeStreamTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeStreamTest.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.datafaker.transformations.Field.compositeField;
@@ -101,7 +100,7 @@ class FakeStreamTest {
         List<Supplier<String>> suppliers = List.of(() -> faker.name().firstName(), () -> faker.name().lastName());
         Stream<String> stream = faker.stream(suppliers).len(3).generate();
 
-        assertThat(stream.collect(Collectors.toList())).hasSize(3);
+        assertThat(stream.toList()).hasSize(3);
     }
 
     @Test
@@ -115,7 +114,7 @@ class FakeStreamTest {
             .maxLen(20)
             .generate();
 
-        List<String> namesList = names.collect(Collectors.toList());
+        List<String> namesList = names.toList();
         assertThat(namesList).hasSize(14);
         assertThat(namesList.get(0)).isEqualTo("Flor");
         assertThat(namesList.get(1)).isEqualTo("Brian");

--- a/src/test/java/net/datafaker/sequence/FakeStreamTest.java
+++ b/src/test/java/net/datafaker/sequence/FakeStreamTest.java
@@ -318,7 +318,7 @@ class FakeStreamTest {
             .build();
 
         int count = 0;
-        for (String digit : digits) {
+        for (var digit : digits) {
             assertThat(digit).matches("\\d");
             count++;
         }
@@ -336,7 +336,7 @@ class FakeStreamTest {
 
         int count = 0;
         int amountOfElementsToTake = 1_000;
-        for (String digit : digits) {
+        for (var digit : digits) {
             assertThat(digit).matches("\\d");
             count++;
             if (count == amountOfElementsToTake) {
@@ -360,7 +360,7 @@ class FakeStreamTest {
         File csvFile = Files.newTemporaryFile();
         assertThat(csvFile).exists().isEmpty();
 
-        try (BufferedOutputStream fos = new BufferedOutputStream(new FileOutputStream(csvFile))) {
+        try (var fos = new BufferedOutputStream(new FileOutputStream(csvFile))) {
             transformer.writeToOutputStream(fos, schema, 2);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/test/java/net/datafaker/service/WeightedRandomSelectorTest.java
+++ b/src/test/java/net/datafaker/service/WeightedRandomSelectorTest.java
@@ -119,7 +119,7 @@ class WeightedRandomSelectorTest {
         Map<String, Integer> counts = countResults(selector, items);
 
         assertThat(counts.keySet()).containsExactlyInAnyOrderElementsOf(expectedCounts.keySet());
-        for (String element : expectedCounts.keySet()) {
+        for (var element : expectedCounts.keySet()) {
             assertThat(counts.get(element)).isCloseTo(expectedCounts.get(element), withinPercentage(1));
         }
     }

--- a/src/test/java/net/datafaker/service/WeightedRandomSelectorTest.java
+++ b/src/test/java/net/datafaker/service/WeightedRandomSelectorTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +131,7 @@ class WeightedRandomSelectorTest {
                 "Input list cannot be null"
             ),
             Arguments.of(
-                Collections.emptyList(),
+                List.of(),
                 "Input list cannot be empty"
             ),
             Arguments.of(


### PR DESCRIPTION
- collect(Collectors.toList()) ➡️  toList()
- Use List/Set/Map.of where immutables are okay
- Leverage Records
- Use updated instanceof form to reduce assignments/intermediate storage
- Leverage var + local variable type inference
- Use text blocks to avoid concatenation, etc.