### PR TITLE
Add TemporalUnit overloads to timeAndDate(), deprecate TimeUnit variants

### DIFF
--- a/docs/documentation/date-format.md
+++ b/docs/documentation/date-format.md
@@ -7,8 +7,8 @@ Since 1.2.0 Datafaker supports specifying of date formats for dates and timestam
 
     ```java
     Faker faker = new Faker();
-    System.out.println(faker.timeAndDate().future(1, TimeUnit.HOURS, "yyyy MM.dd mm:hh:ss"));
-    System.out.println(faker.timeAndDate().past(1, TimeUnit.HOURS, "yyyy-MM-dd mm:hh:ss"));
+    System.out.println(faker.timeAndDate().future(1, ChronoUnit.HOURS, "yyyy MM.dd mm:hh:ss"));
+    System.out.println(faker.timeAndDate().past(1, ChronoUnit.HOURS, "yyyy-MM-dd mm:hh:ss"));
     System.out.println(faker.timeAndDate().birthday(1, 99, "yyyy/MM/dd"));
     ```
 

--- a/src/main/java/net/datafaker/providers/base/TimeAndDate.java
+++ b/src/main/java/net/datafaker/providers/base/TimeAndDate.java
@@ -349,8 +349,10 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @since 3.0.0
      */
     public Instant past(long atMost, TemporalUnit unit, Instant referenceDate) {
-        Instant lowerBound = referenceDate.atZone(ZoneId.systemDefault()).minus(atMost, unit).toInstant();
-        return between(lowerBound, referenceDate);
+        Instant earliest = referenceDate.atZone(ZoneId.systemDefault()).minus(atMost, unit).toInstant();
+        long boundMillis = referenceDate.toEpochMilli() - earliest.toEpochMilli();
+        long pastMillis = referenceDate.toEpochMilli() - 1 - faker.random().nextLong(boundMillis - 1);
+        return Instant.ofEpochMilli(pastMillis);
     }
 
     /**

--- a/src/main/java/net/datafaker/providers/base/TimeAndDate.java
+++ b/src/main/java/net/datafaker/providers/base/TimeAndDate.java
@@ -8,9 +8,8 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * A generator of random times and dates.
@@ -34,7 +33,7 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      */
     public Instant future() {
         long FIFTY_YEARS = TimeUnit.DAYS.toMillis(18262);
-        return future(faker.number().numberBetween(1, FIFTY_YEARS), MILLISECONDS);
+        return future(faker.number().numberBetween(1, FIFTY_YEARS), ChronoUnit.MILLIS);
     }
 
     /**
@@ -43,8 +42,22 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param atMost at most this amount of time ahead from now exclusive.
      * @param unit   the time unit.
      * @return a future date from now.
+     * @deprecated since 3.0.0. Use {@link #future(long, TemporalUnit)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public Instant future(long atMost, TimeUnit unit) {
+        return future(atMost, unit.toChronoUnit());
+    }
+
+    /**
+     * Generates a future date from now.
+     *
+     * @param atMost at most this amount of time ahead from now exclusive.
+     * @param unit   the temporal unit, e.g. {@link ChronoUnit#HOURS}.
+     * @return a future date from now.
+     * @since 3.0.0
+     */
+    public Instant future(long atMost, TemporalUnit unit) {
         Instant aBitLaterThanNow = Instant.now().plusMillis(1);
         return future(atMost, unit, aBitLaterThanNow);
     }
@@ -56,8 +69,23 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param unit    the time unit.
      * @param pattern date time pattern to convert to string.
      * @return a string representation of a future date from now.
+     * @deprecated since 3.0.0. Use {@link #future(long, TemporalUnit, String)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public String future(long atMost, TimeUnit unit, String pattern) {
+        return future(atMost, unit.toChronoUnit(), pattern);
+    }
+
+    /**
+     * Generates and converts to string representation a future date from now.
+     *
+     * @param atMost  at most this amount of time ahead from now exclusive.
+     * @param unit    the temporal unit, e.g. {@link ChronoUnit#HOURS}.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a future date from now.
+     * @since 3.0.0
+     */
+    public String future(long atMost, TemporalUnit unit, String pattern) {
         return formatInstant(future(atMost, unit), pattern);
     }
 
@@ -68,9 +96,24 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param minimum the minimum amount of time in the future from now.
      * @param unit    the time unit.
      * @return a future date from now, with a minimum time.
