### PR TITLE
fix(build): use releaseJavaVersion for kotlin-maven-plugin jvmTarget

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>${maven.compiler.target}</jvmTarget>
+                    <jvmTarget>${releaseJavaVersion}</jvmTarget>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- `kotlin-maven-plugin`'s `<jvmTarget>` referenced the undeclared property `maven.compiler.target`, which resolves to null. Maven doesn't fail on an unresolved plugin-config expression — it just leaves the parameter unset — so `kotlin-maven-plugin` silently fell back to its internal default and compiled Kotlin sources targeting JVM **1.8** instead of the project's actual target (`releaseJavaVersion` = 17, used by `maven-compiler-plugin` via `<release>`).
- Fixed by pointing `jvmTarget` at the same `releaseJavaVersion` property already used for Java compilation, keeping Kotlin and Java bytecode targets consistent.
- Issue introduced in 740895ed99665f1c77dc9bbf771d71eb66f3c330 (#1865), which added `maven.compiler.target` as the `jvmTarget` value without ever declaring that property.

## Test plan
- [x] Verified via `mvn test-compile -X` that kotlinc previously received `-jvm-target 1.8`, and now receives `-jvm-target 17` after the fix.
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)