### PR TITLE
Refactor small maintainability issues in transformations, fake-value resolution and Irish PPSN generation

### DIFF
--- a/src/main/java/net/datafaker/idnumbers/IrishIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/IrishIdNumber.java
@@ -48,12 +48,24 @@ public class IrishIdNumber implements IdNumberGenerator {
 
     @Override
     public String generateValid(final BaseProviders faker) {
-        int[] weights = {8, 7, 6, 5, 4, 3, 2};
         // Generate 7 digits
         String digitsPpsn = faker.number().digits(7);
-        int[] digits = digitsPpsn.chars().map(c -> Character.getNumericValue(c)).toArray();
 
-        String suffix = faker.bool().bool() ? faker.options().option("A", "B", "H", "W") : "";
+        String suffix = faker.bool().bool()
+            ? faker.options().option("A", "B", "H", "W")
+            : "";
+
+        int weightedSum = calculateWeightedSum(digitsPpsn, suffix);
+
+        // Build the PPSN
+        return digitsPpsn + calculateCheckSumCharacter(weightedSum) + suffix;
+    }
+    private int calculateWeightedSum(String digitsPpsn, String suffix) {
+        int[] weights = {8, 7, 6, 5, 4, 3, 2};
+        int[] digits = digitsPpsn.chars()
+            .map(Character::getNumericValue)
+            .toArray();
+
         int sum = 0;
 
         for (int i = 0; i < 7; i++) {
@@ -63,16 +75,19 @@ public class IrishIdNumber implements IdNumberGenerator {
         // If we have suffix include it in the checksum
         if (!suffix.isEmpty()) {
             char extraChar = suffix.charAt(0);
+
             int extraValue = switch (extraChar) {
                 case 'A', 'B', 'H' -> extraChar - 'A' + 1;
                 case 'W' -> 0;
-                default -> throw new IllegalStateException("Unexpected suffix: " + suffix);
+                default -> throw new IllegalStateException(
+                    "Unexpected suffix: " + suffix
+                );
             };
+
             sum += extraValue * 9;
         }
 
-        // Build the PPSN
-        return digitsPpsn + calculateCheckSumCharacter(sum) + suffix;
+        return sum;
     }
 
     boolean validateAndCheckModulo23(String ppsn) {

--- a/src/main/java/net/datafaker/idnumbers/IrishIdNumber.java
+++ b/src/main/java/net/datafaker/idnumbers/IrishIdNumber.java
@@ -51,20 +51,17 @@ public class IrishIdNumber implements IdNumberGenerator {
         // Generate 7 digits
         String digitsPpsn = faker.number().digits(7);
 
-        String suffix = faker.bool().bool()
-            ? faker.options().option("A", "B", "H", "W")
-            : "";
+        String suffix = faker.bool().bool() ? faker.options().option("A", "B", "H", "W") : "";
 
         int weightedSum = calculateWeightedSum(digitsPpsn, suffix);
 
         // Build the PPSN
         return digitsPpsn + calculateCheckSumCharacter(weightedSum) + suffix;
     }
+
     private int calculateWeightedSum(String digitsPpsn, String suffix) {
         int[] weights = {8, 7, 6, 5, 4, 3, 2};
-        int[] digits = digitsPpsn.chars()
-            .map(Character::getNumericValue)
-            .toArray();
+        int[] digits = digitsPpsn.chars().map(c -> Character.getNumericValue(c)).toArray();
 
         int sum = 0;
 
@@ -75,15 +72,11 @@ public class IrishIdNumber implements IdNumberGenerator {
         // If we have suffix include it in the checksum
         if (!suffix.isEmpty()) {
             char extraChar = suffix.charAt(0);
-
             int extraValue = switch (extraChar) {
                 case 'A', 'B', 'H' -> extraChar - 'A' + 1;
                 case 'W' -> 0;
-                default -> throw new IllegalStateException(
-                    "Unexpected suffix: " + suffix
-                );
+                default -> throw new IllegalStateException("Unexpected suffix: " + suffix);
             };
-
             sum += extraValue * 9;
         }
 

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -82,7 +82,6 @@ public class FakeValuesService {
     private static final Map<String, String[]> EXPRESSION_2_SPLITTED = new CopyOnWriteMap<>(WeakHashMap::new);
 
     private final Map<String, RegExpContext> regexp2SupplierMap = new CopyOnWriteMap<>(HashMap::new);
-
     public void updateFakeValuesInterfaceMap(List<SingletonLocale> locales) {
         for (final SingletonLocale l : locales) {
             fakeValuesInterfaceMap.computeIfAbsent(l, this::getCachedFakeValue);
@@ -119,8 +118,8 @@ public class FakeValuesService {
     /**
      * Allows adding urls of files with custom data. Data should be in YAML format.
      *
-     * @param locale the locale for which an url is going to be added.
-     * @param url    url of a file with YAML structure
+     * @param locale  the locale for which an url is going to be added.
+     * @param url     url of a file with YAML structure
      * @throws IllegalArgumentException in case of invalid url
      */
     public void addUrl(Locale locale, URL url) {
@@ -945,10 +944,10 @@ public class FakeValuesService {
             if (current.getParameterCount() == args.length || current.getParameterCount() < args.length && current.isVarArgs()) {
                 final Object[] coercedArguments = args.length == 0 ? EMPTY_ARRAY : coerceArguments(current, args);
                 if (coercedArguments != null && rightIsMostRestrictive(mostRestrictive, current)) {
-                    mostRestrictive = current;
-                    coercedArgumentsForMostRestrictive = coercedArguments;
+                        mostRestrictive = current;
+                        coercedArgumentsForMostRestrictive = coercedArguments;
+                    }
                 }
-            }
         }
         if (mostRestrictive != null) {
             return new MethodAndCoercedArgs(mostRestrictive, coercedArgumentsForMostRestrictive);
@@ -980,7 +979,7 @@ public class FakeValuesService {
                 return true;
             }
             if (parameterTypes1[j].isPrimitive()) {
-                for (Class<?> primitive : PRIMITIVES) {
+                for (Class<?> primitive: PRIMITIVES) {
                     if (primitive == parameterTypes1[j]) {
                         return false;
                     } else if (primitive == parameterTypes2[j]) {

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -82,6 +82,7 @@ public class FakeValuesService {
     private static final Map<String, String[]> EXPRESSION_2_SPLITTED = new CopyOnWriteMap<>(WeakHashMap::new);
 
     private final Map<String, RegExpContext> regexp2SupplierMap = new CopyOnWriteMap<>(HashMap::new);
+
     public void updateFakeValuesInterfaceMap(List<SingletonLocale> locales) {
         for (final SingletonLocale l : locales) {
             fakeValuesInterfaceMap.computeIfAbsent(l, this::getCachedFakeValue);
@@ -118,8 +119,8 @@ public class FakeValuesService {
     /**
      * Allows adding urls of files with custom data. Data should be in YAML format.
      *
-     * @param locale  the locale for which an url is going to be added.
-     * @param url     url of a file with YAML structure
+     * @param locale the locale for which an url is going to be added.
+     * @param url    url of a file with YAML structure
      * @throws IllegalArgumentException in case of invalid url
      */
     public void addUrl(Locale locale, URL url) {
@@ -874,12 +875,10 @@ public class FakeValuesService {
      * @throws RuntimeException if there's a problem invoking the method, or it doesn't exist.
      */
     private ValueResolver resolveFakerObjectAndMethod(ProviderRegistration faker, String key, int dotIndex, String[] args) {
-        final String[] classAndMethod;
-        if (dotIndex == -1) {
-            classAndMethod = new String[]{key};
-        } else {
-            classAndMethod = new String[]{key.substring(0, dotIndex), dotIndex == key.length() - 1 ? "" : key.substring(dotIndex + 1)};
-        }
+        final String[] classAndMethod = new String[]{
+            key.substring(0, dotIndex),
+            dotIndex == key.length() - 1 ? "" : key.substring(dotIndex + 1)
+        };
 
         try {
             String fakerMethodName = removeUnderscoreChars(classAndMethod[0]);
@@ -947,10 +946,10 @@ public class FakeValuesService {
             if (current.getParameterCount() == args.length || current.getParameterCount() < args.length && current.isVarArgs()) {
                 final Object[] coercedArguments = args.length == 0 ? EMPTY_ARRAY : coerceArguments(current, args);
                 if (coercedArguments != null && rightIsMostRestrictive(mostRestrictive, current)) {
-                        mostRestrictive = current;
-                        coercedArgumentsForMostRestrictive = coercedArguments;
-                    }
+                    mostRestrictive = current;
+                    coercedArgumentsForMostRestrictive = coercedArguments;
                 }
+            }
         }
         if (mostRestrictive != null) {
             return new MethodAndCoercedArgs(mostRestrictive, coercedArgumentsForMostRestrictive);
@@ -982,7 +981,7 @@ public class FakeValuesService {
                 return true;
             }
             if (parameterTypes1[j].isPrimitive()) {
-                for (Class<?> primitive: PRIMITIVES) {
+                for (Class<?> primitive : PRIMITIVES) {
                     if (primitive == parameterTypes1[j]) {
                         return false;
                     } else if (primitive == parameterTypes2[j]) {

--- a/src/main/java/net/datafaker/service/FakeValuesService.java
+++ b/src/main/java/net/datafaker/service/FakeValuesService.java
@@ -578,7 +578,6 @@ public class FakeValuesService {
      * {@link BaseFaker#address()}'s {@link Address#streetName()}.
      */
     protected String resolveExpression(String expression, Object current, ProviderRegistration root, FakerContext context) {
-        // indexOf(<String>) is faster than indexOf(<char>) since it has jvm intrinsic
         if (!expression.contains("}")) {
             return expression;
         }

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -28,10 +28,10 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
 
     @Override
     public Object apply(Object input, Schema<Object, ?> schema) {
-        Class clazz;
+        Class<?> clazz;
         Object result = null;
-        if (input instanceof Class) {
-            clazz = (Class) input;
+        if (input instanceof Class<?> inputClass) {
+            clazz = inputClass;
         } else {
             clazz = input.getClass();
             result = input;
@@ -129,12 +129,12 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
     /**
      * The output is tied to provided Class source.
      * An empty source will output an empty stream.
-     *
+     * <p>
      * Configure available input with {@link #from(Class source)}.
      */
     @Override
     public Stream<Object> generateStream(final Schema<Object, ?> schema, long limit) {
-        if(sourceClazz.isEmpty())
+        if (sourceClazz.isEmpty())
             return Stream.empty();
         else
             return Stream

--- a/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
+++ b/src/main/java/net/datafaker/transformations/JavaObjectTransformer.java
@@ -129,12 +129,12 @@ public class JavaObjectTransformer implements Transformer<Object, Object> {
     /**
      * The output is tied to provided Class source.
      * An empty source will output an empty stream.
-     * <p>
+     *
      * Configure available input with {@link #from(Class source)}.
      */
     @Override
     public Stream<Object> generateStream(final Schema<Object, ?> schema, long limit) {
-        if (sourceClazz.isEmpty())
+        if(sourceClazz.isEmpty())
             return Stream.empty();
         else
             return Stream


### PR DESCRIPTION
### Summary

This pull request makes a small set of maintainability-focused refactorings:

- Replaces raw `Class` usage in `JavaObjectTransformer.apply()` with `Class<?>` and typed `instanceof` handling.
- Removes an unreachable `dotIndex == -1` branch from the private `FakeValuesService.resolveFakerObjectAndMethod()` helper.
- Removes a misleading expression-resolution comment that referred to `indexOf()` while the code uses `contains("}")`.
- Extracts the Irish PPSN weighted checksum calculation into a private helper method.

### Why

These changes address small maintainability issues found during source inspection. They improve type clarity, remove unreachable control-flow noise, align comments with the current implementation, and separate checksum calculation from the high-level PPSN generation workflow.

The changes are intentionally small and avoid public API or generic-contract redesign.

### Refactoring approach

The refactoring was kept local to the affected implementation details:

- `JavaObjectTransformer.apply()` now uses `Class<?>` to represent an unknown class type more safely.
- `FakeValuesService.resolveFakerObjectAndMethod()` now reflects the verified private helper call contract more directly.
- `FakeValuesService.resolveExpression()` no longer contains a stale implementation-specific comment.
- `IrishIdNumber.generateValid()` now delegates weighted checksum accumulation to `calculateWeightedSum(...)`, while preserving the existing weights, suffix handling, multiplier, checksum character calculation and output format.

### Validation

The following validation was performed:

- `JavaObjectTransformerTest` and `JavaObjectTransformerConstructorTest` passed.
- `FakeValuesServiceTest` passed.
- `IrishIdNumberTest` passed.
- Full Maven verification passed with:

```bash
./mvnw -Dgpg.skip=true clean verify
```