+     * @deprecated since 3.0.0. Use {@link #future(long, long, TemporalUnit)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public Instant future(long atMost, long minimum, TimeUnit unit) {
-        Instant minimumDate = Instant.now().plus(minimum, unit.toChronoUnit());
+        return future(atMost, minimum, unit.toChronoUnit());
+    }
+
+    /**
+     * Generates a future date from now, with a minimum time.
+     *
+     * @param atMost  at most this amount of time ahead from now exclusive.
+     * @param minimum the minimum amount of time in the future from now.
+     * @param unit    the temporal unit, e.g. {@link ChronoUnit#HOURS}.
+     * @return a future date from now, with a minimum time.
+     * @since 3.0.0
+     */
+    public Instant future(long atMost, long minimum, TemporalUnit unit) {
+        Instant minimumDate = Instant.now().atZone(ZoneId.systemDefault()).plus(minimum, unit).toInstant();
         return future(atMost - minimum, unit, minimumDate);
     }
 
@@ -83,8 +126,25 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param unit    the time unit.
      * @param pattern date time pattern to convert to string.
      * @return a string representation of a future date from now, with a minimum time.
+     * @deprecated since 3.0.0. Use {@link #future(long, long, TemporalUnit, String)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public String future(long atMost, long minimum, TimeUnit unit, String pattern) {
+        return future(atMost, minimum, unit.toChronoUnit(), pattern);
+    }
+
+    /**
+     * Generates and converts to string representation
+     * of a future date from now, with a minimum time.
+     *
+     * @param atMost  at most this amount of time ahead from now exclusive.
+     * @param minimum the minimum amount of time in the future from now.
+     * @param unit    the temporal unit, e.g. {@link ChronoUnit#HOURS}.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a future date from now, with a minimum time.
+     * @since 3.0.0
+     */
+    public String future(long atMost, long minimum, TemporalUnit unit, String pattern) {
         return formatInstant(future(atMost, minimum, unit), pattern);
     }
 
@@ -95,11 +155,25 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param unit          the time unit.
      * @param referenceDate the future date relative to this date.
      * @return a future date relative to {@code referenceDate}.
+     * @deprecated since 3.0.0. Use {@link #future(long, TemporalUnit, Instant)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public Instant future(long atMost, TimeUnit unit, Instant referenceDate) {
-        long upperBoundMillis = unit.toMillis(atMost);
-        long futureMillis = referenceDate.toEpochMilli() + 1 + faker.random().nextLong(upperBoundMillis - 1);
-        return Instant.ofEpochMilli(futureMillis);
+        return future(atMost, unit.toChronoUnit(), referenceDate);
+    }
+
+    /**
+     * Generates a future date relative to the {@code referenceDate}.
+     *
+     * @param atMost        at most this amount of time ahead to the {@code referenceDate} exclusive.
+     * @param unit          the temporal unit, e.g. {@link ChronoUnit#YEARS}.
+     * @param referenceDate the future date relative to this date.
+     * @return a future date relative to {@code referenceDate}.
+     * @since 3.0.0
+     */
+    public Instant future(long atMost, TemporalUnit unit, Instant referenceDate) {
+        Instant upperBound = referenceDate.atZone(ZoneId.systemDefault()).plus(atMost, unit).toInstant();
+        return between(referenceDate.plusMillis(1), upperBound);
     }
 
     /**
@@ -111,17 +185,34 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param referenceDate the future date relative to this date.
      * @param pattern       date time pattern to convert to string.
      * @return a string representation of a future date relative to {@code referenceDate}.
+     * @deprecated since 3.0.0. Use {@link #future(long, TemporalUnit, Instant, String)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public String future(long atMost, TimeUnit unit, Instant referenceDate, String pattern) {
+        return future(atMost, unit.toChronoUnit(), referenceDate, pattern);
+    }
+
+    /**
+     * Generates and converts to string representation
+     * a future date relative to the {@code referenceDate}.
+     *
+     * @param atMost        at most this amount of time ahead to the {@code referenceDate} exclusive.
+     * @param unit          the temporal unit, e.g. {@link ChronoUnit#YEARS}.
+     * @param referenceDate the future date relative to this date.
+     * @param pattern       date time pattern to convert to string.
+     * @return a string representation of a future date relative to {@code referenceDate}.
+     * @since 3.0.0
+     */
+    public String future(long atMost, TemporalUnit unit, Instant referenceDate, String pattern) {
         return formatInstant(future(atMost, unit, referenceDate), pattern);
     }
 
     /**
      * Generates a past date from now.
      */
