### PR TITLE
feat(build): Maven POM cosmetics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
         <junit.version>6.1.1</junit.version>
         <libphonenumber.version>9.0.33</libphonenumber.version>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <releaseJavaVersion>17</releaseJavaVersion>
+        <buildJavaVersion>17</buildJavaVersion>
 
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -202,8 +202,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
+                        <release>${releaseJavaVersion}</release>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -244,9 +243,12 @@
                             <goal>enforce</goal>
                         </goals>
                         <configuration>
+                            <requireMavenVersion>
+                                <version>[3.6,)</version>
+                            </requireMavenVersion>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>${maven.compiler.source}</version>
+                                    <version>[${buildJavaVersion},)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,9 @@
         </dependency>
     </dependencies>
     <build>
+
+        <defaultGoal>clean verify</defaultGoal>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,11 @@
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <junit.version>6.1.1</junit.version>
         <libphonenumber.version>9.0.33</libphonenumber.version>
+
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
@@ -48,6 +51,7 @@
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+        <moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
         <mockito-core.version>5.23.0</mockito-core.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <reflections.version>0.10.2</reflections.version>
@@ -221,7 +225,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.11.0</version>
+                <version>${central-publishing-maven-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
@@ -356,7 +360,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.3.0.Final</version>
+                <version>${moditect-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>add-module-infos</id>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <additionalparam>-Xdoclint:none</additionalparam>
         <coverage.reports.dir>${project.build.directory}/target/coverage-reports</coverage.reports.dir>
 
         <assertj-core.version>3.27.7</assertj-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
         <mockito-core.version>5.23.0</mockito-core.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+        <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <reflections.version>0.10.2</reflections.version>
         <slf4j.version>2.0.18</slf4j.version>
         <javaparser.version>3.28.2</javaparser.version>
@@ -216,6 +217,21 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${versions-maven-plugin.version}</version>
+                    <configuration>
+                        <ruleSet>
+                            <ignoreVersions>
+                                <ignoreVersion>
+                                    <type>regex</type>
+                                    <version>.*(?i)(alpha|beta|rc|cr|preview|milestone|[mb][0-9]+).*</version>
+                                </ignoreVersion>
+                            </ignoreVersions>
+                        </ruleSet>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
#### **Description:**

This PR makes subtle optimizations to `pom.xml` in order to improve developer experience, build flexibility, and maintenance.

The changes are split into separate, self-contained commits. This allows you to review and cherry-pick (or drop) specific improvements independently, depending on what should be adopted.

#### **Changes:**

* **Added Default Goal:** Defined `<defaultGoal>clean verify</defaultGoal>` to enable full lifecycle builds via a simple `mvn` execution.
* **Modernized Java Setup:** Replaced outdated `source`/`target` options with the modern `<release>` compiler configuration.
* **Flexible Enforcer Rules:** Refactored Enforcer rules to use range-based versions (`[17,)`), allowing builds with newer JDKs (e.g., Java 21) while ensuring minimum requirements.
* **Dependency Management:** Integrated `versions-maven-plugin` configured to filter out non-stable pre-releases (alpha, beta, rc, etc.) for streamlined dependency checks.
* **POM Clean-up:** Centralized hardcoded plugin versions into properties and removed the obsolete `<additionalparam>` Javadoc property.