### PR TITLE
fix flaky test `TimeAndDateTest.testFutureDateWithBounds`

### DIFF
--- a/src/test/java/net/datafaker/providers/base/TimeAndDateTest.java
+++ b/src/test/java/net/datafaker/providers/base/TimeAndDateTest.java
@@ -36,7 +36,7 @@ class TimeAndDateTest {
     void testFutureDateWithBounds() {
         Instant now = Instant.now();
         Instant future = timeAndDate.future(1, TimeUnit.SECONDS);
-        assertThat(future).isBetween(now, now.plusSeconds(1));
+        assertThat(future).isBetween(now, Instant.now().plusSeconds(1));
     }
 
     @RepeatedTest(100)


### PR DESCRIPTION
Example of test failure: https://github.com/datafaker-net/datafaker/actions/runs/29958635963/job/89060037790?pr=1888

### The problem

The test is using variable `now`:

```java
    void testFutureDateWithBounds() {
        Instant now = Instant.now();

        System.gc(); // --- GC runs at this moment ---

        Instant future = timeAndDate.future(1, TimeUnit.SECONDS);
        assertThat(future).isBetween(now, now.plusSeconds(1)); // -- `future` > `now+1s`
    }
```

If GC runs exactly at this moment (or JVM gets a bit slower for any reason), the `future` might appear later than `now + 1 second`.