-     public Instant past() {
-         long FIFTY_YEARS = TimeUnit.DAYS.toMillis(18262);
-         return past(faker.number().numberBetween(1, FIFTY_YEARS), MILLISECONDS);
+    public Instant past() {
+        long FIFTY_YEARS = TimeUnit.DAYS.toMillis(18262);
+        return past(faker.number().numberBetween(1, FIFTY_YEARS), ChronoUnit.MILLIS);
     }
 
     /**
@@ -130,8 +221,22 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param atMost at most this amount of time earlier from now exclusive.
      * @param unit   the time unit.
      * @return a past date from now.
+     * @deprecated since 3.0.0. Use {@link #past(long, TemporalUnit)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public Instant past(long atMost, TimeUnit unit) {
+        return past(atMost, unit.toChronoUnit());
+    }
+
+    /**
+     * Generates a past date from now.
+     *
+     * @param atMost at most this amount of time earlier from now exclusive.
+     * @param unit   the temporal unit, e.g. {@link ChronoUnit#DAYS}.
+     * @return a past date from now.
+     * @since 3.0.0
+     */
+    public Instant past(long atMost, TemporalUnit unit) {
         Instant aBitEarlierThanNow = Instant.now().minusMillis(1);
         return past(atMost, unit, aBitEarlierThanNow);
     }
@@ -143,8 +248,23 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param unit    the time unit.
      * @param pattern date time pattern to convert to string.
      * @return a string representation of a past date from now.
+     * @deprecated since 3.0.0. Use {@link #past(long, TemporalUnit, String)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public String past(long atMost, TimeUnit unit, String pattern) {
+        return past(atMost, unit.toChronoUnit(), pattern);
+    }
+
+    /**
+     * Generates a string representation of a past date from now.
+     *
+     * @param atMost  at most this amount of time earlier from now exclusive.
+     * @param unit    the temporal unit, e.g. {@link ChronoUnit#DAYS}.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a past date from now.
+     * @since 3.0.0
+     */
+    public String past(long atMost, TemporalUnit unit, String pattern) {
         return formatInstant(past(atMost, unit), pattern);
     }
 
@@ -155,9 +275,24 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param minimum the minimum amount of time in the past from now.
      * @param unit    the time unit.
      * @return a past date from now.
+     * @deprecated since 3.0.0. Use {@link #past(long, long, TemporalUnit)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public Instant past(long atMost, long minimum, TimeUnit unit) {
-        Instant minimumDate = Instant.now().minusMillis(unit.toMillis(minimum));
+        return past(atMost, minimum, unit.toChronoUnit());
+    }
+
+    /**
+     * Generates a past date from now, with a minimum time.
+     *
+     * @param atMost  at most this amount of time earlier from now exclusive.
+     * @param minimum the minimum amount of time in the past from now.
+     * @param unit    the temporal unit, e.g. {@link ChronoUnit#DAYS}.
+     * @return a past date from now, with a minimum time.
+     * @since 3.0.0
+     */
+    public Instant past(long atMost, long minimum, TemporalUnit unit) {
+        Instant minimumDate = Instant.now().atZone(ZoneId.systemDefault()).minus(minimum, unit).toInstant();
         return past(atMost - minimum, unit, minimumDate);
     }
 
@@ -169,8 +304,24 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param unit    the time unit.
      * @param pattern date time pattern to convert to string.
      * @return a string representation of a past date from now, with a minimum time.
+     * @deprecated since 3.0.0. Use {@link #past(long, long, TemporalUnit, String)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public String past(long atMost, long minimum, TimeUnit unit, String pattern) {
+        return past(atMost, minimum, unit.toChronoUnit(), pattern);
+    }
+
+    /**
+     * Generates and converts to string representation a past date from now, with a minimum time.
+     *
+     * @param atMost  at most this amount of time earlier from now exclusive.
+     * @param minimum the minimum amount of time in the past from now.
+     * @param unit    the temporal unit, e.g. {@link ChronoUnit#DAYS}.
+     * @param pattern date time pattern to convert to string.
+     * @return a string representation of a past date from now, with a minimum time.
+     * @since 3.0.0
+     */
+    public String past(long atMost, long minimum, TemporalUnit unit, String pattern) {
         return formatInstant(past(atMost, minimum, unit), pattern);
     }
 
@@ -181,12 +332,27 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param unit          the time unit.
      * @param referenceDate the past date relative to this date.
      * @return a past date relative to {@code referenceDate}.
+     * @deprecated since 3.0.0. Use {@link #past(long, TemporalUnit, Instant)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public Instant past(long atMost, TimeUnit unit, Instant referenceDate) {
-        long upperBoundMillis = unit.toMillis(atMost);
-        long pastMillis = referenceDate.toEpochMilli() - 1 - faker.random().nextLong(upperBoundMillis - 1);
-        return Instant.ofEpochMilli(pastMillis);
+        return past(atMost, unit.toChronoUnit(), referenceDate);
     }
+
+    /**
+     * Generates a past date relative to the {@code referenceDate}.
+     *
+     * @param atMost        at most this amount of time past to the {@code referenceDate} exclusive.
+     * @param unit          the temporal unit, e.g. {@link ChronoUnit#YEARS}.
+     * @param referenceDate the past date relative to this date.
+     * @return a past date relative to {@code referenceDate}.
+     * @since 3.0.0
+     */
+    public Instant past(long atMost, TemporalUnit unit, Instant referenceDate) {
+        Instant lowerBound = referenceDate.atZone(ZoneId.systemDefault()).minus(atMost, unit).toInstant();
+        return between(lowerBound, referenceDate);
+    }
+
     /**
      * Generates a string representation of a past date relative to the {@code referenceDate}.
      *
@@ -195,8 +361,24 @@ public class TimeAndDate extends AbstractProvider<BaseProviders> {
      * @param referenceDate the past date relative to this date.
      * @param pattern       date time pattern to convert to string.
      * @return a string representation of a past date relative to {@code referenceDate}.
+     * @deprecated since 3.0.0. Use {@link #past(long, TemporalUnit, Instant, String)} instead.
      */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public String past(long atMost, TimeUnit unit, Instant referenceDate, String pattern) {
+        return past(atMost, unit.toChronoUnit(), referenceDate, pattern);
+    }
+
+    /**
+     * Generates a string representation of a past date relative to the {@code referenceDate}.
+     *
+     * @param atMost        at most this amount of time past to the {@code referenceDate} exclusive.
+     * @param unit          the temporal unit, e.g. {@link ChronoUnit#YEARS}.
+     * @param referenceDate the past date relative to this date.
+     * @param pattern       date time pattern to convert to string.
+     * @return a string representation of a past date relative to {@code referenceDate}.
+     * @since 3.0.0
+     */
+    public String past(long atMost, TemporalUnit unit, Instant referenceDate, String pattern) {
         return formatInstant(past(atMost, unit, referenceDate), pattern);
     }
 

--- a/src/test/java/net/datafaker/providers/base/TimeAndDateTest.java
+++ b/src/test/java/net/datafaker/providers/base/TimeAndDateTest.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@SuppressWarnings("removal")
 class TimeAndDateTest {
     private final Faker faker = new Faker();
     private final TimeAndDate timeAndDate = faker.timeAndDate();
@@ -82,6 +84,68 @@ class TimeAndDateTest {
         Instant now = Instant.now();
         Instant past = timeAndDate.past(100, TimeUnit.SECONDS);
         assertThat(past.toEpochMilli()).isLessThan(now.toEpochMilli());
+    }
+
+    @RepeatedTest(100)
+    void testFutureDateWithBoundsTemporalUnit() {
+        Instant now = Instant.now();
+        Instant future = timeAndDate.future(1, ChronoUnit.SECONDS);
+        assertThat(future).isBetween(now, Instant.now().plusSeconds(1));
+    }
+
+    @RepeatedTest(100)
+    void testFutureDateWithBoundsInYears() {
+        Instant now = Instant.now();
+        Instant future = timeAndDate.future(10, ChronoUnit.YEARS);
+        Instant tenYearsLater = now.atZone(ZoneId.systemDefault()).plusYears(10).toInstant();
+        assertThat(future).isBetween(now, tenYearsLater);
+    }
+
+    @RepeatedTest(100)
+    void testFutureDateWithBoundsFromGivenMomentTemporalUnit() {
+        Instant moment = Instant.now().minus(10, ChronoUnit.DAYS);
+        Instant future = timeAndDate.future(15, MINUTES, moment);
+        assertThat(future).isBetween(moment, moment.plus(15, MINUTES));
+    }
+
+    @RepeatedTest(100)
+    void testFutureDateWithMinimumTemporalUnit() {
+        Instant now = Instant.now();
+        Instant future = timeAndDate.future(5, 4, ChronoUnit.SECONDS);
+        assertThat(future)
+            .isBetween(now.plusMillis(3500), now.plusMillis(5500));
+    }
+
+    @RepeatedTest(100)
+    void testPastDateWithBoundsTemporalUnit() {
+        Instant now = Instant.now();
+        Instant past = timeAndDate.past(100, ChronoUnit.SECONDS);
+        assertThat(past.toEpochMilli()).isLessThan(now.toEpochMilli());
+    }
+
+    @RepeatedTest(100)
+    void testPastDateWithBoundsInYears() {
+        Instant now = Instant.now();
+        Instant past = timeAndDate.past(10, ChronoUnit.YEARS);
+        Instant tenYearsEarlier = now.atZone(ZoneId.systemDefault()).minusYears(10).toInstant();
+        assertThat(past).isBetween(tenYearsEarlier, now);
+    }
+
+    @RepeatedTest(100)
+    void testPastDateWithMinimumTemporalUnit() {
+        final long now = System.currentTimeMillis();
+        Instant past = timeAndDate.past(5, 4, ChronoUnit.SECONDS);
+        assertThat(past.toEpochMilli()).isLessThan(now)
+            .isGreaterThan(now - 5500)
+            .isLessThan(now - 3500);
+    }
+
+    @RepeatedTest(100)
+    void testPastDateWithReferenceDateTemporalUnit() {
+        Instant now = Instant.now();
+        Instant past = timeAndDate.past(1, ChronoUnit.YEARS, now);
+        Instant oneYearEarlier = now.atZone(ZoneId.systemDefault()).minusYears(1).toInstant();
+        assertThat(past).isBetween(oneYearEarlier, now);
     }
 
     @RepeatedTest(100)
@@ -157,11 +221,28 @@ class TimeAndDateTest {
     }
 
     @Test
+    void futureWithMaskTemporalUnit() {
+        String pattern = "yyyy MM.dd mm:hh:ss";
+        assertValidDate(timeAndDate.future(1, ChronoUnit.HOURS, pattern), pattern);
+        assertValidDate(timeAndDate.future(20, 1, ChronoUnit.HOURS, pattern), pattern);
+        assertValidDate(timeAndDate.future(20, ChronoUnit.HOURS, Instant.now(), pattern), pattern);
+        assertValidDate(timeAndDate.future(2, ChronoUnit.YEARS, Instant.now(), pattern), pattern);
+    }
+
+    @Test
     void pastWithMask() {
         String pattern = "yyyy MM.dd mm:hh:ss";
         assertValidDate(timeAndDate.past(1, TimeUnit.DAYS, pattern), pattern);
         assertValidDate(timeAndDate.past(20, 1, TimeUnit.DAYS, pattern), pattern);
         assertValidDate(timeAndDate.past(1, TimeUnit.DAYS, Instant.now(), pattern), pattern);
+    }
+
+    @Test
+    void pastWithMaskTemporalUnit() {
+        String pattern = "yyyy MM.dd mm:hh:ss";
+        assertValidDate(timeAndDate.past(1, ChronoUnit.DAYS, pattern), pattern);
+        assertValidDate(timeAndDate.past(20, 1, ChronoUnit.DAYS, pattern), pattern);
+        assertValidDate(timeAndDate.past(1, ChronoUnit.YEARS, Instant.now(), pattern), pattern);
     }
 
     @Test


### PR DESCRIPTION
Closes #1911

## What

`timeAndDate().past(10, TimeUnit.of(ChronoUnit.YEARS))` fails today because `java.util.concurrent.TimeUnit` maxes out at days. Per the approach agreed in the issue: the twelve `future`/`past` overloads taking `TimeUnit` are deprecated (`@Deprecated(since = "3.0.0", forRemoval = true)`, delegating via `unit.toChronoUnit()`), and twelve equivalents taking `java.time.temporal.TemporalUnit` are added — so `ChronoUnit.YEARS`, `MONTHS`, etc. now work.

Bounds are computed via `referenceDate.atZone(ZoneId.systemDefault()).plus/minus(atMost, unit)` so calendar units are handled correctly (`Instant.plus` would reject units above days); the random instant still comes from the existing `between(from, to)` helper, preserving the uniform distribution and strict-before/after invariants.

## Testing

- `./mvnw test -Dtest=TimeAndDateTest` — 1930 tests pass, including new `ChronoUnit.YEARS` bounds cases and TemporalUnit variants of the bounds/minimum/reference-date tests
- `FakerTest` + `DateAndTimeTest` pass — existing `TimeUnit` behavior and `#{date.past '15','SECONDS'}` expressions unaffected
- `./mvnw spotless:check` clean

Docs (`date-format.md`) examples updated to `ChronoUnit`.